### PR TITLE
Add a URL for the installers collection

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -439,7 +439,7 @@ class Razor::App < Sinatra::Base
   #
   # @todo danielp 2013-06-26: this should be some sort of discovery, not a
   # hand-coded list, but ... it will do, for now.
-  COLLECTIONS = [:brokers, :repos, :tags, :policies, :nodes]
+  COLLECTIONS = [:brokers, :repos, :tags, :policies, :nodes, :installers]
 
   #
   # The main entry point for the public/management API
@@ -883,7 +883,11 @@ class Razor::App < Sinatra::Base
     policy_hash(policy).to_json
   end
 
-  # FIXME: Add a query to list all installers
+  get '/api/collections/installers' do
+    Razor::Installer.all.
+      map { |inst| view_object_reference(inst) }.
+      to_json
+  end
 
   get '/api/collections/installers/:name' do
     begin

--- a/lib/razor/installer.rb
+++ b/lib/razor/installer.rb
@@ -102,6 +102,17 @@ module Razor
       find_on_installer_paths(File::join("common", filename))
     end
 
+    # List all known installers, both from the DB and the file
+    # system. Return an array of +Razor::Installer+ objects, sorted by
+    # +name+
+    def self.all
+      (Razor.config.installer_paths.map do |ip|
+        Dir.glob(File::join(ip, "*.yaml")).map { |p| File::basename(p, ".yaml") }
+       end + Razor::Data::Installer.all).flatten.uniq.sort.map do |name|
+        find(name)
+      end
+    end
+
     private
     def self.find_on_installer_paths(*paths)
       Razor.config.installer_paths.each do |ip|


### PR DESCRIPTION
Note that there is already a handler for individual installers

Fixes https://github.com/puppetlabs/razor-server/issues/119
