### PR TITLE
Move location of stage_done_url call to %firstboot

### DIFF
--- a/installers/vmware_esxi/ks.cfg.erb
+++ b/installers/vmware_esxi/ks.cfg.erb
@@ -20,7 +20,6 @@ reboot
 
 # %include /tmp/networkconfig
 %pre --interpreter=busybox
-wget <%= stage_done_url("kickstart") %>
 
 # echo 'network --bootproto=static --addvmportgroup=false --device=vmnic0 --ip=<%= @node_ip_address %> --netmask=<%= @ip_range_subnet %> --gateway=<%= @gateway %> --nameserver=<%= @nameserver %> --hostname=<%= @node_hostname %>' > /tmp/networkconfig
 
@@ -28,6 +27,7 @@ wget <%= stage_done_url("kickstart") %>
 
 %firstboot --interpreter=busybox
 
+wget <%= stage_done_url("kickstart") %>
 # wget <%= @api_svc_uri %>/policy/callback/<%= @policy_uuid %>/postinstall/end
 # enable HV (Hardware Virtualization to run nested 64bit Guests + Hyper-V VM)
 grep -i 'vhv.allow' /etc/vmware/config || echo 'vhv.allow = 'TRUE'' >> /etc/vmware/config


### PR DESCRIPTION
The call back tot he razor server should not be done in the %pre section.

In the case of a ESXi 5.0 installation - the kickstart script will fail - because the wget call will not return any content and throws an error.

To make this more compatible with all versions - call should and can be made in the %firstboot section
