### PR TITLE
Apply sanboot work-around to all virtual machines

### DIFF
--- a/tasks/common/boot_local.erb
+++ b/tasks/common/boot_local.erb
@@ -10,7 +10,10 @@ sleep 3
 <%# the other, depending on the node and the bugs in its BIOS (see          %>
 <%# http://ipxe.org/cmd/sanboot)                                            %>
 
-<% if node.facts["virtual"] == "kvm" %>
+<%# testing "is_virtual" exists technically isn't necessary, since we have  %>
+<%# full control over the client, but just in case someone builds a custom  %>
+<%# kernel image that doesn't include it, or something...                   %>
+<% if !node.facts["is_virtual"] or node.facts["is_virtual"] != "false"  %>
 echo forcing local booting with sanboot 0x80
 sanboot --no-describe --drive 0x80
 <% end %>


### PR DESCRIPTION
To date almost all virtual machine engines -- VMWare, VirtualBox, KVM -- have
a firmware fault that causes them to fail to progress to the next configured
device in the boot sequence after a clean iPXE exit back to the PXE firmware.

This is extremely unfortunate, but it is actually harder for users to get at
firmware updates to address the bug for virtual machines than physical ones.

This extends the workaround from "KVM virtual machines" to "any virtual
machine", on the basis that they don't appear to suffer the "lock up" bug when
hit with sanboot to go direct to the boot sector of the first hard disk.

This does make it impossible to boot from Razor to, say, the second hard disk,
or a USB device, or whatever, unless that happens to configure as BIOS device
0x80 (eg: first hard disk), but ... that is less common than trying to boot to
the OS we just installed, I guess.

This also does nothing for users of physical hardware that suffer the same
firmware issue; we don't have enough information to construct a generic or
specific blacklist for those nodes yet.

Signed-off-by: Daniel Pittman daniel@rimspace.net
