### PR TITLE
Ensure we use a canonical `hw_id` format

### DIFF
--- a/lib/razor/data/node.rb
+++ b/lib/razor/data/node.rb
@@ -68,7 +68,7 @@ module Razor::Data
     end
 
     def self.checkin(body)
-      hw_id = body['hw_id']
+      hw_id = canonicalize_hw_id(body['hw_id'])
       if node = lookup(hw_id)
         if body['facts'] != node.facts
           node.facts = body['facts']
@@ -84,14 +84,16 @@ module Razor::Data
       { :action => :none }
     end
 
+    def self.canonicalize_hw_id(input)
+      input.gsub(/[_:]/, '').downcase
+    end
+
     def self.lookup(hw_id)
-      self[:hw_id => hw_id]
+      self[:hw_id => canonicalize_hw_id(hw_id)]
     end
 
     def self.boot(hw_id, dhcp_mac = nil)
-      unless node = lookup(hw_id)
-        node = Node.create(:hw_id => hw_id)
-      end
+      node = lookup(hw_id) || Node.create(:hw_id => canonicalize_hw_id(hw_id))
       node.dhcp_mac = dhcp_mac if dhcp_mac && dhcp_mac != ""
       node.boot_count += 1
       node.save

--- a/spec/app/installer_validity_spec.rb
+++ b/spec/app/installer_validity_spec.rb
@@ -21,7 +21,7 @@ describe "stock installer" do
       before(:each) do
         Razor.config["installer_path"] = INSTALLER_PATH
 
-        @node = Node.create(:hw_id => "00:11:22:33:44:55")
+        @node = Node.create(:hw_id => "001122334455")
         policy = Fabricate(:policy, :installer_name => name)
         @node.bind(policy)
         @node.save

--- a/spec/app/provisioning_spec.rb
+++ b/spec/app/provisioning_spec.rb
@@ -24,7 +24,7 @@ describe "provisioning API" do
 
   describe "booting known nodes" do
     before(:each) do
-      @node = Node.create(:hw_id => "00:11:22:33:44:55")
+      @node = Node.create(:hw_id => "001122334455")
     end
 
     it "without policy should boot the microkernel" do
@@ -83,7 +83,7 @@ describe "provisioning API" do
 
   describe "fetching a template" do
     before(:each) do
-      @node = Node.create(:hw_id => "00:11:22:33:44:55")
+      @node = Node.create(:hw_id => "001122334455")
       @node.bind(policy)
       @node.save
     end
@@ -142,7 +142,7 @@ describe "provisioning API" do
     end
 
     it "should store the log message for an existing node" do
-      node = Node.create(:hw_id => "00:11:22:33:44:55")
+      node = Node.create(:hw_id => "001122334455")
 
       get "/svc/log/#{node.id}?msg=message&severity=warn"
       last_response.status.should == 204
@@ -155,7 +155,7 @@ describe "provisioning API" do
 
   describe "storing node IP" do
     before(:each) do
-      @node = Node.create(:hw_id => "00:11:22:33:44:55")
+      @node = Node.create(:hw_id => "001122334455")
     end
 
     it "should store an IP" do
@@ -178,7 +178,7 @@ describe "provisioning API" do
   end
 
   describe "node checkin" do
-    hw_id = "00:11:22:33:44:55"
+    hw_id = "001122334455"
 
     it "should return 400 for non-json requests" do
       header 'Content-Type', 'text/plain'


### PR DESCRIPTION
This forces every input hw_id, regardless of format, into the current
"canonical" format: the mac addresses, in an (unreliably) sorted order,
concatenated, `:` removed, downcased.

While imperfect, this does give us a robust short term way to manage
hardware identification.  For the longer term we need to separate out
canonical input from the model objects themselves, and to manage the hardware
identifiers in a more robust fashion.

(eg: support using the DMI serial number, and non-Ethernet hardware, for more
 robust identification; support "subset of total network interfaces", etc.)

Signed-off-by: Daniel Pittman daniel@rimspace.net
