### PR TITLE
Handle an absent fact blacklist in the configuration

### DIFF
--- a/lib/razor/config.rb
+++ b/lib/razor/config.rb
@@ -58,7 +58,7 @@ module Razor
 
     def facts_blacklist_rx
       @facts_blacklist_rx ||=
-        Regexp.compile("\\A((" + self["facts.blacklist"].map do |s|
+        Regexp.compile("\\A((" + Array(self["facts.blacklist"]).map do |s|
                          if s =~ %r{\A/(.*)/\Z}
                            $1
                          else


### PR DESCRIPTION
This updates the configuration handling code to gracefully accept an absent
fact blacklist, and to treat this as an empty array.

Signed-off-by: Daniel Pittman daniel@rimspace.net
