### PR TITLE
bootif kernel argument needs ethernet interface type or it will not be u...

### DIFF
--- a/installers/debian/wheezy/kernel_args.erb
+++ b/installers/debian/wheezy/kernel_args.erb
@@ -1,2 +1,2 @@
-<% @bootif = node.dhcp_mac ? "BOOTIF=#{node.dhcp_mac} " : "interface=auto " %>
+<% @bootif = node.dhcp_mac ? "BOOTIF=01-#{node.dhcp_mac} " : "interface=auto " %>
 DEBCONF_DEBUG=5 install auto=true url=<%= file_url("preseed") %> debian-installer=en_US locale=en_US kbd-chooser/method=us netcfg/get_hostname=<%= node.shortname %> netcfg/get_domain=<%= node.domainname %> fb=false debconf/frontend=noninteractive console-setup/ask_detect=false <%= @bootif %>


### PR DESCRIPTION
bootif kernel argument needs ethernet interface type or it will not be used in setting up the network interfaces with interface=auto.

This can prevent the OS installer from running in a node with multiple NICs due to long standing bug https://bugs.launchpad.net/ubuntu/+source/netcfg/+bug/713385 that apparently is never going to be fixed.
