### PR TITLE
Enable polices to match nodes directly.

### DIFF
--- a/db/migrate/005_many2many_nodes_policies.rb
+++ b/db/migrate/005_many2many_nodes_policies.rb
@@ -1,0 +1,20 @@
+require_relative './util'
+
+Sequel.migration do
+  up do
+    extension(:constraint_validations)
+
+    # Join table for nodes/tags; we can't use create_join_table since we
+    # want the association to disappear if either end disappears
+    create_table :policies_nodes do
+      foreign_key :policy_id, :policies, :null=>false, :on_delete => :cascade
+      foreign_key :node_id, :nodes, :null=>false, :on_delete => :cascade
+      primary_key [:policy_id, :node_id]
+      index [:policy_id, :node_id]
+    end
+  end
+
+  down do
+    drop_table :policies_nodes
+  end
+end

--- a/doc/api.md
+++ b/doc/api.md
@@ -255,6 +255,31 @@ to this policy at the most. This can either be set to `nil`, indicating
 that an unbounded number of nodes can be bound to this policy, or a
 positive integer to set an upper bound.
 
+### Adding Nodes to Policies
+
+Nodes can be directly associated to a policy, bypassing the use of tags
+where static associations are appropriate.  This is done with the
+ `add-policy-node` command with the following data:
+
+    {
+      "name": "a_policy_name",
+      "node": "node1" || "1"
+    }
+
+The value for node can be in the form "node<id>" or just "<id>".
+
+### Removing Nodes from a Policy
+
+Nodes statically associated with a policy are removed with the
+ `remove-policy-node` command and takes the same data as the add command:
+
+    {
+      "name": "a_policy_name",
+      "node": "node1" || "1"
+    }
+
+The value for node can be in the form "node<id>" or just "<id>".
+
 ### Enable/disable policy
 
 Policies can be enabled or disabled. Only enabled policies are used when

--- a/lib/razor/view.rb
+++ b/lib/razor/view.rb
@@ -59,6 +59,7 @@ module Razor
           :root_password => policy.root_password,
         },
         :rule_number => policy.rule_number,
+        :nodes => policy.nodes.map { |n| view_object_reference(n) }.compact,
         :tags => policy.tags.map {|t| view_object_reference(t) }.compact,
       })
     end
@@ -116,7 +117,7 @@ module Razor
       view_object_hash(node).merge(
         :hw_info       => node.hw_hash,
         :dhcp_mac      => node.dhcp_mac,
-        :policy        => view_object_reference(node.policy),
+        :bound_policy  => view_object_reference(node.bound_policy),
         :log           => { :id => view_object_url(node) + "/log",
                             :name => "log" },
         :tags          => node.tags.map { |t| view_object_reference(t) },

--- a/spec/app/api_spec.rb
+++ b/spec/app/api_spec.rb
@@ -102,7 +102,7 @@ describe "command and query API" do
       get "/api/collections/policies/#{URI.escape(pl.name)}"
       policy = last_response.json
 
-      policy.keys.should =~ %w[name id spec configuration enabled rule_number max_count repo tags installer broker]
+      policy.keys.should =~ %w[name id spec configuration enabled rule_number max_count repo tags nodes installer broker]
       policy["repo"].keys.should =~ %w[id name spec]
       policy["configuration"].keys.should =~ %w[hostname_pattern root_password]
       policy["tags"].should be_empty
@@ -548,7 +548,7 @@ describe "command and query API" do
             },
           },
         },
-        'policy'   => {
+        'bound_policy'   => {
           '$schema'    => 'http://json-schema.org/draft-04/schema#',
           'type'       => 'object',
           'required'   => %w[spec id name],

--- a/spec/fabricators/fabricator.rb
+++ b/spec/fabricators/fabricator.rb
@@ -62,7 +62,7 @@ Fabricator(:node_with_facts, :class_name => Razor::Data::Node) do
 end
 
 Fabricator(:bound_node, from: :node) do
-  policy
+  bound_policy { Fabricate(:policy) }
 
   facts do
     data = {}
@@ -90,11 +90,11 @@ Fabricator(:bound_node, from: :node) do
   after_build do |node, _|
     # @todo danielp 2013-08-19: this seems to highlight some data duplication
     # that, frankly, doesn't seem like a good thing to me.
-    node.root_password = node.policy.root_password
+    node.root_password = node.bound_policy.root_password
   end
 
   after_save do |node, _|
-    node.hostname = node.policy.hostname_pattern.gsub('${id}', node.id.to_s)
+    node.hostname = node.bound_policy.hostname_pattern.gsub('${id}', node.id.to_s)
     node.save
   end
 end


### PR DESCRIPTION
Added commands 'add-policy-node' and 'remove-policy-node'

NOTE: I know this is being actively debated/discussed.  I hope this will
illustrate what I want to achieve.

ALSO NOTE: This should merge cleanly over the current master But
will not over some of the other PRs that are under review.

This change allows for policies to have a static list of nodes it will
match.  This allows a policy to match a predefined, static list of nodes
that are specifically targeted. Allowing the bypassing of having to
create one to one tags for nodes (e.g:

  {
    "name": "node1",
    "rule": ["eq", ["fact", "macaddress"], "01:01:01:01:01:01"]
  }

Policies can have both a list of nodes to match and a list of tags to
match.  Normal policy ordering applies, having a node on a policy
directly does not mean that the policy will have a higer priority for
that node.  I.e. if another policy higher up the order matches a node
via tags, it will still bind over a lower priority policy that would
match direct.

Note that an additional association between policies and nodes needed to
be created in the respective Razor::Data classes.  The existing
association that associated a node to its binding policy was renamed to
'bound_policy'.  A helper method called 'policy' exists on the node to
retrive 'bound_policy' however this is really just to support backwards
compatibility in installer templates.  I think all the internal code
refers to node.bound_policy.

This change is to better support the use case of environments where
machines would only ever be explicitly provisioned rather than auto
provisioned based on a policy.
