### PR TITLE
Add support for Debian 7.2 multiarch netboot CD

### DIFF
--- a/installers/debian/wheezy/boot_install.erb
+++ b/installers/debian/wheezy/boot_install.erb
@@ -2,8 +2,44 @@
 echo Razor <%= installer.label %> model boot_call
 echo Installation node: <%= node_url  %>
 echo Installation repo: <%= repo_url %>
-
 sleep 3
-kernel <%= repo_url("/linux") %> <%= render_template("kernel_args").strip %> || goto error
-initrd <%= repo_url("/initrd.gz") %> || goto error
+
+set cmdline <%= render_template("kernel_args").strip %>
+
+<%
+    # Is this a new-style combined installer build, or one with only
+    # one architecture present in the files we discover?  If so, we
+    # want to use that.  This also allows us to handle architecture
+    # nicely for installation.
+    if repo_file('install.amd') or repo_file('install.386')
+%>
+# check for 64-bit CPU support and boot the AMD64 installer.
+cpuid --ext 29 || goto i386
+
+# AMD64 support in CPU, boot the AMD64 installer.
+<% if repo_file('install.amd') %>
+echo detected AMD64 CPU support, booting AMD64 installer
+kernel <%= repo_url('install.amd/vmlinuz') %> ${cmdline}        || goto error
+initrd <%= repo_url('install.amd/initrd.gz') %>                 || goto error
 boot
+<% else %>
+echo No AMD64 installer present, expected install.amd directory
+<% end %>
+
+:i386
+<% if repo_file('install.386') %>
+kernel <%= repo_url('install.386/vmlinuz') %> ${cmdline}        || goto error
+initrd <%= repo_url('install.386/initrd.gz') %>                 || goto error
+<% else %>
+echo No i386 installer present, expected install.386 directory
+<% end %>
+
+:fail
+echo Unable to find a suitable installer to boot, sorry
+goto error
+<% else %>
+# fallback to classic boot mode, hope your arch matches...
+kernel <%= repo_url("/linux") %>  ${cmdline}                    || goto error
+initrd <%= repo_url("/initrd.gz") %>                            || goto error
+boot
+<% end %>


### PR DESCRIPTION
This enhances the Debian installer to detect and (hopefully) support the new
Debian 7.2 multiarch installer CD image available as the default download link
on the debian.org homepage.

The biggest change is that this includes both an i386 and an AMD64 kernel, and
package set, on a single disk.  Optimally, this actually means that we can
detect at runtime what CPU instruction set the client supports and boot the
correct image.

This makes, I believe, this the first multi-arch capable installer.  Which the
rest of the system won't yet support, but so it goes...

This fixes issue #82, where https://github.com/eglute discovered and reported
the failure.

Signed-off-by: Daniel Pittman daniel@rimspace.net
