### PR TITLE
Fix torquebox messaging race condition

### DIFF
--- a/lib/razor/messaging/sequel.rb
+++ b/lib/razor/messaging/sequel.rb
@@ -1,7 +1,12 @@
-# This is a message processor; torquebox loads this into a brandnew
-# interpreter. We therefore have to load the entire Razor environment
-require_relative '../../razor/initialize'
-require_relative '../../razor'
+# This allows Ruby to parse the Razor::Messaging::Sequel class without
+# Kernel::include-ing the ../../razor and ../../razor/initialize files.
+# Loading those files here causes a race condition when trying to load the
+# Razor::Data classes, which include parts of the Razor::Messaging::Sequel
+# class, which isn't yet defined.
+module Razor
+  module Messaging
+  end
+end
 
 require 'torquebox-messaging'
 


### PR DESCRIPTION
Razor::Messaging::Sequel is loaded in a new Torquebox environment to process messages, so it naturally needs to load the entire Razor environment as well. Calling `require '../../razor' at the top of the file, though, caused the files in lib/razor/data to be loaded before the lib/razor/messaging/sequel.rb had finished being loading. This didn't show up until trying to run`rake console` from the command-line, at which point initialization would fail.
