### PR TITLE
Add node power state management to Razor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # Razor Server Release Notes
 
++ the `node` object view has changed:
+  - the `node["state"]["power"]` field is removed.
+  - the `node["power"]` object is added with the fields:
+    * `"desired_power_state"` reflecting the configured desired power state for the node
+    * `"last_known_power_state"` reflecting the last observed power state
+    * `"last-power_state_update_at"` reflecting the point in time that power state observation was taken.
+  - it is important to note that this is not a real-time power state, but a
+    scheduled observation; do not assume that the last known state reflects
+    current reality.
+
 ## 0.12.0 - 2014-01-03
 
 + the server's management API underneath `/api` can now be protected with

--- a/app.rb
+++ b/app.rb
@@ -699,6 +699,24 @@ class Razor::App < Sinatra::Base
     { :result => 'reboot request queued' }
   end
 
+  command :set_node_desired_power_state do |data|
+    data['name'] or
+      error 400, :error => "Supply 'name' to indicate which node to edit"
+
+    check_permissions! "commands:set-node-desired-power-state:#{data['name']}"
+
+    node = Razor::Data::Node.find_by_name(data['name']) or
+      error 404, :error => "node #{data['name']} does not exist"
+
+    case data['to']
+    when 'on', 'off', nil
+      node.set(desired_power_state: data['to']).save
+      {result: "set desired power state to #{data['to'] || 'ignored (null)'}"}
+    else
+      error 400, :error => "invalid power state #{data['to']}"
+    end
+  end
+
   command :create_recipe do |data|
     check_permissions! "commands:create-recipe:#{data['name']}"
 

--- a/db/migrate/010_node_power_state.rb
+++ b/db/migrate/010_node_power_state.rb
@@ -1,0 +1,32 @@
+require_relative './util'
+
+Sequel.migration do
+  up do
+    # Since an enum is ordered, this makes `on` > `off`.
+    run %q{CREATE TYPE power_state AS ENUM ('off', 'on')}
+    add_column :nodes, :desired_power_state, 'power_state', :null => true
+
+    # This kind of hurts.
+    rename_column :nodes, :last_known_power_state, :__last_known_power_state
+    add_column :nodes, :last_known_power_state, 'power_state', :null => true
+    from(:nodes).where(:__last_known_power_state => true).
+      update(:last_known_power_state => 'on')
+    from(:nodes).where(:__last_known_power_state => false).
+      update(:last_known_power_state => 'off')
+    drop_column :nodes, :__last_known_power_state
+  end
+
+  down do
+    # Migrate back to the boolean version of the last power state column.
+    rename_column :nodes, :last_known_power_state, :__last_known_power_state
+    add_column :nodes, :last_known_power_state, :boolean, :null => true
+    from(:nodes).where(:__last_known_power_state => 'on').
+      update(:last_known_power_state => true)
+    from(:nodes).where(:__last_known_power_state => 'off').
+      update(:last_known_power_state => false)
+    drop_column :nodes, :__last_known_power_state
+
+    drop_column :nodes, :desired_power_state
+    run %q{DROP TYPE power_state}
+  end
+end

--- a/doc/api.md
+++ b/doc/api.md
@@ -410,6 +410,29 @@ The RBAC pattern for this command is:
 `reboot-node:${node}:${hard ? 'hard' : 'soft'}`
 
 
+### Set Node Desired Power State
+
+In addition to monitoring power, Razor can enforce node power state.
+This command allows a desired power state to be set for a node, and if the
+node is observed to be in a different power state an IPMI command will be
+issued to change to the desired state.
+
+The format of the command is:
+
+    {
+      "name": "node1234",
+      "to":   "on"|"off"|null
+    }
+
+The `name` field identifies the node to change the setting on.
+
+The `to` field contains the desired power state to set.  Valid values are
+`on`, `off`, or `null` (the JSON NULL/nil value), which reflect "power on",
+"power off", and "do not enforce power state" respectively.
+
+Power state is enforced every time it is observed; by default this happens on a scheduled basis in the background every few minutes.
+
+
 ### Modify Node Metadata
 
 Node metadata is similar to a nodes facts except metadata is what the

--- a/lib/razor/data/node.rb
+++ b/lib/razor/data/node.rb
@@ -392,9 +392,24 @@ module Razor::Data
     # We update our power state regardless of the outcome, including setting
     # it to "unknown" on failures of the IPMI code, though not on failures
     # like command execution blowing up.
+    #
+    # If we have a current power state, and a desired power state, and they
+    # don't match, we also queue work to toggle power into the
+    # appropriate state.
     def update_power_state!
       begin
-        self.last_known_power_state = Razor::IPMI.on?(self)
+        self.last_known_power_state = Razor::IPMI.on?(self) ? 'on' : 'off'
+
+        # If we have both a desired and known power state...
+        unless self.desired_power_state.nil? or self.last_known_power_state.nil?
+          # ...and they don't match...
+          unless self.desired_power_state == self.last_known_power_state
+            # ...toggle our power state to what is desired.  This is put into
+            # the background because it isn't actually related to our current
+            # transaction, and that ensures we do the right thing later.
+            self.publish(self.desired_power_state)
+          end
+        end
       rescue Razor::IPMI::IPMIError
         self.last_known_power_state = nil
         raise
@@ -408,6 +423,16 @@ module Razor::Data
     # background from the message queue.
     def reboot!(hard)
       Razor::IPMI.reset(self, hard)
+    end
+
+    # Turn the node on.
+    def on
+      Razor::IPMI.power(self, true)
+    end
+
+    # Turn the node off.
+    def off
+      Razor::IPMI.power(self, false)
     end
   end
 end

--- a/lib/razor/ipmi.rb
+++ b/lib/razor/ipmi.rb
@@ -77,6 +77,14 @@ module Razor::IPMI
     true
   end
 
+  def self.power(node, on)
+    output = run(node, 'power', on ? 'on' : 'off')
+    unless output =~ %r(Chassis Power Control: #{on ? 'Up/On' : 'Down/Off'})i
+      raise IPMIError(node, 'reset', "output did not indicate power state correctly:\n#{output}")
+    end
+    !!on
+  end
+
   # This list is hard-coded from the set of boot device types that IPMItool
   # knows about, which in turn comes from (and matches) the IPMI spec, so it
   # shouldn't change any time soon.

--- a/lib/razor/view.rb
+++ b/lib/razor/view.rb
@@ -125,13 +125,6 @@ module Razor
       return nil unless node
 
       boot_stage = node.policy ? node.recipe.boot_template(node) : nil
-      if node.last_known_power_state.nil?
-        power_state = nil
-      elsif node.last_known_power_state
-        power_state = 'on'
-      else
-        power_state = 'off'
-      end
 
       view_object_hash(node).merge(
         :hw_info       => node.hw_hash,
@@ -146,8 +139,12 @@ module Razor
           :installed    => node.installed,
           :installed_at => ts(node.installed_at),
           :stage        => boot_stage,
-          :power        => power_state
         }.delete_if { |k,v| v.nil? },
+        :power => {
+          :desired_power_state        => node.desired_power_state,
+          :last_known_power_state     => node.last_known_power_state,
+          :last_power_state_update_at => node.last_power_state_update_at
+        },
         :hostname      => node.hostname,
         :root_password => node.root_password,
         :last_checkin  => ts(node.last_checkin)

--- a/spec/app/api_spec.rb
+++ b/spec/app/api_spec.rb
@@ -594,6 +594,28 @@ describe "command and query API" do
           '$schema'  => 'http://json-schema.org/draft-04/schema#',
           'type'     => 'string',
         },
+        'power' => {
+          '$schema'    => 'http://json-schema.org/draft-04/schema#',
+          'type'       => 'object',
+          'properties' => {
+            'desired_power_state' => {
+              '$schema'  => 'http://json-schema.org/draft-04/schema#',
+              'type'     => ['string', 'null'],
+              'pattern'  => 'on|off'
+            },
+            'last_known_power_state' => {
+              '$schema'  => 'http://json-schema.org/draft-04/schema#',
+              'type'     => ['string', 'null'],
+              'pattern'  => 'on|off'
+            },
+            'last_power_state_update_at' => {
+              '$schema'  => 'http://json-schema.org/draft-04/schema#',
+              'type'     => ['string', 'null'],
+              # 'pattern' => '' ...date field.
+            }
+          },
+          'additionalProperties' => false,
+        }
       },
       'additionalProperties' => false,
     }.freeze

--- a/spec/data/node_spec.rb
+++ b/spec/data/node_spec.rb
@@ -372,7 +372,7 @@ describe Razor::Data::Node do
     end
   end
 
-  context "ipmi" do
+  context "IPMI" do
     context "validation" do
       it "should work with only hostname set" do
         # expect this to raise no errors
@@ -448,7 +448,7 @@ describe Razor::Data::Node do
     end
 
     describe "last_known_power_state" do
-      [true, false, nil].each do |value|
+      ['on', 'off', nil].each do |value|
         it "should update the timestamp when the power state is set to #{value.inspect}" do
           Timecop.freeze do
             # Make sure that we are not mis-detecting a previously set value
@@ -466,12 +466,15 @@ describe Razor::Data::Node do
     end
 
     describe "update_power_state!" do
+      include TorqueBox::Injectors
+
       before :each do
         node.update(:ipmi_hostname => Faker::Internet.domain_name).save
       end
 
       let :prehistory do Time.at(-446061360) end
       let :thefuture  do Time.at(1445480880) end
+      let :queue      do fetch('/queues/razor/sequel-instance-messages') end
 
 
       # @todo danielp 2013-12-05: this stubs the IPMI on? question, which is
@@ -479,9 +482,9 @@ describe Razor::Data::Node do
       # run, or the power state query mechanism, both of which are about as
       # tied to implementation, so I don't feel too bad about this...
 
-      { 'on' => true, 'off' => false }.each do |name, value|
-        it "should update the power state if the machine is #{name}" do
-          Razor::IPMI.stub(:on?).and_return(value)
+      %w{on off}.each do |value|
+        it "should update the power state if the machine is #{value}" do
+          Razor::IPMI.stub(:on?).and_return(value == 'on')
 
           Timecop.freeze(prehistory) do
             node.last_known_power_state.should be_nil
@@ -489,7 +492,7 @@ describe Razor::Data::Node do
 
             node.update_power_state!
 
-            node.last_known_power_state.should(value ? be_true : be_false)
+            node.last_known_power_state.should == value
             node.last_power_state_update_at.should == prehistory
           end
         end
@@ -504,12 +507,12 @@ describe Razor::Data::Node do
 
           node.update_power_state!
 
-          node.last_known_power_state.should be_true
+          node.last_known_power_state.should == 'on'
           node.last_power_state_update_at.should == prehistory
 
           Timecop.freeze(thefuture) do
             node.update_power_state!
-            node.last_known_power_state.should be_true
+            node.last_known_power_state.should == 'on'
             node.last_power_state_update_at.should == thefuture
           end
         end
@@ -524,7 +527,7 @@ describe Razor::Data::Node do
 
           node.update_power_state!
 
-          node.last_known_power_state.should be_true
+          node.last_known_power_state.should == 'on'
           node.last_power_state_update_at.should == prehistory
 
           Timecop.freeze(thefuture) do
@@ -550,7 +553,7 @@ describe Razor::Data::Node do
 
           node.update_power_state!
 
-          node.last_known_power_state.should be_true
+          node.last_known_power_state.should == 'on'
           node.last_power_state_update_at.should == prehistory
 
           Timecop.freeze(thefuture) do
@@ -561,10 +564,87 @@ describe Razor::Data::Node do
               node.update_power_state!
             }.to raise_error exception.class, exception.message
 
-            node.last_known_power_state.should be_true
+            node.last_known_power_state.should == 'on'
             node.last_power_state_update_at.should == prehistory
           end
         end
+      end
+
+      it "should queue nothing else if desired power state is null" do
+        Razor::IPMI.stub(:on?).and_return(true, false)
+
+        # First, it is on...
+        node.update_power_state!
+        queue.should be_empty
+
+        # ...then it is off...
+        node.update_power_state!
+        queue.should be_empty
+      end
+
+      it "should queue nothing if desired is off and actual is off" do
+        Razor::IPMI.stub(:on?).and_return(false)
+        node.set(:desired_power_state => 'off').save
+        node.update_power_state!
+        queue.should be_empty
+      end
+
+      it "should queue nothing if desired is on and actual is on" do
+        Razor::IPMI.stub(:on?).and_return(true)
+        node.set(:desired_power_state => 'on').save
+        node.update_power_state!
+        queue.should be_empty
+      end
+
+      it "should queue turning off if desired is off and actual is on" do
+        Razor::IPMI.stub(:on?).and_return(true)
+        node.set(:desired_power_state => 'off').save
+
+        expect {
+          node.update_power_state!
+        }.to have_published(
+          'class'     => node.class.name,
+          'instance'  => node.pk_hash,
+          'message'   => 'off',
+          'arguments' => []
+        ).on(queue)
+      end
+
+      it "should queue turning on if desired is on and actual is off" do
+        Razor::IPMI.stub(:on?).and_return(false)
+        node.set(:desired_power_state => 'on').save
+
+        expect {
+          node.update_power_state!
+        }.to have_published(
+          'class'     => node.class.name,
+          'instance'  => node.pk_hash,
+          'message'   => 'on',
+          'arguments' => []
+        ).on(queue)
+      end
+
+      it "should queue turning on twice if actual remains off when checked again" do
+        Razor::IPMI.stub(:on?).and_return(false)
+        node.set(:desired_power_state => 'on').save
+
+        expect {
+          node.update_power_state!
+        }.to have_published(
+          'class'     => node.class.name,
+          'instance'  => node.pk_hash,
+          'message'   => 'on',
+          'arguments' => []
+        ).on(queue)
+
+        expect {
+          node.update_power_state!
+        }.to have_published(
+          'class'     => node.class.name,
+          'instance'  => node.pk_hash,
+          'message'   => 'on',
+          'arguments' => []
+        ).on(queue)
       end
     end
   end

--- a/spec/ipmi_spec.rb
+++ b/spec/ipmi_spec.rb
@@ -142,6 +142,22 @@ EOT
       end
     end
 
+    context "power" do
+      it "should power on successfully" do
+        fake_run('power on', <<EOT, '')
+Chassis Power Control: Up/On
+EOT
+        Razor::IPMI.power(ipmi_node, true)
+      end
+
+      it "should power off successfully" do
+        fake_run('power off', <<EOT, '')
+Chassis Power Control: Down/Off
+EOT
+        Razor::IPMI.power(ipmi_node, false)
+      end
+    end
+
     describe "boot_from_device" do
       it "should raise an error if a bad device name is passed" do
         expect {

--- a/spec/scheduled_jobs/ipmi_spec.rb
+++ b/spec/scheduled_jobs/ipmi_spec.rb
@@ -22,7 +22,7 @@ describe Razor::ScheduledJobs::IPMI do
 
   it "should skip nodes that were recently checked" do
     Timecop.freeze do
-      Fabricate(:node_with_ipmi, :last_known_power_state => true, :last_power_state_update_at => Time.now - 30)
+      Fabricate(:node_with_ipmi, :last_known_power_state => 'on', :last_power_state_update_at => Time.now - 30)
 
       queue.count.should == 0
       ipmi.run
@@ -31,8 +31,8 @@ describe Razor::ScheduledJobs::IPMI do
   end
 
   it "should check nodes that were not recently checked regardless of power state" do
-    on      = Fabricate(:node_with_ipmi, :last_known_power_state => true, :last_power_state_update_at => Time.now - 600)
-    off     = Fabricate(:node_with_ipmi, :last_known_power_state => false, :last_power_state_update_at => Time.now - 600)
+    on      = Fabricate(:node_with_ipmi, :last_known_power_state => 'on', :last_power_state_update_at => Time.now - 600)
+    off     = Fabricate(:node_with_ipmi, :last_known_power_state => 'off', :last_power_state_update_at => Time.now - 600)
     unknown = Fabricate(:node_with_ipmi, :last_known_power_state => nil, :last_power_state_update_at => Time.now - 600)
 
     Timecop.freeze do
@@ -51,11 +51,11 @@ describe Razor::ScheduledJobs::IPMI do
   it "should work in the face of all possible types of node" do
     Timecop.freeze do
       want = []
-      want << Fabricate(:node_with_ipmi, :last_known_power_state => true, :last_power_state_update_at => Time.now - 600).pk_hash
-      want << Fabricate(:node_with_ipmi, :last_known_power_state => false, :last_power_state_update_at => Time.now - 600).pk_hash
+      want << Fabricate(:node_with_ipmi, :last_known_power_state => 'on', :last_power_state_update_at => Time.now - 600).pk_hash
+      want << Fabricate(:node_with_ipmi, :last_known_power_state => 'off', :last_power_state_update_at => Time.now - 600).pk_hash
       want << Fabricate(:node_with_ipmi, :last_known_power_state => nil, :last_power_state_update_at => Time.now - 600).pk_hash
 
-      Fabricate(:node_with_ipmi, :last_known_power_state => true, :last_power_state_update_at => Time.now - 30)
+      Fabricate(:node_with_ipmi, :last_known_power_state => 'on', :last_power_state_update_at => Time.now - 30)
       Fabricate(:node)
 
       queue.should be_empty


### PR DESCRIPTION
This extends the IPMI system from passive monitoring of power state to active
enforcement: users can now declare the desired power state, and when that is
out of sync Razor will use the IPMI system to toggle to the correct state.

Signed-off-by: Daniel Pittman daniel@rimspace.net
