### PR TITLE
Add courtesy support for an additional local Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config.yaml
 log/*
 /.yardoc
+/Gemfile.local*

--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,10 @@ group :test do
   gem 'rack-test'
   gem 'rspec'
 end
+
+# This allows you to create `Gemfile.local` and have it loaded automatically;
+# the purpose of this is to allow you to put additional development gems
+# somewhere convenient without having to constantly mess with this file.
+#
+# Gemfile.local is in the .gitignore file; do not check one in!
+eval(File.read(File.dirname(__FILE__) + '/Gemfile.local'), binding) rescue nil


### PR DESCRIPTION
Like a white courtesy phone, this makes life just a touch nicer: it allows a
local `Gemfile.local` to exist, and to be evaluated, when using bundler.

This allows local development gems such as additional rspec formatters,
debuggers, and other tools to be introduced without having to push them into
the public realm, forcing them on everyone -- and without having to constantly
hack on the main Gemfile, or maintain a second copy of it.

Signed-off-by: Daniel Pittman daniel@rimspace.net
