### PR TITLE
Don't treat IP address for a node special

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -96,10 +96,7 @@ class Razor::App < Sinatra::Base
     end
 
     def store_url(vars)
-      # We intentionally do not URL escape here; users need to be able to
-      # say '$node_ip' in the URL vars and have the shell interpolate that.
-      q = vars.map { |k,v| "#{k}=#{v}" }.join("&")
-      url "/svc/store/#{@node.id}?#{q}"
+      store_metadata_url('update' => vars)
     end
 
     def store_metadata_url(vars)
@@ -379,18 +376,6 @@ class Razor::App < Sinatra::Base
 
     node.log_append(:event => :node_log,
                     :msg=> params[:msg], :severity => params[:severity])
-    node.save
-    [204, {}]
-  end
-
-  get '/svc/store/:node_id' do
-    node = Razor::Data::Node[params[:node_id]]
-    halt 404 unless node
-    halt 400 unless params[:ip]
-
-    # We only allow setting the ip address for now
-    node.ip_address = params[:ip]
-    node.log_append(:event => :store, :vars => { :ip => params[:ip] })
     node.save
     [204, {}]
   end

--- a/db/migrate/007_mv_ip_to_node_metadata.rb
+++ b/db/migrate/007_mv_ip_to_node_metadata.rb
@@ -1,0 +1,18 @@
+require_relative './util'
+
+Sequel.migration do
+  up do
+    extension(:constraint_validations)
+
+    self[:nodes].all.each do |n|
+      metadata = JSON::parse(n[:metadata])
+      metadata[:ip] = n[:ip_address] if n[:ip_address]
+      puts metadata.to_json
+      self[:nodes].where(:id => n[:id]).update(:metadata => metadata.to_json)
+    end
+    drop_column :nodes, :ip_address
+  end
+
+  # No down migration as it's a bit of work, and we can probably do without
+  # one
+end

--- a/lib/razor/view.rb
+++ b/lib/razor/view.rb
@@ -124,7 +124,6 @@ module Razor
         :metadata      => node.metadata,
         :hostname      => node.hostname,
         :root_password => node.root_password,
-        :ip_address    => node.ip_address,
         :last_checkin  => last_checkin_s
       ).delete_if {|k,v| v.nil? or ( v.is_a? Hash and v.empty? ) }
     end

--- a/spec/app/api_spec.rb
+++ b/spec/app/api_spec.rb
@@ -603,11 +603,6 @@ describe "command and query API" do
           '$schema'  => 'http://json-schema.org/draft-04/schema#',
           'type'     => 'string',
         },
-        'ip_address' => {
-          '$schema'  => 'http://json-schema.org/draft-04/schema#',
-          'type'     => 'string',
-          'pattern'  => '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$'
-        },
         'boot_count' => {
           '$schema'  => 'http://json-schema.org/draft-04/schema#',
           'type'     => 'integer',

--- a/spec/app/provisioning_spec.rb
+++ b/spec/app/provisioning_spec.rb
@@ -165,7 +165,8 @@ describe "provisioning API" do
 
     it "should interpolate store_url" do
       get "/svc/file/#{@node.id}/store_url"
-      assert_url_response("/svc/store/#{@node.id}", "v1" => "42", "v2" => "3")
+      assert_url_response("/svc/store_metadata/#{@node.id}",
+                          "v1" => "42", "v2" => "3")
     end
 
     it "should interpolate node_url" do
@@ -240,30 +241,6 @@ describe "provisioning API" do
       log.size.should == 1
       log[0]["msg"].should == "message"
       log[0]["severity"].should == "warn"
-    end
-  end
-
-  describe "storing node IP" do
-    before(:each) do
-      @node = Fabricate(:node)
-    end
-
-    it "should store an IP" do
-      get "/svc/store/#{@node.id}?ip=8.8.8.8"
-      last_response.status.should == 204
-
-      node = Node[@node.id]
-      node.ip_address.should == "8.8.8.8"
-    end
-
-    it "should return 404 for nonexistent nodes" do
-      get "/svc/store/#{@node.id+1}?ip=8.8.8.8"
-      last_response.status.should == 404
-    end
-
-    it "should return 400 when ip not provided" do
-      get "/svc/store/#{@node.id}"
-      last_response.status.should == 400
     end
   end
 

--- a/spec/fabricators/fabricator.rb
+++ b/spec/fabricators/fabricator.rb
@@ -96,7 +96,9 @@ Fabricator(:bound_node, from: :node) do
   end
 
   metadata do
-    data = {}
+    data = { }
+    # 25% of nodes will have an IP generated
+    data["ip"] = Faker::Internet.ip_v4_address if Random.rand(4) == 3
     20.times do
       data[Faker::Lorem.word] = case Random.rand(4)
                                 when 0 then Faker::Lorem.word
@@ -109,7 +111,6 @@ Fabricator(:bound_node, from: :node) do
     data
   end
 
-  ip_address { Faker::Internet.ip_v4_address }
   boot_count { Random.rand(10) }
 
   # normally the node would be created before binding, so we always have an ID


### PR DESCRIPTION
There's no good reason why we should handle a node's IP address in any
special way; Razor's builtin logic certainly doesn't depend on it.

The big question: should we treat the other dedicated fields similarly ? (Yes, I am looking at you, hostname and root_password)
- Instead of a dedicated node.ip_address field, store the node's IP address
  in node.metadata["ip"]
- Remove the /svc/store endpoint that was used just for that
- make the store_url helper a wrapper for store_metadata_url that is only
  used to update metadata entries (and not remove them)
