### PR TITLE
Fix bad tests in spec/app/api_spec.rb

### DIFF
--- a/spec/app/api_spec.rb
+++ b/spec/app/api_spec.rb
@@ -63,6 +63,7 @@ describe "command and query API" do
 
     it "should return JSON content" do
       get '/api/collections/policies'
+      last_response.status.should == 200
       last_response.content_type.should =~ /application\/json/i
     end
 
@@ -109,7 +110,8 @@ describe "command and query API" do
 
   context "/api/collections/tags - tag list" do
     it "should return JSON content" do
-      get '/api/tags'
+      get '/api/collections/tags'
+      last_response.status.should == 200
       last_response.content_type.should =~ /application\/json/
     end
 


### PR DESCRIPTION
The tests were checking, among other things, that a GET request to `/api/tags` and `/api/collections/policies` returned JSON content, which is a valid expectation. The problem is that both returned JSON content, though `/api/tags` returned a 404 error and `/api/collections/policies` returned a 200. This fixes the bad request to `/api/tags` and adds an additional status code check to make sure that the test will fail if the endpoint doesn't exist.
