### PR TITLE
Mark ISO unpack test pending on OSX

### DIFF
--- a/spec/data/repo_spec.rb
+++ b/spec/data/repo_spec.rb
@@ -437,14 +437,16 @@ describe Razor::Data::Repo do
     end
 
     it "should unpack the repo into the filesystem_safe_name under root" do
-      Dir.mktmpdir do |root|
-        root = Pathname(root)
-        Razor.config['repo_store_root'] = root
-        repo.unpack_repo(tiny_iso)
+      pending("libarchive ISO support on OSX", :if => ::FFI::Platform.mac?) do
+        Dir.mktmpdir do |root|
+          root = Pathname(root)
+          Razor.config['repo_store_root'] = root
+          repo.unpack_repo(tiny_iso)
 
-        (root + repo.filesystem_safe_name).should exist
-        (root + repo.filesystem_safe_name + 'content.txt').should exist
-        (root + repo.filesystem_safe_name + 'file-with-filename-that-is-longer-than-64-characters-which-some-unpackers-get-wrong.txt').should exist
+          (root + repo.filesystem_safe_name).should exist
+          (root + repo.filesystem_safe_name + 'content.txt').should exist
+          (root + repo.filesystem_safe_name + 'file-with-filename-that-is-longer-than-64-characters-which-some-unpackers-get-wrong.txt').should exist
+        end
       end
     end
 


### PR DESCRIPTION
Unfortunately, the libarchive version shipped with OS-X 10.8 and 10.9 doesn't
actually support unpacking ISO images -- or, at least, not the way it is being
used in our code.

This marks the test pending, using the block form, so that unexpected success
will let us identify if the issue is ever fixed, but for now we can run the
test suite successfully on OS-X.

Signed-off-by: Daniel Pittman daniel@rimspace.net
