### PR TITLE
Remove not required kernel_args.erb file from ubuntu preice folder

### DIFF
--- a/installers/ubuntu/precise/kernel_args.erb
+++ b/installers/ubuntu/precise/kernel_args.erb
@@ -1,1 +1,0 @@
-BOOTIF=01-${netX/mac} preseed/url=<%= file_url("preseed") %> debian-installer/locale=en_US netcfg/no_default_route=true netcfg/choose_interface=auto priority=critical


### PR DESCRIPTION
Detected today that there are two kernel_args.erb files for the ubuntu installer and at the moment and forseeable future there is no requirement for different kernel_args.erb files
