### PR TITLE
Correctly implement node reboots

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -698,12 +698,7 @@ class Razor::App < Sinatra::Base
     data['name'] or
       error 400, :error => "Supply 'name' to indicate which node to edit"
 
-    case data['hard']
-    when nil, true, false then # do nothing
-    else error 400, :error => 'the "hard" attribute must be a boolean, or omitted'
-    end
-
-    check_permissions! "commands:reboot-node:#{data['name']}:#{data['hard'] ? 'hard' : 'soft'}"
+    check_permissions! "commands:reboot-node:#{data['name']}"
 
     node = Razor::Data::Node.find_by_name(data['name']) or
       error 404, :error => "node #{data['name']} does not exist"
@@ -711,7 +706,7 @@ class Razor::App < Sinatra::Base
     node.ipmi_hostname or
       error 422, { :error => "node #{node.name} does not have IPMI credentials set" }
 
-    node.publish 'reboot!', !!data['hard']
+    node.publish 'reboot!'
 
     { :result => 'reboot request queued' }
   end

--- a/doc/api.md
+++ b/doc/api.md
@@ -403,14 +403,11 @@ IPMI target.
 ### Reboot node
 
 Razor can request a node reboot through IPMI, if the node has IPMI credentials
-associated.  Both hard (power cycle) and soft (request OS reboot through
-ACPI).  This uses the standard IPMI mechanisms, and has the same limitations
--- including that soft shutdown support may be implemented by simulating error
-states such as overtemperature alerts by some vendors.
+associated.  This only supports hard power cycle reboots.
 
 This is applied in the background, and will run as soon as available execution
 slots are available for the task -- IPMI communication has some generous
-internal rate limits to prevent it overwhelming the machine.
+internal rate limits to prevent it overwhelming the network or host server.
 
 This background process is persistent: if you restart the Razor server before
 the command is executed, it will remain in the queue and the operation will
@@ -432,19 +429,11 @@ The format of the command is:
 
     {
       "name": "node1",
-      "hard": false
     }
 
 The `node` field is the name of the node to operate on.
 
-The `hard` field is a boolean, or absent.  If it is present, and true, the
-reboot will be hard (eg: full power cycle, without any OS involvement).
-Otherwise it will be a soft reboot.  (Soft reboots require the OS to be
-listening, and may not work for all platforms, OS combinations, and
-especially, during installer or firmware boot states.)
-
-The RBAC pattern for this command is:
-`reboot-node:${node}:${hard ? "hard" : "soft"}`
+The RBAC pattern for this command is: `reboot-node:${node}`
 
 
 ### Set node desired power state

--- a/lib/razor/data/node.rb
+++ b/lib/razor/data/node.rb
@@ -425,11 +425,10 @@ module Razor::Data
       end
     end
 
-    # Request a reboot from the machine via IPMI.  This supports both hard and
-    # soft reboots.  This is synchronous, and is expected to be called in the
-    # background from the message queue.
-    def reboot!(hard)
-      Razor::IPMI.reset(self, hard)
+    # Request a reboot from the machine via IPMI.  This is synchronous, and is
+    # expected to be called in the background from the message queue.
+    def reboot!
+      Razor::IPMI.reset(self)
     end
 
     # Turn the node on.

--- a/lib/razor/ipmi.rb
+++ b/lib/razor/ipmi.rb
@@ -69,9 +69,9 @@ module Razor::IPMI
     power_state(node) == 'on'
   end
 
-  def self.reset(node, hard = false)
-    output = run(node, 'power', hard ? 'reset' : 'soft')
-    unless output =~ /Chassis Power Control: #{hard ? 'Reset' : 'Soft'}/i
+  def self.reset(node)
+    output = run(node, 'power', 'cycle')
+    unless output =~ /Chassis Power Control: Cycle/i
       raise IPMIError(node, 'reset', "output did not indicate reset operation:\n#{output}")
     end
     true

--- a/spec/ipmi_spec.rb
+++ b/spec/ipmi_spec.rb
@@ -185,33 +185,10 @@ EOT
 
     describe "reset" do
       it "should return true if hard reset" do
-        fake_run('power reset', <<EOT, '')
-Chassis Power Control: Reset
-EOT
-        Razor::IPMI.reset(ipmi_node, true).should be_true
-      end
-
-      it "should return true if soft reset" do
-        fake_run('power soft', <<EOT, '')
-Chassis Power Control: Soft
-EOT
-        Razor::IPMI.reset(ipmi_node, false).should be_true
-      end
-
-      it "should default to soft reset" do
-        fake_run('power soft', <<EOT, '')
-Chassis Power Control: Soft
+        fake_run('power cycle', <<EOT, '')
+Chassis Power Control: Cycle
 EOT
         Razor::IPMI.reset(ipmi_node).should be_true
-      end
-
-      it "should raise if a hard reset results from a soft reset request" do
-        fake_run('power soft', <<EOT, '')
-Chassis Power Control: Reset
-EOT
-        expect {
-          Razor::IPMI.reset(ipmi_node)
-        }.to raise_error Razor::IPMI::IPMIError, /output did not indicate reset operation/
       end
     end
 


### PR DESCRIPTION
The previous implementation of node reboots, embarrassingly, showed off my
inability to read -- offering features that simply don't exist in IPMI, and
requesting the OS power off rather than reboot.

This replaces that with the correct version, using a hard power cycle to
restart the node on demand.

Signed-off-by: Daniel Pittman daniel@rimspace.net
