### PR TITLE
Use Node Metadata to Over Ride Node Attributes

### DIFF
--- a/brokers/chef.broker/install.erb
+++ b/brokers/chef.broker/install.erb
@@ -56,7 +56,7 @@ printf '%s\n' "$rsa_key" >> /etc/chef/validation.pem
 cat <<'EOP'
 	log_level :info
 	log_location STDOUT
-	chef_server_url "<%= broker.chef_server_url %>"
+	chef_server_url "<%= node.metadata['chef_server_url'] || broker.chef_server_url %>"
 	validation_client_name "<%= broker.validation_client_name %>"
 EOP
 ) > /etc/chef/client.rb

--- a/brokers/puppet-pe.broker/install.erb
+++ b/brokers/puppet-pe.broker/install.erb
@@ -12,7 +12,7 @@ cmd()  { hash "$1" >&/dev/null; } # portable 'which'
 cmd bash || fail "we need bash available to be able to run the installer"
 
 # ...our nice, generic, delegatable script.
-url="https://<%= (broker[:server] || 'puppet') %>:8140/packages/<%= broker[:version] || 'current' %>/install.bash"
+url="https://<%= (node.metadata['puppet_server'] || broker[:server] || 'puppet') %>:8140/packages/<%= broker[:version] || 'current' %>/install.bash"
 
 # Now, figure out how to download and run the script we need...
 if cmd curl; then

--- a/brokers/puppet.broker/install.erb
+++ b/brokers/puppet.broker/install.erb
@@ -120,6 +120,9 @@ puppet module install puppetlabs/inifile
 
 # Update the ini file with the resource tool.
 <% broker.each do |setting, value| %>
+<%- if setting == 'server'
+      value = node.metadata['puppet_server'] || value
+    end -%> 
 puppet resource ini_setting ensure=present path=/etc/puppet/puppet.conf section=main setting=<%= setting.shellescape %> value=<%= value.shellescape %>
 <% end %>
 <% end %>

--- a/lib/razor/data/node.rb
+++ b/lib/razor/data/node.rb
@@ -95,13 +95,15 @@ module Razor::Data
     end
 
     def domainname
-      return nil if hostname.nil?
-      hostname.split(".").drop(1).join(".")
+      name = metadata['hostname'] || hostname
+      return nil if name.nil?
+      name.split(".").drop(1).join(".")
     end
 
     def shortname
-      return nil if hostname.nil?
-      hostname.split(".").first
+      name = metadata['hostname'] || hostname
+      return nil if name.nil?
+      name.split(".").first
     end
 
     # Retrive the entire log for this node as an array of hashes, ordered

--- a/tasks/common/set_hostname.erb
+++ b/tasks/common/set_hostname.erb
@@ -1,7 +1,7 @@
 <%# -*- shell-script -*- %>
 # Configure hostname.
-hostname <%= node.hostname %>
-echo <%= node.hostname %> > /etc/hostname
+hostname <%= node.metadata['hostname'] || node.hostname %>
+echo <%= node.metadata['hostname'] || node.hostname %> > /etc/hostname
 
 # This set of commands should convert the first local (but non-loopback) IP
 # address in the /etc/hosts file to an entry that has the fully-qualified
@@ -10,7 +10,7 @@ echo <%= node.hostname %> > /etc/hostname
 # in the /etc/hosts- file
 cp -p /etc/hosts /etc/hosts-
 grep '^127\.0\.0\.1.*' /etc/hosts- > /etc/hosts
-grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | head -1 | sed 's/^\(127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\)\([[:blank:]]\{1,\}\)\(.*\)$/\1\2'<%= node.hostname %>'\2'<%= node.shortname %>'/' >> /etc/hosts
+grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | head -1 | sed 's/^\(127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\)\([[:blank:]]\{1,\}\)\(.*\)$/\1\2'<%= node.metadata['hostname'] || node.hostname %>'\2'<%= node.shortname %>'/' >> /etc/hosts
 grep -v '^127\.0\.0\.1.*' /etc/hosts- | grep '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' | tail -n +2 >> /etc/hosts
 grep -v '^127\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}.*' /etc/hosts- >> /etc/hosts
 

--- a/tasks/debian/wheezy/preseed.erb
+++ b/tasks/debian/wheezy/preseed.erb
@@ -4,7 +4,7 @@ d-i console-setup/ask_detect boolean false
 d-i keyboard-configuration/xkb-keymap select us
 d-i keyboard-configuration/layoutcode string us
 d-i netcfg/choose_interface select auto
-d-i netcfg/get_hostname string <%= node.hostname %>
+d-i netcfg/get_hostname string <%= node.metadata['hostname'] || node.hostname %>
 d-i netcfg/get_domain string puppetlabs.lan
 d-i netcfg/no_default_route boolean true
 d-i mirror/country string manual

--- a/tasks/redhat/6/kickstart.erb
+++ b/tasks/redhat/6/kickstart.erb
@@ -7,8 +7,8 @@ url --url=<%= repo_url %>
 cmdline
 lang en_US.UTF-8
 keyboard us
-rootpw <%= node.root_password %>
-network --hostname <%= node.hostname %>
+rootpw <%= node.metadata['root_password'] || node.root_password %>
+network --hostname <%= node.metadata['hostname'] || node.hostname %>
 firewall --enabled --ssh
 authconfig --enableshadow --passalgo=sha512 --enablefingerprint
 timezone --utc America/Los_Angeles

--- a/tasks/ubuntu/precise/preseed.erb
+++ b/tasks/ubuntu/precise/preseed.erb
@@ -1,7 +1,7 @@
 d-i console-setup/ask_detect boolean false
 d-i keyboard-configuration/layoutcode string us
 d-i netcfg/choose_interface select auto
-d-i netcfg/get_hostname string <%= node.hostname %>
+d-i netcfg/get_hostname string <%= node.metadata['hostname'] || node.hostname %>
 d-i netcfg/get_domain string <%= node.domainname %>
 d-i netcfg/no_default_route boolean true
 d-i mirror/protocol string <%= repo_uri.scheme %>
@@ -30,8 +30,8 @@ d-i partman/confirm_nooverwrite boolean true
 d-i partman-md/confirm boolean true
 d-i passwd/root-login boolean true
 d-i passwd/make-user boolean true
-d-i passwd/root-password password <%= node.root_password %>
-d-i passwd/root-password-again password <%= node.root_password %>
+d-i passwd/root-password password <%= node.metadata['root_password'] || node.root_password %>
+d-i passwd/root-password-again password <%= node.metadata['root_password'] || node.root_password %>
 d-i passwd/user-fullname string Ubuntu User
 d-i passwd/username string ubuntu
 d-i passwd/user-password password insecure

--- a/tasks/vmware_esxi/ks.cfg.erb
+++ b/tasks/vmware_esxi/ks.cfg.erb
@@ -1,7 +1,9 @@
 # Thanks to William Lam for being the guru
 accepteula
 rootpw --iscrypted <%=
-  if node.root_password =~ /^\$\d+\$[^$]*\$/
+  if node.metadata['hostname'] =~ /^\$\d+\$[^$]*\$/
+    node.metadata['hostname']
+  elsif node.root_password =~ /^\$\d+\$[^$]*\$/
     node.root_password
   else
     require 'unix_crypt'
@@ -28,7 +30,7 @@ wget <%= stage_done_url("kickstart") %>
 
 %firstboot --interpreter=busybox
 # set the hostname correctly before we do anythig else
-esxcli system hostname set --fqdn <%= node.hostname %>
+esxcli system hostname set --fqdn <%= node.metadata['hostname'] || node.hostname %>
 
 # enable HV (Hardware Virtualization to run nested 64bit Guests + Hyper-V VM)
 grep -i 'vhv.allow' /etc/vmware/config || echo 'vhv.allow = 'TRUE'' >> /etc/vmware/config


### PR DESCRIPTION
Where appropriate, allow node metadata to take precedence over node attributes applied by a policy in places such as Tasks and Brokers.

Just looking for feedback atm, I haven't had a chance to run the tests on this yet