### PR TITLE
Move operations are unstable if repeated

### DIFF
--- a/lib/razor/data/policy.rb
+++ b/lib/razor/data/policy.rb
@@ -19,10 +19,19 @@ module Razor::Data
 
     # Put this policy into a different place in the policy table; +where+
     # can be either +before+ or +after+, +other+ must be a policy.
+    #
+    # This will raise an error if the object has not been saved, since this is
+    # required to be confirmed in current position, or if you attempt to move
+    # the object relative to itself.
     def move(where, other)
       raise "Save object first. List plugin can not move unsaved objects" if new?
-      if where == 'before'
-        move_to(other.position_value)
+      if self == other
+        raise ArgumentError, "cannot move a policy relative to itself"
+      elsif where == 'before'
+        # Move, but only if we don't already meet the constraint.
+        if self.position_value >= other.position_value then
+          move_to(other.position_value)
+        end
       elsif where == 'after'
         lp = last_position
         if other.position_value == lp

--- a/spec/data/policy_spec.rb
+++ b/spec/data/policy_spec.rb
@@ -66,13 +66,13 @@ describe Razor::Data::Policy do
   end
 
   context "ordering" do
-    let :p1 do Fabricate(:policy, :rule_number => 1) end
-    let :p2 do Fabricate(:policy, :rule_number => 2) end
+    let :p1 do Fabricate(:policy, :rule_number => 1).save end
+    let :p2 do Fabricate(:policy, :rule_number => 2).save end
 
     def check_move(where, other, list)
       p  = Fabricate(:policy)
       if where
-g        p.move(where, other)
+        p.move(where, other)
         p.save
       end
 
@@ -97,6 +97,29 @@ g        p.move(where, other)
       it "p2 goes between p1 and p2" do
         check_move('before', p2, [p1, :_, p2])
       end
+
+      it "should not change anything if the policy is already before the other" do
+        p1.move('before', p2)
+        Policy.order(:rule_number).all.should == [p1, p2]
+      end
+
+      it "should be stable if moved to first place" do
+        p1, p2, p3, p4, p5 = (1..5).map {|n| Fabricate(:policy, :rule_number => n).save }
+        p5.move('before', p1).save
+        Policy[p5.id].rule_number.should be < Policy[p1.id].rule_number
+        before = Policy[p5.id].rule_number
+        p5.move('before', p1).save
+        Policy[p5.id].rule_number.should be < Policy[p1.id].rule_number
+        Policy.all.all? do |p|
+          p.id == p5.id or p.rule_number.should be > Policy[p5.id].rule_number
+        end
+        Policy[p5.id].rule_number.should == before
+      end
+
+      it "fails if the policy moves relative to itself" do
+        expect { p1.move('before', p1) }.
+          to raise_error ArgumentError, /relative to itself/
+      end
     end
 
     describe "after" do
@@ -106,6 +129,31 @@ g        p.move(where, other)
 
       it "p2 goes to the end of the table" do
         check_move('after', p2, [p1, p2, :_])
+      end
+
+      it "should be stable if moved into the middle" do
+        p1, p2, p3, p4, p5 = (1..5).map {|n| Fabricate(:policy, :rule_number => n).save }
+        p1.move('after', p3).save
+        Policy[p3.id].rule_number.should be < Policy[p1.id].rule_number
+        before = Policy[p1.id].rule_number
+        p1.move('after', p3).save
+        Policy[p3.id].rule_number.should be < Policy[p1.id].rule_number
+        Policy[p1.id].rule_number.should == before
+      end
+
+      it "should be stable if moved to the end" do
+        p1, p2, p3, p4, p5 = (1..5).map {|n| Fabricate(:policy, :rule_number => n).save }
+        p1.move('after', p5).save
+        Policy[p5.id].rule_number.should be < Policy[p1.id].rule_number
+        before = Policy[p1.id].rule_number
+        p1.move('after', p5).save
+        Policy[p5.id].rule_number.should be < Policy[p1.id].rule_number
+        Policy[p1.id].rule_number.should == before
+      end
+
+      it "fails if the policy moves relative to itself" do
+        expect { p1.move('after', p1) }.
+          to raise_error ArgumentError, /relative to itself/
       end
     end
   end


### PR DESCRIPTION
Policy move operations in razor were unstable: if you tried to move a policy before another it could end up following it!  This corrects that, along with cleaning up some style and test problems in the code surrounding the moves.
