### PR TITLE
Move MK checkin `hw_id` from URL into JSON body

### DIFF
--- a/lib/razor/data/node.rb
+++ b/lib/razor/data/node.rb
@@ -64,7 +64,8 @@ module Razor::Data
       end
     end
 
-    def self.checkin(hw_id, body)
+    def self.checkin(body)
+      hw_id = body['hw_id']
       if node = lookup(hw_id)
         if body['facts'] != node.facts
           node.facts = body['facts']

--- a/spec/app/provisioning_spec.rb
+++ b/spec/app/provisioning_spec.rb
@@ -180,26 +180,32 @@ describe "provisioning API" do
 
     it "should return 400 for non-json requests" do
       header 'Content-Type', 'text/plain'
-      post "/svc/checkin/#{hw_id}", "{}"
+      post "/svc/checkin", "{}"
       last_response.status.should == 400
     end
 
     it "should return 400 for malformed JSON" do
       header 'Content-Type', 'application/json'
-      post "/svc/checkin/#{hw_id}", "{}}"
+      post "/svc/checkin", "{}}"
       last_response.status.should == 400
     end
 
     it "should return 400 for JSON without facts" do
       header 'Content-Type', 'application/json'
-      post "/svc/checkin/#{hw_id}", { :stuff => 1 }.to_json
+      post "/svc/checkin", { :stuff => 1, :hw_id => 1 }.to_json
+      last_response.status.should == 400
+    end
+
+    it "should return 400 for JSON without hw_id" do
+      header 'Content-Type', 'application/json'
+      post "/svc/checkin", { :stuff => 1, :facts => {} }.to_json
       last_response.status.should == 400
     end
 
     it "should return a none action for a new node" do
       header 'Content-Type', 'application/json'
-      body = { :facts => { :hostname => "example" }}.to_json
-      post "/svc/checkin/#{hw_id}", body
+      body = { :facts => { :hostname => "example" }, :hw_id => 'foodbaad' }.to_json
+      post "/svc/checkin", body
       last_response.status.should == 200
       last_response.mime_type.should == 'application/json'
       last_response.json.should == { "action" => "none" }

--- a/spec/data/node_spec.rb
+++ b/spec/data/node_spec.rb
@@ -84,7 +84,7 @@ describe Razor::Data::Node do
       policy.add_tag(tag)
       policy.save
 
-      Node.checkin(hw_id, { "facts" => { "f1" => "a" }})
+      Node.checkin({ "hw_id" => hw_id, "facts" => { "f1" => "a" }})
 
       node = Node.lookup(hw_id)
       node.policy.should == policy
@@ -110,7 +110,7 @@ describe Razor::Data::Node do
 
         # Change the policies
         policy10 = make_tagged_policy(10)
-        Node.checkin(node.hw_id, "facts" => node.facts)
+        Node.checkin("hw_id" => node.hw_id, "facts" => node.facts)
         node.reload
         node.policy.should == policy20
       end
@@ -122,7 +122,7 @@ describe Razor::Data::Node do
         node.save
 
         policy20 = make_tagged_policy(20)
-        Node.checkin(node.hw_id, "facts" => { "f1" => "a" })
+        Node.checkin("hw_id" => node.hw_id, "facts" => { "f1" => "a" })
         node.reload
         node.tags.should == [ tag ]
         node.policy.should == random_policy


### PR DESCRIPTION
The MK checkin API had a somewhat inconsistent input: the node `hw_id` field
was supplied inline to the URL, but the facts were supplied in a nested JSON
map, allowing for other inputs.

This pulls down the `hw_id` from the URL into another field in the input JSON,
next to facts, to make the interface uniform.  Now, one place alone needs to
be consulted to understand what is happening -- and the JSON document is a
stand-alone record of what will change.

(That is: the document contains all the data required to reproduce the act, so
capturing the body alone is sufficient to have an audit trail of operations.
It still does not capture the intended operation -- that is "implicit" in the
surrounding environment, so this is not entirely sufficient to provide the
audit facility.)

Signed-off-by: Daniel Pittman daniel@rimspace.net
