### PR TITLE
Node.canonicalize_hw_info: strip out whitespace

### DIFF
--- a/lib/razor/data/node.rb
+++ b/lib/razor/data/node.rb
@@ -228,7 +228,7 @@ module Razor::Data
         # independent of the order in which the BIOS enumerates NICs. We
         # also don't care about case
         k = "mac" if k =~ /net[0-9]+/
-        [k.downcase, v.downcase]
+        [k.downcase, v.strip.downcase]
       end.select do |k, v|
         (HW_INFO_KEYS + ["mac"]).include?(k) && v && v != ""
       end.sort do |a, b|

--- a/spec/data/node_spec.rb
+++ b/spec/data/node_spec.rb
@@ -26,6 +26,11 @@ describe Razor::Data::Node do
       canonicalize("uuid" => "1", "serial" => "2", "asset" => "asset").should ==
         ["asset=asset", "serial=2", "uuid=1"]
     end
+
+    it "should ignore empty and whitespace-only values" do
+      info = canonicalize("uuid" => "", "serial" => "  ", "asset" => "  \t \n ")
+      info.should == []
+    end
   end
 
   context "hw_hash=" do


### PR DESCRIPTION
We treat hw_info values that are only whitespace as not present. They
clealry have no value in discriminating between nodes.
