### PR TITLE
Enforce exception-on-failure handling for all `Sequel::Model`s

### DIFF
--- a/lib/razor/initialize.rb
+++ b/lib/razor/initialize.rb
@@ -35,4 +35,21 @@ module Razor
   # Establish a database connection now and load extensions
   Razor.database
   Razor.database.extension :pg_array
+
+  # Ensure that we raise on ORM failures by default; while this is the default
+  # in sufficiently recent versions of Sequel, it is better explicit than
+  # implicit, especially because a missed check could spell disaster!
+  Sequel::Model.raise_on_save_failure = true
+  Sequel::Model.raise_on_typecast_failure = true
+
+  # Also require that UPDATE or DELETE modify exactly one row when related to
+  # a model object, ensuring that we don't have surprise missed changes
+  # by default.  (In the face of concurrency, you may wish to suppress this
+  # check manually during the individual operation, having reasoned out the
+  # potential downsides of doing so.)
+  Sequel::Model.require_modification = true
+
+  # Require that unknown parameters passed to the model cause a failure,
+  # rather than being silently ignored.
+  Sequel::Model.strict_param_setting = true
 end


### PR DESCRIPTION
This manually enforces the, typically default, Sequel::Model behaviour of
raising an exception when unexpected things happen in the ORM universe.

For example, failing to save an object, typecasting problems, update or delete
operations that touch zero or two rows of data, and so forth.

While these are typically the default behaviours in modern versions of Sequel,
and they represent the conservative choice -- so are likely to stay default --
that has not always been true.

Given that, it is much better to be explicit about our expectations, and
ensure we get the behaviour we desire.

Notably, we can also override this default in any model class, or model
instance, or -- most attractively -- in the individual operations.

Signed-off-by: Daniel Pittman daniel@rimspace.net
