### PR TITLE
* app.rb (/api): fix misplaced dup

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -457,7 +457,7 @@ class Razor::App < Sinatra::Base
     # for discussion and compatibility concerns; we also want to preserve the
     # `id` key for some time so we don't break older clients.
     {
-      "commands" => @@commands.dup.map { |c| c.update("id" => url(c["id"])) },
+      "commands" => @@commands.map { |c| c.dup.update("id" => url(c["id"])) },
       "collections" => COLLECTIONS.map do |coll|
         { "name" => coll, "rel" => spec_url("/collections/#{coll}"),
           "id" => url("/api/collections/#{coll}")}
@@ -487,7 +487,7 @@ class Razor::App < Sinatra::Base
       "name" => name,
       "rel" => Razor::View::spec_url("commands", name),
       "id" => path
-    }
+    }.freeze
 
     # Handler for the command
     post path do

--- a/spec/app/api_spec.rb
+++ b/spec/app/api_spec.rb
@@ -64,6 +64,24 @@ describe "command and query API" do
       end
     end
 
+    it "should properly set the hostname in links" do
+      # This tests https://tickets.puppetlabs.com/browse/RAZOR-93
+      # The first request to /api would 'bake' the hostname into
+      # command URL's
+      header 'Host', 'example.net'
+      get '/api'
+
+      header 'Host', 'example.com'
+      get '/api'
+
+      api = last_response.json
+      (api['commands'] + api['collections']).each do |x|
+        uri = URI::parse(x['id'])
+        uri.host.should be == 'example.com',
+          "id for #{x['name']} is '#{uri.host}' but should be 'example.com'"
+      end
+    end
+
     it "should return JSON content" do
       get '/api'
       last_response.content_type.should =~ /application\/json/i


### PR DESCRIPTION
When we generate the output for the commands in the entrypoint, we
erroneously modify the URL's for the command handlers in the @@commands
array. This leads to all commands having an 'id' containing the hostname
under which /api was accessed the very first time; all subsequent accesses
to /api will use that hostname, even if those accesses use a different
hostname.

As an example, if the first access is to http://localhost:8080/api, even
subsequent requests to http://razor:8080/api will use 'localhost' in the id
properties for commands.

The culprit for this behavior was that the entries in the @@commands array
were directly modified (as @@commands.dup makes a shallow copy, which is
pointless anyway since map creates a new array) With this change, the hash
for each command will not be modified, but a copy will be created and have
the id filled in appropriately.

In addition, to avoid this from happening again, we freeze the hash
describing each command.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-93
