### PR TITLE
(RAZOR-188) Add a refresh-repo command

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -129,6 +129,20 @@ The `delete-repo` command accepts a single repo name:
       "name": "fedora16"
     }
 
+### Refresh a repo
+
+The `refresh-repo` command will trigger a refresh of the repo content from its configured
+source (iso-url) or (url).
+
+It is also useful when adding additional Razor servers to an existing database
+in that it allows you to populate the repo on the new server.
+
+It accepts the name of a single repo. 
+
+    {
+      "name" : "existing-repo"
+    }
+
 ### Create task
 
 Razor supports both tasks stored in the filesystem and tasks

--- a/lib/razor/command/refresh_repo.rb
+++ b/lib/razor/command/refresh_repo.rb
@@ -1,0 +1,15 @@
+# -*- encoding: utf-8 -*-
+class Razor::Command::RefreshRepo < Razor::Command
+  authz '%{name}'
+  attr  'name', type: String, required: true
+
+  def run(request, data)
+    if repo = Razor::Data::Repo[:name => data['name']]
+      repo.refresh(@command)
+      action = _("repo refresh started")
+    else
+      action = _("no changes; repo %{name} does not exist") % {name: data["name"]}
+    end
+    { :result => action }
+  end
+end

--- a/lib/razor/data/repo.rb
+++ b/lib/razor/data/repo.rb
@@ -57,6 +57,10 @@ module Razor::Data
       Razor::Task.find(task_name)
     end
 
+    def refresh(command)
+      publish('make_the_repo_accessible', command)
+    end
+
     # Make the repo accessible on the local system, and then generate
     # a notification.  In the event the repo is remote, it will be downloaded
     # and the temporary file stored for later cleanup.
@@ -165,7 +169,8 @@ module Razor::Data
     # done, notify ourselves of that so any cleanup required can be performed.
     def unpack_repo(command, path)
       destination = repo_store_root + filesystem_safe_name
-      destination.mkpath        # in case it didn't already exist
+      FileUtils.remove_entry_secure(destination) if destination.directory? #delete the destination and contents if it already exists
+      destination.mkpath
       Archive.extract(path, destination)
       self.publish('release_temporary_repo', command)
     end

--- a/spec/app/refresh_repo_spec.rb
+++ b/spec/app/refresh_repo_spec.rb
@@ -1,0 +1,53 @@
+# -*- encoding: utf-8 -*-
+require_relative '../spec_helper'
+require_relative '../../app'
+
+describe "command and query API" do
+  include Rack::Test::Methods
+
+  let(:app) { Razor::App }
+  before :each do
+    authorize 'fred', 'dead'
+  end
+
+  context "/api/commands/refresh-repo" do
+    before :each do
+      header 'content-type', 'application/json'
+    end
+
+    it "should reject bad JSON" do
+      post '/api/commands/refresh-repo', '{"json": "not really..."'
+      last_response.status.should == 400
+      JSON.parse(last_response.body)["error"].should == 'unable to parse JSON'
+    end
+
+    ["foo", 100, 100.1, -100, true, false].map(&:to_json).each do |input|
+      it "should reject non-object inputs (like: #{input.inspect})" do
+        post '/api/commands/refresh-repo', input
+        last_response.status.should == 400
+      end
+    end
+
+    [[], ["name", "a"]].map(&:to_json).each do |input|
+      it "should reject non-object inputs (like: #{input.inspect})" do
+        post '/api/commands/refresh-repo', input
+        last_response.status.should == 422
+      end
+    end
+
+    it "should fail with only bad key present in input" do
+      post '/api/commands/refresh-repo', {"cats" => "> dogs"}.to_json
+      last_response.status.should == 422
+      last_response.mime_type.downcase.should == 'application/json'
+    end
+
+    it "should fail if an extra key is given, if otherwise good" do
+      post '/api/commands/refresh-repo', {
+        "name"      => "magicos",
+        "banana"    => "> orange",
+      }.to_json
+      last_response.status.should == 422
+      last_response.mime_type.downcase.should == 'application/json'
+    end
+  end
+end

--- a/spec/data/repo_spec.rb
+++ b/spec/data/repo_spec.rb
@@ -600,4 +600,21 @@ describe Razor::Data::Repo do
       end
     end
   end
+
+  context "refresh" do
+    let :repo do
+      Repo.new(:name => 'refresh', :iso_url => 'file:///dev/empty', :task_name => 'testing').save
+    end
+
+    it "should publish a 'make_repo_accessible' job" do
+      command = Fabricate(:command)
+      expect {
+        repo.refresh(command)
+      }.to have_published(
+        'class'    => repo.class.name,
+        'instance' => repo.pk_hash,
+        'message'  => 'make_the_repo_accessible'
+      ).on(queue)
+    end
+  end
 end


### PR DESCRIPTION
This is useful in the following scenarios:
- The content of the repo source has been updated and needs to updated on the razor server
- A new razor server connected to an existing database (used by existing razor servers) is brought online.  This command will 'refresh' the repo onto the new server without wanting to manipulate the database.
