### PR TITLE
Add yardoc support, using GitHub Format Markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 config.yaml
 log/*
+/.yardoc

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,2 @@
+--markup-provider=redcarpet
+--markup=markdown

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,12 @@ gem 'sinatra'
 gem 'pg'
 gem 'sequel'
 
+group :doc do
+  gem 'yard'
+  gem 'redcarpet'
+  gem 'github-markup'
+end
+
 group :test do
   gem 'rack-test'
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,34 +1,40 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.1.3)
-    pg (0.14.1)
+    diff-lcs (1.2.4)
+    github-markup (0.7.5)
+    pg (0.15.1)
     rack (1.5.2)
     rack-protection (1.5.0)
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
-    rspec (2.12.0)
-      rspec-core (~> 2.12.0)
-      rspec-expectations (~> 2.12.0)
-      rspec-mocks (~> 2.12.0)
-    rspec-core (2.12.2)
-    rspec-expectations (2.12.1)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.12.2)
+    redcarpet (2.3.0)
+    rspec (2.13.0)
+      rspec-core (~> 2.13.0)
+      rspec-expectations (~> 2.13.0)
+      rspec-mocks (~> 2.13.0)
+    rspec-core (2.13.1)
+    rspec-expectations (2.13.0)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.13.1)
     sequel (3.48.0)
-    sinatra (1.4.2)
-      rack (~> 1.5, >= 1.5.2)
+    sinatra (1.4.3)
+      rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
     tilt (1.4.1)
+    yard (0.8.6.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  github-markup
   pg
   rack-test
+  redcarpet
   rspec
   sequel
   sinatra
+  yard


### PR DESCRIPTION
This adds yardoc support to the gemfile, in a group, and configuration to make
it default to GitHub Format Markdown -- for compatibility with the most common
place for our output to be rendered and read.

Signed-off-by: Daniel Pittman daniel@rimspace.net
