### PR TITLE
(RAZOR-190) Add command to update repo

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -129,6 +129,27 @@ The `delete-repo` command accepts a single repo name:
       "name": "fedora16"
     }
 
+### Set Source of an Existing Repo
+
+The `set-repo-source` command will update an existing repo with a new source.
+It accepts a repo name and one of 'url' or 'iso-url, and an optional 'refresh'
+option that defaults to true and triggers a refresh of the repo from the new
+source.
+
+    {
+      "repo"   : { 'name': 'exisiting-repo' },
+      "iso-url": "http://new.iso.location",
+      "refresh": true
+    }
+
+or;
+
+    {
+      "repo"   : { 'name': 'exisiting-repo' },
+      "url"    : "http://new.repo.location"
+      "refresh": false
+    }
+
 ### Create task
 
 Razor supports both tasks stored in the filesystem and tasks

--- a/doc/api.md
+++ b/doc/api.md
@@ -150,6 +150,20 @@ or;
       "refresh": false
     }
 
+### Refresh a repo
+
+The `refresh-repo` command will trigger a refresh of the repo content from its configured
+source (iso-url) or (url).
+
+It is also useful when adding additional Razor servers to an existing database
+in that it allows you to populate the repo on the new server.
+
+It accepts the name of a single repo. 
+
+    {
+      "repo" : {"name": "existing-repo"}
+    }
+
 ### Create task
 
 Razor supports both tasks stored in the filesystem and tasks

--- a/lib/razor/command/refresh_repo.rb
+++ b/lib/razor/command/refresh_repo.rb
@@ -1,0 +1,43 @@
+# -*- encoding: utf-8 -*-
+class Razor::Command::RefreshRepo < Razor::Command
+  summary "Initiate a refresh of a repository from its source"
+  description <<-EOT
+Initiates a refresh of a repoisitory from its source.  This is done by removing
+the repository from disk and replacing it with a fresh copy from the source.
+
+This is also useful in cases where multiple razor servers are connected to
+a single database.  Second and subsequent servers can use this command to
+populate their own copies of repositories without having to define their own
+in the database.
+
+WARNING: This operation will cause an interuption in the repositories availability
+and may impact dependant tasks in progress.
+  EOT
+
+  example <<-EOT
+Refresh an existing repository:
+  {
+    repo: { 'name': 'myRepo' }
+  }
+  EOT
+
+  authz '%{repo}'
+  object 'repo',    required: true, help: _(<<-HELP) do
+    The repository to trigger a refresh for.
+  HELP
+    attr 'name',    type: String, required: true, references: Razor::Data::Repo,
+                    help: _('The name for the repository to trigger a refresh for.')
+  end
+
+  def run(request, data)
+    repo = Razor::Data::Repo[:name => data['repo']['name']]
+    repo.refresh(@command)
+    { :result => "repo refresh started" }
+  end
+
+  def self.conform!(data)
+    data.tap do |_|
+      data['repo'] = { 'name' => data['repo'] } if data['repo'].is_a?(String)
+    end
+  end
+end

--- a/lib/razor/command/set_repo_source.rb
+++ b/lib/razor/command/set_repo_source.rb
@@ -1,0 +1,64 @@
+# -*- encoding: utf-8 -*-
+class Razor::Command::SetRepoSource < Razor::Command
+  summary "Set the source for an existing repository"
+  description <<-EOT
+Set the source, being either an iso-url or url, on an exisiting repository.
+
+By default the repository will start a refresh of its content from the new
+location, but this can be defered and manually triggered at a later time with
+the refresh-repo command.
+
+WARNING: Refreshing the repository will cause an interuption in the repositories
+availability and may impact dependant tasks in progress.
+  EOT
+
+  example <<-EOT
+Set the source to be an iso-url:
+  {
+    repo: { name: 'myRepo' },
+    iso-url: 'http://myserver.com/my_iso_file.iso'
+  }
+
+Set the source to a URL with the content already unpacked:
+  {
+    repo: { name: 'myRepo' },
+    url: 'http://myserver.com/my_repo/'
+  }
+
+Defer the refresh to be done manually later:
+  {
+    repo: { name: 'myRepo' },
+    url: 'http://myserver.com/my_repo/',
+    refresh: false
+  }
+  EOT
+
+  authz '%{repo}'
+
+  object 'repo',    required: true, help: _(<<-HELP) do
+    The repository to set the source for.
+  HELP
+    attr 'name',    type: String, required: true, references: Razor::Data::Repo,
+                    help: _('The name for the repository to set the source for.')
+  end
+  attr   'url',     type: URI,    exclude: 'iso-url',
+                    help: _('The url to use as the new source.  Cannot be used in conjunction with "iso-url"')
+  attr   'iso-url', type: URI,    exclude: 'url',
+                    help: _('The iso-url to use as the new source. Cannot be used in conjunction with "url"')
+  attr   'refresh', type: :bool,
+                    help: _('Control whether or not to trigger a refresh.  Accepts true/false, default: true')
+
+  require_one_of 'url', 'iso-url'
+
+  def run(request, data)
+    repo = Razor::Data::Repo[:name => data['repo']['name']]
+    data["iso_url"] = data.delete("iso-url")
+    repo.set_source(@command, data)
+  end
+  
+  def self.conform!(data)
+    data.tap do |_|
+      data['repo'] = { 'name' => data['repo'] } if data['repo'].is_a?(String)
+    end
+  end
+end

--- a/lib/razor/data/repo.rb
+++ b/lib/razor/data/repo.rb
@@ -62,6 +62,22 @@ module Razor::Data
       Razor::Task.find(task_name)
     end
 
+    def set_source(command, data)
+      #refresh should default to true
+      data['refresh'] = true if data['refresh'].nil?
+
+      old = self.clone
+      self.iso_url = data['iso_url'] || nil
+      self.url     = data['url']     || nil
+
+      unless self == old
+        self.save
+        self.refresh(command) if data['refresh']
+      end
+
+      self
+    end
+
     # Make the repo accessible on the local system, and then generate
     # a notification.  In the event the repo is remote, it will be downloaded
     # and the temporary file stored for later cleanup.

--- a/lib/razor/data/repo.rb
+++ b/lib/razor/data/repo.rb
@@ -62,6 +62,10 @@ module Razor::Data
       Razor::Task.find(task_name)
     end
 
+    def refresh(command)
+      publish('make_the_repo_accessible', command)
+    end
+
     def set_source(command, data)
       #refresh should default to true
       data['refresh'] = true if data['refresh'].nil?
@@ -186,7 +190,8 @@ module Razor::Data
     # done, notify ourselves of that so any cleanup required can be performed.
     def unpack_repo(command, path)
       destination = iso_location
-      destination.mkpath        # in case it didn't already exist
+      FileUtils.remove_entry_secure(destination) if destination.directory? #delete the destination and contents if it already exists
+      destination.mkpath
       Archive.extract(path, destination)
       self.publish('release_temporary_repo', command)
     end

--- a/spec/app/refresh_repo_spec.rb
+++ b/spec/app/refresh_repo_spec.rb
@@ -1,0 +1,93 @@
+# -*- encoding: utf-8 -*-
+require_relative '../spec_helper'
+require_relative '../../app'
+
+describe "command and query API" do
+  include Rack::Test::Methods
+
+  let(:app) { Razor::App }
+  before :each do
+    authorize 'fred', 'dead'
+  end
+
+  context "/api/commands/refresh-repo" do
+    let :repo do
+      Repo.new(:name => 'magicos', "iso_url" => "file:///dev/null", :task_name => 'testing').save
+    end
+      
+    before :each do
+      header 'content-type', 'application/json'
+    end
+
+    it "should reject bad JSON" do
+      post '/api/commands/refresh-repo', '{"json": "not really..."'
+      last_response.status.should == 400
+      JSON.parse(last_response.body)["error"].should == 'unable to parse JSON'
+    end
+
+    ["foo", 100, 100.1, -100, true, false].map(&:to_json).each do |input|
+      it "should reject non-object inputs (like: #{input.inspect})" do
+        post '/api/commands/refresh-repo', input
+        last_response.status.should == 400
+      end
+    end
+
+    [[], ["name", "a"]].map(&:to_json).each do |input|
+      it "should reject non-object inputs (like: #{input.inspect})" do
+        post '/api/commands/refresh-repo', input
+        last_response.status.should == 422
+      end
+    end
+
+    it "should fail with only bad key present in input" do
+      post '/api/commands/refresh-repo', {"cats" => "dogs"}.to_json
+      last_response.status.should == 422
+      last_response.mime_type.downcase.should == 'application/json'
+    end
+
+    it "should fail if an extra key is given, if otherwise good" do
+      repo.name
+      post '/api/commands/refresh-repo', {
+        "repo"      => "magicos",
+        "banana"    => "orange",
+      }.to_json
+      last_response.status.should == 422
+      last_response.mime_type.downcase.should == 'application/json'
+    end
+
+    it "should fail if a non-existant repo is supplied" do
+      post '/api/commands/refresh-repo', {
+        "repo"      => "nonexistant",
+      }.to_json
+      last_response.status.should == 404
+      last_response.mime_type.downcase.should == 'application/json'
+      JSON.parse(last_response.body)["error"].should =~ /must be the name of an existing repo/
+    end
+
+    it "should return the 202, and the URL of the repo if the params are correct and the repo exists" do
+      post '/api/commands/refresh-repo', {
+        "repo"    => { "name" => repo.name },
+      }.to_json
+
+      last_response.status.should == 202
+      last_response.mime_type.downcase.should == 'application/json'
+
+      data = JSON.parse(last_response.body)
+      data.keys.should =~ %w[command result]
+      data["result"].should =~ %r"repo refresh started"
+    end
+
+    it "should comform the repo value if given as a string instead of an object" do
+      post '/api/commands/refresh-repo', {
+        "repo"    => repo.name,
+      }.to_json
+
+      last_response.status.should == 202
+      last_response.mime_type.downcase.should == 'application/json'
+
+      data = JSON.parse(last_response.body)
+      data.keys.should =~ %w[command result]
+      data["result"].should =~ %r"repo refresh started"
+    end
+  end
+end

--- a/spec/app/set_repo_source_spec.rb
+++ b/spec/app/set_repo_source_spec.rb
@@ -1,0 +1,144 @@
+# -*- encoding: utf-8 -*-
+require_relative '../spec_helper'
+require_relative '../../app'
+
+describe "command and query API" do
+  include Rack::Test::Methods
+
+  let(:app) { Razor::App }
+  before :each do
+    authorize 'fred', 'dead'
+  end
+
+  context "/api/commands/set-repo-source" do
+    let :repo do
+      Repo.new(:name => 'magicos', "iso_url" => "file:///dev/null", :task_name => 'testing').save
+    end
+
+    before :each do
+      header 'content-type', 'application/json'
+    end
+
+    it "should reject bad JSON" do
+      post '/api/commands/set-repo-source', '{"json": "not really..."'
+      last_response.status.should == 400
+      JSON.parse(last_response.body)["error"].should == 'unable to parse JSON'
+    end
+
+    ["foo", 100, 100.1, -100, true, false].map(&:to_json).each do |input|
+      it "should reject non-object inputs (like: #{input.inspect})" do
+        post '/api/commands/set-repo-source', input
+        last_response.status.should == 400
+      end
+    end
+
+    [[], ["name", "a"]].map(&:to_json).each do |input|
+      it "should reject non-object inputs (like: #{input.inspect})" do
+        post '/api/commands/set-repo-source', input
+        last_response.status.should == 422
+      end
+    end
+
+    it "should fail with only bad key present in input" do
+      post '/api/commands/set-repo-source', {"cats" => "> dogs"}.to_json
+      last_response.status.should == 422
+      last_response.mime_type.downcase.should == 'application/json'
+      # @todo danielp 2013-06-26: should do something to assert we got a good
+      # error message or messages out of the system; see comments in app.rb
+      # for details about why that is delayed.
+    end
+
+    it "should fail if only the repo is given" do
+      repo.name
+      post '/api/commands/set-repo-source', {"repo" => {"name" => "magicos"}}.to_json
+      last_response.status.should == 422
+      last_response.mime_type.downcase.should == 'application/json'
+    end
+
+    it "should fail if only the iso_url is given" do
+      post '/api/commands/set-repo-source', {"iso_url" => "file:///dev/null"}.to_json
+      last_response.status.should == 422
+      last_response.mime_type.downcase.should == 'application/json'
+    end
+
+    it "should fail if attempting to update a repo that does not exist" do
+      post '/api/commands/set-repo-source', {
+        "repo"      => {"name" => "nonexistant"},
+        "iso-url"   => "file:///dev/null",
+      }.to_json
+      last_response.status.should == 404
+      last_response.mime_type.downcase.should == 'application/json'
+      JSON.parse(last_response.body)["error"].should =~ /must be the name of an existing repo/
+    end
+
+    it "should fail if an extra key is given, if otherwise good" do
+      post '/api/commands/set-repo-source', {
+        "repo"      => { "name" => repo.name },
+        "iso-url"   => "file:///dev/null",
+        "banana"    => "> orange",
+      }.to_json
+      last_response.status.should == 422
+      last_response.mime_type.downcase.should == 'application/json'
+      JSON.parse(last_response.body)["error"].should =~ /extra attribute banana was present/
+    end
+
+    [ true, false ].each do |test|
+      it "should accept #{test} as a value for refresh" do
+        post '/api/commands/set-repo-source', {
+          "repo"    => { "name" => repo.name },
+          "iso-url" => "file:///dev/random",
+          "refresh" => test,
+        }.to_json
+        last_response.status.should == 202
+      end
+    end
+
+    it "should not except non true/false values for refresh" do
+      post '/api/commands/set-repo-source', {
+        "repo"    => { "name" => repo.name },
+        "iso-url" => "file:///dev/random",
+        "refresh" => "garbage",
+      }.to_json
+      last_response.status.should == 422
+      last_response.mime_type.downcase.should == 'application/json'
+      JSON.parse(last_response.body)["error"].should =~ /refresh should be one of true, false/
+    end
+
+    it "should return the 202, and the URL of the repo" do
+      post '/api/commands/set-repo-source', {
+        "repo"    => { "name" => repo.name },
+        "iso-url" => "file:///dev/random"
+      }.to_json
+
+      last_response.status.should == 202
+      last_response.mime_type.downcase.should == 'application/json'
+
+      data = JSON.parse(last_response.body)
+      data.keys.should =~ %w[command id name spec]
+      data["id"].should =~ %r"/api/collections/repos/#{repo.name}\Z"
+    end
+
+    it "should comform the repo value if given as a string instead of an object" do
+      post '/api/commands/set-repo-source', {
+        "repo"    => repo.name,
+        "iso-url" => "file:///dev/random"
+      }.to_json
+
+      last_response.status.should == 202
+      last_response.mime_type.downcase.should == 'application/json'
+
+      data = JSON.parse(last_response.body)
+      data.keys.should =~ %w[command id name spec]
+      data["id"].should =~ %r"/api/collections/repos/#{repo.name}\Z"
+    end
+
+    it "should update a repo record in the database" do
+      post '/api/commands/set-repo-source', {
+        "repo"    => { "name" => repo.name },
+        "iso-url" => "file:///dev/random"
+      }.to_json
+
+      Repo.find(:name => repo.name).iso_url.should == "file:///dev/random"
+    end
+  end
+end

--- a/spec/data/repo_spec.rb
+++ b/spec/data/repo_spec.rb
@@ -675,4 +675,21 @@ describe Razor::Data::Repo do
       ).on(queue)
     end
   end
+  
+  context "refresh" do
+    let :repo do
+      Repo.new(:name => 'refresh', :iso_url => 'file:///dev/empty', :task_name => 'testing').save
+    end
+
+    it "should publish a 'make_repo_accessible' job" do
+      command = Fabricate(:command)
+      expect {
+        repo.refresh(command)
+      }.to have_published(
+        'class'    => repo.class.name,
+        'instance' => repo.pk_hash,
+        'message'  => 'make_the_repo_accessible'
+      ).on(queue)
+    end
+  end
 end

--- a/spec/lib/razor/fake_queue.rb
+++ b/spec/lib/razor/fake_queue.rb
@@ -22,13 +22,15 @@ RSpec::Matchers.define :have_published do |expected|
     raise "queue was not set with `on`" unless @queue
     before = @queue.count - 1   # only newly published messages count
     code_to_run.call            # don't care if you throw past me
-    after = @queue.peek_at_all.slice(before .. -1).map{|msg| msg[:body]}
-    after.any? do |msg|
-      expected.all? do |k, v|
-        # The comparison on the right allows us to use rspec matchers, as well
-        # as Class instances, regexp vs string, etc, smart matching.
-        # Especially the ability to use an rspec matcher is ideal.
-        msg.has_key?(k) and v === msg[k]
+    if after = @queue.peek_at_all.slice(before .. -1)
+      after = after.map{|msg| msg[:body]}
+      after.any? do |msg|
+        expected.all? do |k, v|
+          # The comparison on the right allows us to use rspec matchers, as well
+          # as Class instances, regexp vs string, etc, smart matching.
+          # Especially the ability to use an rspec matcher is ideal.
+          msg.has_key?(k) and v === msg[k]
+        end
       end
     end
   end


### PR DESCRIPTION
Add an update-repo command that will allow the update of repo settings. When the supplied setting are different, the process will trigger a 'make_repo_available' event.  This is required, because if you create the repo and then policies/tags etc only to realise you botched the definition of the repo, you first have to pull down all the dependants (policies and the like) to delete/recreate the repo.