### PR TITLE
Update os_boot.erb

### DIFF
--- a/tasks/ubuntu/os_boot.erb
+++ b/tasks/ubuntu/os_boot.erb
@@ -6,7 +6,7 @@ exec >> /var/log/razor.log 2>&1
 
 
 # APT configuration and system update
-sed -i 's_<%= repo_url %>_http://gb.archive.ubuntu.com/ubuntu_' /etc/apt/sources.list
+sed -i s$'\001'<%= repo_url %>$'\001'http://gb.archive.ubuntu.com/ubuntu$'\001' /etc/apt/sources.list
 
 apt-get -y update
 [ "$?" -eq 0 ] || curl -s <%= log_url("apt_update_fail", :error) %>


### PR DESCRIPTION
Using the underscore character " _ " for the separator can be problematic - if the <%= repo_url %> value contains an underscore .

My example, the repo was named "ubuntu_server" and of course the sed command would wonk out when hitting the underscore in the url (http://192.168.1.5:8080/svc/repo/ubuntu_server)

I replaced the delimiter with the character that has the octal value 001 - in ASCII it's the SOH character (start of heading) - which is extremely unlikely to appear in the repo name.

I think it is safer to use this.
