### PR TITLE
Disallow empty key names in hash

### DIFF
--- a/lib/razor/validation/array_attribute.rb
+++ b/lib/razor/validation/array_attribute.rb
@@ -48,16 +48,16 @@ class Razor::Validation::ArrayAttribute
         begin
           check[:validate] and check[:validate].call(value)
         rescue => e
-          raise Razor::ValidationFailure, _("attribute %{name} fails type checking for %{type}: %{error}") % {name: name, type: ruby_type_to_json(check[:type]), error: e.to_s}
+          raise Razor::ValidationFailure, _("attribute at index %{index} fails type checking for %{type}: %{error}") % {index: index, type: ruby_type_to_json(check[:type]), error: e.to_s}
         end
 
         # If we got here we passed all the checks, and have a match, so we are good.
         break true
       end or raise Razor::ValidationFailure, n_(
-        "attribute %{name} has wrong type %{actual} where %{expected} was expected",
-        "attribute %{name} has wrong type %{actual} where one of %{expected} was expected",
+        "attribute at position %{index} has wrong type %{actual} where %{expected} was expected",
+        "attribute at position %{index} has wrong type %{actual} where one of %{expected} was expected",
         Array(@type).count) % {
-        name:     name,
+        index:     index,
         actual:   ruby_type_to_json(value),
         expected: Array(@type).map {|x| ruby_type_to_json(x[:type]) }.join(', ')}
     end
@@ -80,6 +80,8 @@ class Razor::Validation::ArrayAttribute
       when Module then
         if entry <= URI then
           {type: String, validate: -> str { URI.parse(str) }}
+        elsif entry <= Hash then
+          {type: Hash, validate: -> hash { raise ArgumentError, "blank hash key not allowed" if hash.keys.include? '' }}
         else
           {type: entry}
         end

--- a/lib/razor/validation/hash_attribute.rb
+++ b/lib/razor/validation/hash_attribute.rb
@@ -108,7 +108,7 @@ class Razor::Validation::HashAttribute
         if entry <= URI then
           {type: String, validate: -> str { URI.parse(str) }}
         elsif entry <= Hash then
-          {type: Hash, validate: -> hash { raise ArgumentError, "blank attribute not allowed" if hash.keys.include? '' }}
+          {type: Hash, validate: -> hash { raise ArgumentError, "blank hash key not allowed" if hash.keys.include? '' }}
         else
           {type: entry}
         end

--- a/spec/validation/array_attribute_spec.rb
+++ b/spec/validation/array_attribute_spec.rb
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+require_relative '../spec_helper'
+
+describe Razor::Validation::ArrayAttribute do
+  def attr
+    Razor::Validation::ArrayAttribute
+  end
+
+  context "validate!" do
+    subject(:attr) { Razor::Validation::ArrayAttribute.new(0) }
+
+    it "should fail if value's key is blank" do
+      attr.type(Hash)
+      expect { attr.validate!({'' => 'abc'}, 0) }.
+        to raise_error(/blank attribute/)
+    end
+  end
+
+end

--- a/spec/validation/hash_attribute_spec.rb
+++ b/spec/validation/hash_attribute_spec.rb
@@ -71,6 +71,12 @@ describe Razor::Validation::HashAttribute do
         to raise_error(/bad URI/)
     end
 
+    it "should fail if value's key is blank" do
+      attr.type(Hash)
+      expect { attr.validate!({'attr' => {'' => 'abc'}}) }.
+          to raise_error(/blank attribute/)
+    end
+
     context "references" do
       let :node do Fabricate(:node) end
       # Necessary because of the magic in lookups.


### PR DESCRIPTION
The key in {"": "blank"} should not be allowed in any commands (e.g. modify-node-metadata) since it is not a meaningful attribute. This commit includes cases where Array holds a Hash. Also including a fix for a few error messages that reference undefined variables.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-121
