### PR TITLE
ESXi: add, and always use, encrypted password support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,12 @@ gem 'jdbc-postgres'
 gem 'archive'
 gem 'hashie', '~> 2.0.5'
 
+## support for various installers and utility
+# This allows us to encrypt plain-text-in-the-DB passwords when they travel,
+# unencrypted, over the wire during kickstart phases, etc.
+gem "unix-crypt", "~> 1.1.1"
+
+
 group :doc do
   gem 'yard'
   gem 'kramdown'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
     torquebox-transactions (3.0.0)
       torquebox-core (= 3.0.0)
     torquebox-web (3.0.0-java)
+    unix-crypt (1.1.1)
     yard (0.8.7.2)
 
 PLATFORMS
@@ -106,4 +107,5 @@ DEPENDENCIES
   timecop
   torquebox
   torquebox-server
+  unix-crypt (~> 1.1.1)
   yard

--- a/installers/vmware_esxi/ks.cfg.erb
+++ b/installers/vmware_esxi/ks.cfg.erb
@@ -1,6 +1,16 @@
 # Thanks to William Lam for being the guru
 accepteula
-rootpw bananaman
+rootpw --iscrypted <%=
+  if node.root_password =~ /^\$\d+\$[^$]*\$/
+    node.root_password
+  else
+    require 'unix_crypt'
+    # @todo danielp 2013-11-07: if ESXi supports a stronger algorithm, we
+    # should probably upgrade to using it in preference to MD5.  SHA512 is
+    # current state-of-the-art practice, elsewhere.
+    UnixCrypt::MD5.build(node.root_password)
+  end
+%>
 clearpart --firstdisk --overwritevmfs
 install --firstdisk --overwritevmfs
 # Set the network to DHCP on the first network adapater


### PR DESCRIPTION
This updates the ESXi kickstart file to use encrypted passwords.  Since we can
robustly identify an encrypted password in the policy, we test for that and
either ship the pre-encrypted password, or encrypt it ourselves on the server.

That way the data crossing the wire, which is not secured, contains only a
reasonably secure password hash.  This is a step up from sending a plain-text
password, at the very least.

This also makes the root password from the policy actually _work_ on ESXi,
replacing the previously hard-coded password.

Signed-off-by: Daniel Pittman daniel@rimspace.net
