### PR TITLE
Minimal fix for 500 errors when create-policy tags are not an array

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -822,7 +822,9 @@ class Razor::App < Sinatra::Base
   command :create_policy do |data|
     check_permissions! "commands:create-policy:#{data['name']}"
 
-    tags = (data.delete("tags") || []).map do |t|
+    tags = (data.delete("tags") || [])
+    tags.is_a?(Array) or error 400, :error => "tags must be an array"
+    tags = tags.map do |t|
       Razor::Data::Tag.find_or_create_with_rule(t)
     end
 

--- a/spec/app/create_policy_spec.rb
+++ b/spec/app/create_policy_spec.rb
@@ -49,6 +49,12 @@ describe "create policy command" do
       last_response.json["id"].should =~ %r'/api/collections/policies/test%20policy\Z'
     end
 
+    it "should fail if the tags value is a string" do
+      policy_hash[:tags] = ""
+      create_policy
+      last_response.status.should == 400
+    end
+
     it "should fail if a nonexisting tag is referenced" do
       policy_hash[:tags] = [ { "name" => "not_a_tag"} ]
       create_policy


### PR DESCRIPTION
This is the absolutely minimal fix for the current failure -- a runtime Ruby
error about methods missing, or other similar oddities -- when the value of
the "tags" data in create-policy is not the type expected.

This makes no attempt to find and fix similar errors elsewhere, and is a
one-shot patch for the specific failure.

Signed-off-by: Daniel Pittman daniel@rimspace.net
