### PR TITLE
Prevent duplicate tempfiles when streaming download

### DIFF
--- a/lib/razor/data/repo.rb
+++ b/lib/razor/data/repo.rb
@@ -83,35 +83,29 @@ module Razor::Data
       tmpdir   = Pathname(Dir.mktmpdir("razor-repo-#{filesystem_safe_name}-download"))
       filename = tmpdir + Pathname(url.path).basename
 
-      File.open(filename, CreateFileForWrite, 0600) do |dest|
-        url.open do |source|
-          # JRuby 1.7.4 requires String or IO class be passed to
-          # `IO.copy_stream`, which unfortunately precludes our using it.
-          # open-uri sanely returns StringIO for short bodies, which just
-          # don't work here.  We should replace it with the cleaner
-          # one-function version when we can.
-          #
-          # Preallocating the buffer reduces object churn.
-          buffer = ''
-          while source.read(BufferSize, buffer)
-            written = dest.write(buffer)
-            unless written == buffer.size
-              raise "download_file_to_tempdir(#{url}): unable to cope with partial write of #{written} bytes when #{buffer.size} expected"
-            end
-          end
-
-          # Try and get our data out to disk safely before we consider the
-          # write completed.  That way a crash won't leak partial state, given
-          # our database does try and be this conservative too.
-          begin
-            dest.flush
-            dest.respond_to?('fdatasync') ? dest.fdatasync : dest.fsync
-          rescue NotImplementedError
-            # This signals that neither fdatasync nor fsync could be used on
-            # this IO, which we can politely ignore, because what the heck can
-            # we do anyhow?
-          end
+      result = url.open
+      unless result.is_a?(File)
+        # Create Tempfile to converge code flow.
+        tmpfile = Tempfile.new filename.to_s
+        tmpfile.binmode
+        tmpfile << result.read
+        result = tmpfile
+      end
+      begin
+        # Try and get our data out to disk safely before we consider the
+        # write completed.  That way a crash won't leak partial state, given
+        # our database does try and be this conservative too.
+        begin
+          result.flush
+          result.respond_to?('fdatasync') ? result.fdatasync : result.fsync
+        rescue NotImplementedError
+          # This signals that neither fdatasync nor fsync could be used on
+          # this IO, which we can politely ignore, because what the heck can
+          # we do anyhow?
         end
+        FileUtils.mv(result, filename)
+      ensure
+        result.close
       end
 
       # Downloading was successful, so save our temporary directory for later

--- a/spec/data/repo_spec.rb
+++ b/spec/data/repo_spec.rb
@@ -326,6 +326,11 @@ describe Razor::Data::Repo do
           res.body   = ' ' * LongFileSize
         end
 
+        @server.mount_proc '/redirect.iso' do |req, res|
+          res.status = 301
+          res['location'] = '/long.iso'
+        end
+
         Thread.new { @server.start }
       end
 
@@ -335,6 +340,10 @@ describe Razor::Data::Repo do
 
       let :repo do
         Repo.new(:name => 'test', :iso_url => 'http://localhost:8000/')
+      end
+
+      after :each do
+        repo.exists? && repo.destroy
       end
 
       context "download_file_to_tempdir" do
@@ -352,6 +361,12 @@ describe Razor::Data::Repo do
 
         it "should copy long content down on success" do
           url  = URI.parse('http://localhost:8000/long.iso')
+          file = repo.download_file_to_tempdir(url)
+          File.size?(file).should == LongFileSize
+        end
+
+        it "should follow redirects" do
+          url  = URI.parse('http://localhost:8000/redirect.iso')
           file = repo.download_file_to_tempdir(url)
           File.size?(file).should == LongFileSize
         end


### PR DESCRIPTION
Per RAZOR-73: When downloading a file for a repo, the code would create two temporary files: one from open-uri and one the code created explicitly. This now moves open-uri's tempfile in an attempt to avoid creating a duplicate.
