### PR TITLE
Disallow empty key name for node metadata

### DIFF
--- a/lib/razor/validation/hash_attribute.rb
+++ b/lib/razor/validation/hash_attribute.rb
@@ -107,6 +107,8 @@ class Razor::Validation::HashAttribute
       when Module then
         if entry <= URI then
           {type: String, validate: -> str { URI.parse(str) }}
+        elsif entry <= Hash then
+          {type: Hash, validate: -> hash { raise ArgumentError, "blank attribute not allowed" if hash.keys.include? '' }}
         else
           {type: entry}
         end

--- a/spec/app/modify_node_metadata_spec.rb
+++ b/spec/app/modify_node_metadata_spec.rb
@@ -66,6 +66,13 @@ describe "modify node metadata command" do
     last_response.json["error"].should =~ /no_replace must be boolean true or string 'true'/
   end
 
+  it "should reject blank attributes" do
+    data = { 'node' => "node#{node.id}", 'update' => { '' => 'v1'} }
+    modify_metadata(data)
+    last_response.status.should == 422
+    last_response.json["error"].should =~ /blank attribute not allowed/
+  end
+
   describe "when updating metadata on a node" do
 
     it "should create a new metadata item on a node" do


### PR DESCRIPTION
The key {"": "blank"} should not be allowed in node metadata (modify-node-metadata command) since it is not a meaningful attribute.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-121
