### PR TITLE
Policies Can Seed Metadata on Nodes

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -565,8 +565,15 @@ class Razor::App < Sinatra::Base
     data['value'] or error 400,
       :error => 'must supply value'
 
+    if data['no_replace']
+      data['no_replace'] == true or data['no_replace'] == 'true' or error 400,
+        :error => "no_replace must be boolean true or string 'true'"
+    end
+
     if node = Razor::Data::Node.find_by_name( data['node'] )
       operation = { 'update' => { data['key'] => data['value'] } }
+      operation['no_replace'] = true unless operation['no_replace'].nil?
+
       node.modify_metadata(operation)
     else
       error 400, :error => "Node #{data['node']} not found"
@@ -606,6 +613,11 @@ class Razor::App < Sinatra::Base
     if data['clear']
       data['clear'] == true or data['clear'] == 'true' or error 400,
         :error => "clear must be boolean true or string 'true'"
+    end
+
+    if data['no_replace']
+      data['no_replace'] == true or data['no_replace'] == 'true' or error 400,
+        :error => "no_replace must be boolean true or string 'true'"
     end
 
     if data['update'] and data['remove']

--- a/db/migrate/010_policy_add_node_metadata.rb
+++ b/db/migrate/010_policy_add_node_metadata.rb
@@ -1,0 +1,16 @@
+require_relative './util'
+
+Sequel.migration do
+  up do
+    extension(:constraint_validations)
+      alter_table :policies do
+        add_column :node_metadata, String
+      end
+  end
+
+  down do
+    alter_table :policies do
+      drop_column :node_metadata
+    end
+  end
+end

--- a/doc/api.md
+++ b/doc/api.md
@@ -239,6 +239,7 @@ will return with status code 400.
       "root_password": "secret",
       "max_count": "20",
       "line_number": "100"
+      "node_metadata": { "key1": "value1", "key2": "value2" },
       "tags": [{ "name": "existing_tag"},
                { "name": "new_tag", "rule": ["=", "dollar", "dollar"]}]
     }
@@ -257,6 +258,11 @@ The `max_count` determines how many nodes can be bound at any given point
 to this policy at the most. This can either be set to `nil`, indicating
 that an unbounded number of nodes can be bound to this policy, or a
 positive integer to set an upper bound.
+
+The `node_metadata` allows a pollicy to apply apply metadata to a node
+when it binds.  This is NON AUTHORITIVE in that it will not replace 
+existing metadata on the node with the same keys it will only add keys
+that are missing.
 
 ### Enable/disable policy
 
@@ -381,6 +387,8 @@ metadata.  The request should look like:
             ...
         }
         'remove': [ 'key3', 'key4', ... ],  # Remove these keys
+        'no_replace': true                  # Do not replace keys on 
+                                            # update. Only add new keys
     }
 
 or
@@ -394,6 +402,37 @@ As above, multiple update and/or removes can be done in the one command,
 however, clear can only be done on its own (it doesnt make sense to
 update some details and then clear everything).  An error will also be
 returned if an attempt is made to update and remove the same key.
+
+### Update Node Metadata
+
+The `update-node-metadata` command is a shortcut to `modify-node-metadata`
+that allows for updating single keys on the command line or with a GET
+request with a simple data structure that looks like.
+
+    {
+        'node'      : 'mode1',
+        'key'       : 'my_key',
+        'value'     : 'my_val',
+        'no_replace': true       #Optional. Will not replace existing keys
+    }
+
+### Remove Node Metadata
+
+The `remove-node-metadata` command is a shortcut to `modify-node-metadata`
+that allows for removing a single key OR all keys only on the command
+like or with a GET request with a simple datastructure that looks like:
+
+    {
+        'node' : 'node1',
+        'key'  : 'my_key',
+    }
+
+or
+
+    {
+        'node' : 'node1',
+        'all'  : true,     # Removes all keys
+    }
 
 ## Collections
 

--- a/lib/razor/data/node.rb
+++ b/lib/razor/data/node.rb
@@ -160,6 +160,15 @@ module Razor::Data
       self.installed_at = nil
       self.root_password = policy.root_password
       self.hostname = policy.hostname_pattern.gsub(/\$\{\s*id\s*\}/, id.to_s)
+      
+      if policy.node_metadata
+        modify_metadata( { 
+          'no_remove' => true,
+          'update' => policy.node_metadata
+        } )
+      end
+
+      self
     end
 
     # This is a hack around the fact that the auto_validates plugin does
@@ -230,7 +239,9 @@ module Razor::Data
       if data['update']
         data['update'].is_a? Hash or raise ArgumentError, 'update must be a hash'
         data['update'].each do |k,v|
-          new_metadata[k] = v
+          unless (data['no_replace'] == true or data['no_replace'] == 'true') and new_metadata[k] 
+            new_metadata[k] = v
+          end
         end
       end
       if data['remove']

--- a/lib/razor/data/policy.rb
+++ b/lib/razor/data/policy.rb
@@ -6,6 +6,26 @@ module Razor::Data
     many_to_many :tags
     many_to_one  :broker
 
+    plugin :serialization, :json, :node_metadata
+
+    # This is a hack around the fact that the auto_validates plugin does
+    # not play nice with the JSON serialization plugin (the serializaton
+    # happens in the before_save hook, which runs after validation)
+    #
+    # To avoid spurious error messages, we tell the validation machinery to
+    # expect a Hash resp.
+    #
+    # Add the fields to be serialized to the 'serialized_fields' array
+    #
+    # FIXME: Figure out a way to address this issue upstream
+    def schema_type_class(k)
+      if [ :node_metadata ].include?(k)
+        Hash
+      else
+        super
+      end
+    end
+
     def recipe
       Razor::Recipe.find(recipe_name)
     end

--- a/lib/razor/view.rb
+++ b/lib/razor/view.rb
@@ -60,10 +60,11 @@ module Razor
         },
         :rule_number => policy.rule_number,
         :tags => policy.tags.map {|t| view_object_reference(t) }.compact,
+        :node_metadata => policy.node_metadata || {},
         :nodes => { :id => view_object_url(policy) + "/nodes",
                     :count => policy.nodes.count,
                     :name => "nodes" }
-      })
+      }).delete_if {|k,v| v.nil? or ( v.is_a? Hash and v.empty? ) }
     end
 
     def tag_hash(tag)

--- a/spec/app/api_spec.rb
+++ b/spec/app/api_spec.rb
@@ -146,10 +146,14 @@ describe "command and query API" do
     end
 
     it "should have the right keys" do
+      pl.max_count = 10
+      pl.node_metadata = { "key1" => "val1" }
+      pl.save
+
       get "/api/collections/policies/#{URI.escape(pl.name)}"
       policy = last_response.json
 
-      policy.keys.should =~ %w[name id spec configuration enabled rule_number max_count repo tags recipe broker nodes]
+      policy.keys.should =~ %w[name id spec configuration enabled rule_number max_count repo tags recipe broker node_metadata nodes]
       policy["repo"].keys.should =~ %w[id name spec]
       policy["configuration"].keys.should =~ %w[hostname_pattern root_password]
       policy["tags"].should be_empty


### PR DESCRIPTION
- This update allows a policy to add metadata to nodes that bind to
  it.
- It will do so in a non-authoritive manner in that it will only
  add metadata keys that do not already exist.
- For this purpose, update-node-metadata and modify-node-metadata now
  has a no_replace option that enables the non-authoritive behaviour.
