### PR TITLE
Link repo to task

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,9 @@
     3. `tasks/common`
     For a more complete guide to migrating, see
     [This migration page](http://links.puppetlabs.com/razor-migration-task-revamp)
+  + `create-repo` now requires a `task` argument. The argument must have the form:
+    { "name" => "TASK_NAME" } # Where TASK_NAME is the name of an existing task, whether
+    that be stock or custom.
 
 ## 0.13.0 - 2014-01-21
 

--- a/app.rb
+++ b/app.rb
@@ -333,7 +333,8 @@ class Razor::App < Sinatra::Base
       # have to put the kernel and initrd into the microkernel/ directory
       # in their repo store manually for things to work.
       @repo = Razor::Data::Repo.new(:name => "microkernel",
-                                    :iso_url => "file:///dev/null")
+                                    :iso_url => "file:///dev/null",
+                                    :task_name => @task.name)
     end
     template = @task.boot_template(@node)
 

--- a/db/migrate/017_add_task_name_to_repo.rb
+++ b/db/migrate/017_add_task_name_to_repo.rb
@@ -1,0 +1,54 @@
+# -*- encoding: utf-8 -*-
+require_relative './util'
+
+# Add the `task_name` column as a mandatory link between `repo` and a task.
+# After this, the existing link from `policy` to a task is no longer required,
+# but still serves as an override on the policy level.
+Sequel.migration do
+  up do
+    extension(:constraint_validations)
+
+    add_column :repos, :task_name, String, :null => true
+
+    from(:repos).update(:task_name => 'noop')
+
+    alter_table(:repos) { set_column_not_null :task_name }
+
+    alter_table(:policies) { set_column_allow_null :task_name }
+
+    # If only one task exists for the repo (via policy), assign it to repo and remove it from policy.
+    from(:policies).
+        join(:repos, :id => :repo_id).
+        select_group(:repos__id).
+        having("count(*) = 1").
+        each do |repo|
+          task_name = from(:policies).select(:task_name).where(:repo_id => repo[:id])
+          from(:repos).where(id: repo[:id]).update(:task_name => task_name)
+          from(:policies).where(repo_id: repo[:id]).update(:task_name => nil)
+        end
+
+    # Warning if using repo's task 'noop' + override on policy.
+    from(:policies).
+        join(:repos, :id => :repo_id).
+        select_group(:repos__id).
+        having("count(*) > 1").
+        each do |repo|
+          repo_name = from(:repos).select(:name).where(:id => repo[:id]).single_value
+          puts _("Warning: Multiple policies found for repo #{repo_name}; unable to control task from repo")
+        end
+  end
+
+  down do
+    # Move back to policy if policy is empty.
+    from(:policies).exclude(:task_name => nil).each do |policy|
+      puts "Policy #{policy[:name]} already has a task_name; not overriding"
+    end
+    from(:repos).each do |repo_iterator|
+      from(:policies).
+          where(repo_id: repo_iterator[:id], task_name: nil).
+          update(:task_name => repo_iterator[:task_name])
+    end
+    alter_table(:repos) { drop_column :task_name }
+    alter_table(:policies) { set_column_not_null :task_name }
+  end
+end

--- a/lib/razor/command/create_repo.rb
+++ b/lib/razor/command/create_repo.rb
@@ -5,6 +5,9 @@ class Razor::Command::CreateRepo < Razor::Command
   attr  'name',    type: String, required: true
   attr  'url',     type: URI,    exclude: 'iso-url'
   attr  'iso-url', type: URI,    exclude: 'url'
+  object 'task', required: true do
+    attr 'name', type: String, required: true
+  end
 
   require_one_of 'url', 'iso-url'
 
@@ -14,6 +17,10 @@ class Razor::Command::CreateRepo < Razor::Command
     # same transactional context, ensuring we don't send a message to our
     # background workers without also committing this data to our database.)
     data["iso_url"] = data.delete("iso-url")
+    if data["task"]
+      data["task_name"] = data.delete("task")["name"]
+    end
+
     repo = Razor::Data::Repo.new(data).save.freeze
 
     # Finally, return the state (started, not complete) and the URL for the

--- a/lib/razor/data/policy.rb
+++ b/lib/razor/data/policy.rb
@@ -65,20 +65,18 @@ module Razor::Data
     end
 
     def task
-      Razor::Task.find(task_name)
+      task_name ? Razor::Task.find(task_name) : repo.task
     end
 
     def validate
       super
-
       # Because we allow tasks in the file system, we do not have a fk
       # constraint on +task_name+; this check only helps spot simple
       # typos etc.
       begin
-        self.task
+        Razor::Task.find(task_name) if task_name
       rescue Razor::TaskNotFoundError
-        errors.add(:task_name,
-                   _("task '%{name}' does not exist") % {name: task_name})
+        errors.add(:task, _("task '%{name}' does not exist") % {name: task_name})
       end
     end
 

--- a/lib/razor/data/repo.rb
+++ b/lib/razor/data/repo.rb
@@ -22,7 +22,7 @@ module Razor::Data
     # The only columns that may be set through "mass assignment", which is
     # typically through the constructor.  Only enforced at the Ruby layer, but
     # since we direct everything through the model that is acceptable.
-    set_allowed_columns :name, :iso_url, :url
+    set_allowed_columns :name, :iso_url, :url, :task_name
 
     # When a new instance is saved, we need to make the repo accessible as a
     # local file.
@@ -49,6 +49,10 @@ module Razor::Data
       elsif url.nil? and iso_url.nil?
         errors.add(:urls, _("you must set one of the 'url' or 'iso_url' attributes"))
       end
+    end
+
+    def task
+      Razor::Task.find(task_name)
     end
 
     # Make the repo accessible on the local system, and then generate

--- a/spec/app/api_spec.rb
+++ b/spec/app/api_spec.rb
@@ -136,7 +136,7 @@ describe "command and query API" do
     end
 
     it "should list all policies" do
-      pl =  Fabricate(:policy, :repo => @repo, :task_name => "some_os")
+      pl =  Fabricate(:policy, :repo => @repo)
       pl.add_tag @tag
 
       get '/api/collections/policies'

--- a/spec/app/create_policy_spec.rb
+++ b/spec/app/create_policy_spec.rb
@@ -26,7 +26,7 @@ describe "create policy command" do
       # use them in these tests
       { :name          => "test policy",
         :repo          => { "name" => repo.name },
-        :task        => { "name" => "some_os" },
+        :task          => {"name" => "some_os"},
         :broker        => { "name" => broker.name },
         :hostname      => "host${id}.example.com",
         :root_password => "geheim",

--- a/spec/app/create_repo_spec.rb
+++ b/spec/app/create_repo_spec.rb
@@ -56,11 +56,22 @@ describe "command and query API" do
       last_response.mime_type.downcase.should == 'application/json'
     end
 
+    it "should fail if task-name is omitted" do
+      post '/api/commands/create-repo', {
+          "name"      => "magicos",
+          "iso-url"   => "file:///dev/null",
+          "banana"    => "> orange",
+      }.to_json
+      last_response.status.should == 422
+      last_response.mime_type.downcase.should == 'application/json'
+    end
+
     it "should fail if an extra key is given, if otherwise good" do
       post '/api/commands/create-repo', {
         "name"      => "magicos",
         "iso-url"   => "file:///dev/null",
         "banana"    => "> orange",
+        "task"      => {"name" => "some_os"},
       }.to_json
       last_response.status.should == 422
       last_response.mime_type.downcase.should == 'application/json'
@@ -68,8 +79,9 @@ describe "command and query API" do
 
     it "should return the 202, and the URL of the repo" do
       post '/api/commands/create-repo', {
-        "name" => "magicos",
-        "iso-url" => "file:///dev/null"
+        "name"    => "magicos",
+        "iso-url" => "file:///dev/null",
+        "task"    => {"name" => "some_os"},
       }.to_json
 
       last_response.status.should == 202
@@ -82,8 +94,9 @@ describe "command and query API" do
 
     it "should create an repo record in the database" do
       post '/api/commands/create-repo', {
-        "name" => "magicos",
-        "iso-url" => "file:///dev/null"
+        "name"    => "magicos",
+        "iso-url" => "file:///dev/null",
+        "task"    => {"name" => "some_os"},
       }.to_json
 
       Repo.find(:name => "magicos").should be_an_instance_of Repo

--- a/spec/fabricators/fabricator.rb
+++ b/spec/fabricators/fabricator.rb
@@ -37,6 +37,7 @@ end
 Fabricator(:repo, :class_name => Razor::Data::Repo) do
   name      { Faker::Commerce.product_name + " #{Fabricate.sequence}" }
   iso_url   'file:///dev/null'
+  task_name { Fabricate(:task).name }
 end
 
 
@@ -56,7 +57,6 @@ end
 Fabricator(:policy, :class_name => Razor::Data::Policy) do
   name             { Faker::Commerce.product_name + " #{Fabricate.sequence}" }
   enabled          true
-  task_name        { Fabricate(:task).name }
   hostname_pattern 'host${id}.example.org'
   root_password    { Faker::Internet.password }
 

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -16,7 +16,7 @@ describe Razor::Messaging::Sequel do
     it "should return nil if no instance is found" do
       # Ensure we don't just, say, return the first instance of an object
       # regardless of the input.
-      saved = Razor::Data::Repo.new(:name => 'some', :iso_url => 'file:///').save
+      saved = Fabricate(:repo)
       handler.find_instance_in_class(Razor::Data::Repo, { :name => 'nonesuch' }).
         should be_nil
     end
@@ -34,7 +34,7 @@ describe Razor::Messaging::Sequel do
     end
 
     it "should return an instance if the object exists" do
-      saved = Razor::Data::Repo.new(:name => 'some', :iso_url => 'file:///').save
+      saved = Fabricate(:repo)
       # This may not be identity, but is equality.
       handler.find_instance_in_class(Razor::Data::Repo, saved.pk_hash).
         should == saved
@@ -262,7 +262,7 @@ describe Razor::Messaging::Sequel do
     end
 
     it "should not queue a retry if the instance is found" do
-      pk = Razor::Data::Repo.new(:name => 'some', :iso_url => 'file:///').save.pk_hash
+      pk = Fabricate(:repo).pk_hash
       content = {
         'class'     => 'Razor::Data::Repo',
         'instance'  => pk,
@@ -275,7 +275,7 @@ describe Razor::Messaging::Sequel do
     end
 
     it "should deliver the message if 'arguments' is missing" do
-      pk = Razor::Data::Repo.new(:name => 'some', :iso_url => 'file:///').save.pk_hash
+      pk = Fabricate(:repo).pk_hash
       content = {
         'class'     => 'Razor::Data::Repo',
         'instance'  => pk,
@@ -287,7 +287,7 @@ describe Razor::Messaging::Sequel do
     end
 
     it "should deliver the message if 'arguments' is nil" do
-      pk = Razor::Data::Repo.new(:name => 'some', :iso_url => 'file:///').save.pk_hash
+      pk = Fabricate(:repo).pk_hash
       content = {
         'class'     => 'Razor::Data::Repo',
         'instance'  => pk,
@@ -302,7 +302,7 @@ describe Razor::Messaging::Sequel do
 
   describe "Sequel::Model#publish" do
     subject(:repo) do
-      repo = Razor::Data::Repo.new(:name => 'test', :iso_url => 'file:///').save
+      repo = Fabricate(:repo)
       queue.remove_messages # saving produces messages, which we are not testing.
       repo
     end


### PR DESCRIPTION
The association between a repo and a task should not be indirect through the policy. Repo requires an association to task. Policy has an optional association to task, which will help with backward-compatibility.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-143
