### PR TITLE
Add user help to all commands

### DIFF
--- a/lib/razor/command/add_policy_tag.rb
+++ b/lib/razor/command/add_policy_tag.rb
@@ -1,5 +1,25 @@
 # -*- encoding: utf-8 -*-
 class Razor::Command::AddPolicyTag < Razor::Command
+  summary "Add a tag to an existing policy"
+  description <<-EOT
+Add a tag to an existing policy.  You can either specify an existing tag by
+name, or you can create a new one by supplying the rule as well as the name.
+
+In the later case the tag is atomically created, before adding it to the
+policy.  If one fails, neither will take effect.
+  EOT
+
+  example <<-EOT
+Adding the existing tag `virtual` to the policy `example`:
+
+    {"name": "example", "tag": "virtual"}
+
+Adding a new tag `virtual` to the policy `example`:
+
+    {"name": "example", "tag": "virtual",
+     "rule": ["=" ["fact" "virtual" "false"] "true"]}
+  EOT
+
   attr 'name', type: String, required: true, references: Razor::Data::Policy
   attr 'tag',  type: String, required: true, size: 1..Float::INFINITY
   attr 'rule', type: Array

--- a/lib/razor/command/create_broker.rb
+++ b/lib/razor/command/create_broker.rb
@@ -1,5 +1,26 @@
 # -*- encoding: utf-8 -*-
 class Razor::Command::CreateBroker < Razor::Command
+  summary "Create a new broker configuration for hand-off of installed nodes"
+  description <<-EOT
+Create a new broker configuration.  Brokers are responsible for handing a node
+off to a config management system, such as Puppet or Chef.  In cases where you
+have no configuration management system, you can use the `noop` broker.
+  EOT
+
+  example <<-EOT
+Creating a simple Puppet broker:
+
+    {
+      "name": "puppet",
+      "configuration": {
+         "server":      "puppet.example.org",
+         "environment": "production"
+      },
+      "broker-type": "puppet"
+    }
+  EOT
+
+
   authz  '%{name}'
   attr   'name', type: String, required: true, size: 1..250
   attr   'broker-type', type: String, references: [Razor::BrokerType, :name]

--- a/lib/razor/command/create_policy.rb
+++ b/lib/razor/command/create_policy.rb
@@ -1,6 +1,37 @@
 # -*- encoding: utf-8 -*-
 
 class Razor::Command::CreatePolicy < Razor::Command
+  summary "Create a new policy"
+  description <<-EOT
+Policies tie together the rules, as tags, with the task and repo containing
+the OS to install, and the broker for post-install configuration.
+
+The overall list of policies is ordered, and polcies are considered in that
+order. When a new policy is created, the entry `before` or `after` can be
+used to put the new policy into the table before or after another
+policy. If neither `before` or `after` are specified, the policy is
+appended to the policy table.
+  EOT
+
+  example <<-EOT
+A sample policy installing CentOS 6.4:
+
+    {
+      "name":          "centos-for-small",
+      "repo":          {"name": "centos-6.4"},
+      "task":          {"name": "centos"},
+      "broker":        {"name": "noop"},
+      "enabled":       true,
+      "hostname":      "host${id}.example.com",
+      "root_password": "secret",
+      "max_count":     20,
+      "before":        {"name": "other policy"},
+      "tags": [
+        {"name": "small", "rule": ["<=", ["num", ["fact", "processorcount"]], 2]}
+      ]
+    }
+  EOT
+
   authz  '%{name}'
   attr   'name',          type: String, required: true, size: 1..Float::INFINITY
   attr   'hostname',      type: String, required: true, size: 1..Float::INFINITY

--- a/lib/razor/command/create_repo.rb
+++ b/lib/razor/command/create_repo.rb
@@ -1,10 +1,42 @@
 # -*- encoding: utf-8 -*-
 class Razor::Command::CreateRepo < Razor::Command
-  authz '%{name}'
+  summary "Create a new repository, from an ISO image or a URL"
+  description <<-EOT
+Create a new repository, which can either contain the content to install a
+node, or simply point to an existing online repository by URL.
+  EOT
 
+  example <<-EOT
+Create a repository from an ISO image, which will be downloaded and unpacked
+by the razor-server in the background:
+
+    {
+      "name":    "fedora19",
+      "iso-url": "http://example.com/Fedora-19-x86_64-DVD.iso"
+    }
+
+You can also unpack an ISO image from a file *on the server*; this does not
+upload the file from the client:
+    {
+      "name":    "fedora19",
+      "iso-url": "file:///tmp/Fedora-19-x86_64-DVD.iso"
+    }
+
+Finally, you can providing a `url` property when you create the repository;
+this form is merely a pointer to a resource somehwere and nothing will be
+downloaded onto the Razor server:
+
+    {
+      "name": "fedora19",
+      "url":  "http://mirrors.n-ix.net/fedora/linux/releases/19/Fedora/x86_64/os/"
+    }
+  EOT
+
+  authz '%{name}'
   attr  'name',    type: String, required: true, size: 1..250
   attr  'url',     type: URI,    exclude: 'iso-url', size: 1..1000
   attr  'iso-url', type: URI,    exclude: 'url', size: 1..1000
+
   object 'task', required: true do
     attr 'name', type: String, required: true
   end

--- a/lib/razor/command/create_tag.rb
+++ b/lib/razor/command/create_tag.rb
@@ -1,6 +1,22 @@
 # -*- encoding: utf-8 -*-
 
 class Razor::Command::CreateTag < Razor::Command
+  summary "Create a new tag"
+  description <<-EOT
+Create a new tag, and set the rule it will use to match on facts and node
+metadata.
+  EOT
+
+  example <<-EOT
+Create a simple tag:
+
+    {
+      "name": "small",
+      "rule": ["=", ["fact", "processorcount"], "2"]
+    }
+
+  EOT
+
   authz '%{name}'
   attr  'name', type: String, required: true, size: 1..Float::INFINITY
   attr  'rule', type: Array

--- a/lib/razor/command/create_task.rb
+++ b/lib/razor/command/create_task.rb
@@ -1,6 +1,41 @@
 # -*- encoding: utf-8 -*-
 
 class Razor::Command::CreateTask < Razor::Command
+  summary "Create a new task, stored entirely in the database"
+  description <<-EOT
+
+Razor supports both tasks stored in the filesystem and tasks stored in the
+database; in general, it is highly recommended that you store your tasks in
+the filesystem. Details about that can be found [on the Wiki][tasks]
+
+For production setups, you may want to store your tasks in the database.
+This command allows you to do that, though it is absolutely not required.
+
+[tasks]: https://github.com/puppetlabs/razor-server/wiki/Writing-tasks
+  EOT
+
+  example <<-EOT
+Define the RedHat task included with Razor using this command:
+
+    {
+      "name":        "redhat6",
+      "os":          "Red Hat Enterprise Linux",
+      "os_version":  "6",
+      "description": "A basic installer for RHEL6",
+      "boot_seq": {
+        "1":       "boot_install",
+        "default": "boot_local"
+      }
+      "templates": {
+        "boot_install": "#!ipxe\necho Razor <%= task.label %> task boot_call\necho Installation node: <%= node_url  %>\necho Installation repo: <%= repo_url %>\n\nsleep 3\nkernel <%= repo_url(\"/isolinux/vmlinuz\") %> <%= render_template(\"kernel_args\").strip %> || goto error\ninitrd <%= repo_url(\"/isolinux/initrd.img\") %> || goto error\nboot\n:error\nprompt --key s --timeout 60 ERROR, hit 's' for the iPXE shell; reboot in 60 seconds && shell || reboot\n",
+        "kernel_args": "ks=<%= file_url(\"kickstart\") %> network ksdevice=bootif BOOTIF=01-${netX/mac}",
+        "kickstart": "#!/bin/bash\n# Kickstart for RHEL/CentOS 6\n# see: http://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/6/html/Installation_Guide/s1-kickstart2-options.html\n\ninstall\nurl --url=<%= repo_url %>\ncmdline\nlang en_US.UTF-8\nkeyboard us\nrootpw <%= node.root_password %>\nnetwork --hostname <%= node.hostname %>\nfirewall --enabled --ssh\nauthconfig --enableshadow --passalgo=sha512 --enablefingerprint\ntimezone --utc America/Los_Angeles\n# Avoid having 'rhgb quiet' on the boot line\nbootloader --location=mbr --append=\"crashkernel=auto\"\n# The following is the partition information you requested\n# Note that any partitions you deleted are not expressed\n# here so unless you clear all partitions first, this is\n# not guaranteed to work\nzerombr\nclearpart --all --initlabel\nautopart\n# reboot automatically\nreboot\n\n# followig is MINIMAL https://partner-bugzilla.redhat.com/show_bug.cgi?id=593309\n%packages --nobase\n@core\n\n%end\n\n%post --log=/var/log/razor.log\necho Kickstart post\ncurl -s -o /root/razor_postinstall.sh <%= file_url(\"post_install\") %>\n\n# Run razor_postinstall.sh on next boot via rc.local\nif [ ! -f /etc/rc.d/rc.local ]; then\n  # On systems using systemd /etc/rc.d/rc.local does not exist at all\n  # though systemd is set up to run the file if it exists\n  touch /etc/rc.d/rc.local\n  chmod a+x /etc/rc.d/rc.local\nfi\necho bash /root/razor_postinstall.sh >> /etc/rc.d/rc.local\nchmod +x /root/razor_postinstall.sh\n\ncurl -s <%= stage_done_url(\"kickstart\") %>\n%end\n############\n",
+        "post_install": "#!/bin/bash\n\nexec >> /var/log/razor.log 2>&1\n\necho \"Starting post_install\"\n\n# Wait for network to come up when using NetworkManager.\nif service NetworkManager status >/dev/null 2>&1 && type -P nm-online; then\n    nm-online -q --timeout=10 || nm-online -q -x --timeout=30\n    [ \"$?\" -eq 0 ] || exit 1\nfi\n\n<%= render_template(\"set_hostname\") %>\n\n<%= render_template(\"store_ip\") %>\n\n# @todo lutter 2013-09-12: we should register the system with RHN; be\n# careful though, since this file is also used by the CentOS installer, for\n# which there is no RHN registration\n\n<%= render_template(\"os_complete\") %>\n\n# We are done\ncurl -s <%= stage_done_url(\"finished\") %>\n"
+      }
+    }
+EOT
+
+
   authz '%{name}'
   attr  'name', type: String, required: true, size: 1..250
   attr  'os',   type: String, required: true, size: 1..1000

--- a/lib/razor/command/delete_broker.rb
+++ b/lib/razor/command/delete_broker.rb
@@ -1,6 +1,19 @@
 # -*- encoding: utf-8 -*-
 
 class Razor::Command::DeleteBroker < Razor::Command
+  summary "Delete an existing broker configuration"
+  description <<-EOT
+Delete a broker configuration from Razor.  If the broker is currently used by
+a policy the attempt will fail.
+  EOT
+
+  example <<-EOT
+Delete the unused broker configuration "obsolete":
+
+    {"name": "obsolete"}
+  EOT
+
+
   authz '%{name}'
   attr  'name', type: String, required: true, size: 1..250
 

--- a/lib/razor/command/delete_node.rb
+++ b/lib/razor/command/delete_node.rb
@@ -1,5 +1,16 @@
 # -*- encoding: utf-8 -*-
 class Razor::Command::DeleteNode < Razor::Command
+  summary "Remove a single node from the database"
+  description <<-EOT
+Remove a single node from the database.  Should the node boot again it will be
+rediscovered and treated as any other new node.
+  EOT
+  example <<-EOT
+Delete the node "node17":
+
+    {"name": "node17"}
+  EOT
+
   authz '%{name}'
   attr  'name', type: String, required: true, size: 1..250
 

--- a/lib/razor/command/delete_policy.rb
+++ b/lib/razor/command/delete_policy.rb
@@ -1,5 +1,19 @@
 # -*- encoding: utf-8 -*-
 class Razor::Command::DeletePolicy < Razor::Command
+  summary "Delete a policy from Razor, so it no longer matches new nodes"
+  description <<-EOT
+Delete a single policy, removing it from Razor.  This will work regardless of
+the number of nodes bound to that policy.  Any node that was installed will
+remain "installed", and will not be matched to by other policy.
+  EOT
+
+  example <<-EOT
+Delete the policy "obsolete":
+
+    {"name": "obsolete"}
+  EOT
+
+
   authz '%{name}'
   attr  'name', type: String, required: true, size: 1..Float::INFINITY
 

--- a/lib/razor/command/delete_repo.rb
+++ b/lib/razor/command/delete_repo.rb
@@ -1,5 +1,17 @@
 # -*- encoding: utf-8 -*-
 class Razor::Command::DeleteRepo < Razor::Command
+  summary "Delete a repo, removing any local files it downloaded"
+  description <<-EOT
+The repo, and any associated content on disk, will be removed.  This will fail
+if the repo is in use with an existing policy.
+  EOT
+
+  example <<-EOT
+Delete the "fedora16" repo:
+
+    {"name": "fedora16"}
+  EOT
+
   authz '%{name}'
   attr  'name', type: String, required: true, size: 1..250
 

--- a/lib/razor/command/delete_tag.rb
+++ b/lib/razor/command/delete_tag.rb
@@ -1,6 +1,26 @@
 # -*- encoding: utf-8 -*-
 
 class Razor::Command::DeleteTag < Razor::Command
+  summary "Delete a tag"
+  description <<-EOT
+The tag will be deleted if it is not used, or if the `force` flag is true.
+
+If `force` is true, the tag will be removed from all policies that use it
+before being deleted.
+  EOT
+
+  example <<-EOT
+Delete a tag, but only if it is not used:
+
+    {"name": "example"}
+    {"name": "example", "force": false}
+
+Delete a tag regardless of it being used:
+
+    {"name": "example", "force": true}
+  EOT
+
+
   authz '%{name}'
   attr  'name',  type: String, required: true, size: 1..Float::INFINITY
   attr  'force', type: :bool

--- a/lib/razor/command/disable_policy.rb
+++ b/lib/razor/command/disable_policy.rb
@@ -1,6 +1,21 @@
 # -*- encoding: utf-8 -*-
 
 class Razor::Command::DisablePolicy < Razor::Command
+  summary "Disable a policy, preventing it from matching new nodes"
+  description <<-EOT
+When a policy is disabled it will no longer match new nodes.  Any existing
+node matched to it will remain matched to it.  This does not cause nodes to
+stop installing if that was triggered by matching this policy prior to the
+disable command.
+  EOT
+
+  example <<-EOT
+Disable a policy:
+
+    {"name": "example"}
+  EOT
+
+
   authz '%{name}'
   attr  'name', type: String, required: true, references: Razor::Data::Policy
 

--- a/lib/razor/command/enable_policy.rb
+++ b/lib/razor/command/enable_policy.rb
@@ -1,6 +1,21 @@
 # -*- encoding: utf-8 -*-
 
 class Razor::Command::EnablePolicy < Razor::Command
+  summary "Enable a policy, allowing it to matching new nodes"
+  description <<-EOT
+When a policy is disabled it will no longer match new nodes.  This command
+will reverse the effect of disabling the policy, allowing it to match new
+nodes again.  This does not cause nodes to be matched against the policy until
+the next time they check in.
+  EOT
+
+  example <<-EOT
+Enable a policy:
+
+    {"name": "example"}
+  EOT
+
+
   authz '%{name}'
   attr  'name', type: String, required: true, references: Razor::Data::Policy
 

--- a/lib/razor/command/modify_node_metadata.rb
+++ b/lib/razor/command/modify_node_metadata.rb
@@ -1,6 +1,36 @@
 # -*- encoding: utf-8 -*-
 
 class Razor::Command::ModifyNodeMetadata < Razor::Command
+  summary "Perform various editing operations on node metadata"
+  description <<-EOT
+Node metadata can be added, changed, or removed with this command; it contains
+a limited editing language to make changes to the existing metadata in an
+atomic fashion.
+
+It can also clear all metadata from a node, although that operation is
+exclusive to all other editing operations, and cannot be performed atomically
+with them.
+  EOT
+
+  example <<-EOT
+Editing node metadata, by adding and removing some keys, but refusing to
+modify an existing value already present on a node:
+
+    {
+        "node": "node1",
+        "update": {
+            "key1": "value1",
+            "key2": "value2"
+        }
+        "remove": ["key3", "key4"],
+        "no_replace": true
+    }
+
+Removing all node metadata:
+
+    {"node": "node1", "clear": true}
+  EOT
+
   attr 'node',       type: String, required: true, references: [Razor::Data::Node, :name]
   attr 'update',     type: Hash
   attr 'remove',     type: Array

--- a/lib/razor/command/modify_policy_max_count.rb
+++ b/lib/razor/command/modify_policy_max_count.rb
@@ -1,6 +1,24 @@
 # -*- encoding: utf-8 -*-
 
 class Razor::Command::ModifyPolicyMaxCount < Razor::Command
+  summary "Change the maximum node count for an existing policy"
+  description <<-EOT
+Adjust the maximum node count for a policy.  The new value must be equal to or
+greater than the number of nodes currently bound to the policy; it may also be
+`null` for an "unlimited" count of nodes bound.
+  EOT
+
+  example <<-EOT
+Set a policy to match an unlimited number of nodes:
+
+    {"name": "example", "max-count": null}
+
+Set a policy to a maximum of 15 nodes:
+
+    {"name": "example", "max-count": 15}
+  EOT
+
+
   attr 'name',      type: String, required: true, references: Razor::Data::Policy
   attr 'max-count', required: true
 

--- a/lib/razor/command/move_policy.rb
+++ b/lib/razor/command/move_policy.rb
@@ -1,6 +1,22 @@
 # -*- encoding: utf-8 -*-
 
 class Razor::Command::MovePolicy < Razor::Command
+  summary "Change the order that policies are considered when matching against nodes"
+  description <<-EOT
+Policies can be moved before or after specific policies.
+  EOT
+
+  example <<-EOT
+Move a policy before another policy:
+
+    {"name": "policy", "before": "other"}
+
+Move a policy after another policy:
+
+    {"name": "policy", "after": other"}
+  EOT
+
+
   authz '%{name}'
   attr   'name', type: String, required: true, references: Razor::Data::Policy
 

--- a/lib/razor/command/reboot_node.rb
+++ b/lib/razor/command/reboot_node.rb
@@ -1,6 +1,37 @@
 # -*- encoding: utf-8 -*-
 
 class Razor::Command::RebootNode < Razor::Command
+  summary "Request an IPMI power cycle of a node"
+  description <<-EOT
+Razor can request a node reboot through IPMI, if the node has IPMI credentials
+associated.  This only supports hard power cycle reboots.
+
+This is applied in the background, and will run as soon as available execution
+slots are available for the task -- IPMI communication has some generous
+internal rate limits to prevent it overwhelming the network or host server.
+
+This background process is persistent: if you restart the Razor server before
+the command is executed, it will remain in the queue and the operation will
+take place after the server restarts.  There is no time limit on this at
+this time.
+
+Multiple commands can be queued, and they will be processed sequentially, with
+no limitation on how frequently a node can be rebooted.
+
+If the IPMI request fails (that is: ipmitool reports it is unable to
+communicate with the node) the request will be retried.  No detection of
+actual results is included, though, so you may not know if the command is
+delivered and fails to reboot the system.
+
+This is not integrated with the IPMI power state monitoring, and you may not
+see power transitions in the record, or through the node object if polling.
+  EOT
+
+  example <<-EOT
+Queue a node reboot: `{"name": "node1"}`
+  EOT
+
+
   authz '%{name}'
   attr  'name', type: String, required: true, references: Razor::Data::Node
 

--- a/lib/razor/command/reinstall_node.rb
+++ b/lib/razor/command/reinstall_node.rb
@@ -1,6 +1,19 @@
 # -*- encoding: utf-8 -*-
 
 class Razor::Command::ReinstallNode < Razor::Command
+  summary "Remove any policy associated with a node, and make it available for reinstallation"
+  description <<-EOT
+Remove a node's association with any policy and clears its `installed` flag;
+once the node reboots, it will boot back into the Microkernel and go through
+discovery, tag matching and possibly be bound to another policy. This command
+does not change its metadata or facts.
+  EOT
+
+  example <<-EOT
+Make 'node17' available for reinstallation: `{"name": "node17"}`
+  EOT
+
+
   authz '%{name}'
   attr  'name', type: String, required: true, references: Razor::Data::Node
 

--- a/lib/razor/command/remove_node_metadata.rb
+++ b/lib/razor/command/remove_node_metadata.rb
@@ -2,6 +2,23 @@
 
 # Remove a specific key or remove all (works with GET)
 class Razor::Command::RemoveNodeMetadata < Razor::Command
+  summary "Remove one, or all, keys from a nodes metadata"
+  description <<-EOT
+This is a shortcut to `modify-node-metadata` that allows for removing a single
+key OR all keys in a simpler form.
+  EOT
+
+  example <<-EOT
+Remove a single key from a node:
+
+    {"node": "node1", "key": "my_key"}
+
+or remove all keys from a node:
+
+    {"node": "node1", "all": true}
+  EOT
+
+
   attr 'node', type: String, required: true, references: [Razor::Data::Node, :name]
   attr 'key',  type: String, size: 1..Float::INFINITY
   attr 'all',  type: [String, :bool]

--- a/lib/razor/command/remove_policy_tag.rb
+++ b/lib/razor/command/remove_policy_tag.rb
@@ -1,6 +1,18 @@
 # -*- encoding: utf-8 -*-
 
 class Razor::Command::RemovePolicyTag < Razor::Command
+  summary "Remove a tag from an existing policy"
+  description <<-EOT
+This will remove a tag already present from a policy.  This change has no
+effect on nodes already bound to the policy.
+  EOT
+
+  example <<-EOT
+Remove the tag `virtual` to the policy `example`:
+
+    {"name": "example", "tag": "virtual"}
+  EOT
+
   attr 'name', type: String, required: true, references: Razor::Data::Policy
   attr 'tag',  type: String, required: true, size: 1..Float::INFINITY
 

--- a/lib/razor/command/set_node_desired_power_state.rb
+++ b/lib/razor/command/set_node_desired_power_state.rb
@@ -1,6 +1,23 @@
 # -*- encoding: utf-8 -*-
 
 class Razor::Command::SetNodeDesiredPowerState < Razor::Command
+  summary "Set the desired IPMI power state for a node"
+  description <<-EOT
+In addition to monitoring power, Razor can enforce node power state.
+This command allows a desired power state to be set for a node, and if the
+node is observed to be in a different power state an IPMI command will be
+issued to change to the desired state.
+  EOT
+
+  example <<-EOT
+Setting the power state for the node:
+
+    {
+      "name": "node1234",
+      "to":   "on"|"off"|null
+    }
+  EOT
+
   authz '%{name}'
   attr  'name', type: String, required: true,  references: Razor::Data::Node
   attr  'to',   type: [String, nil], required: false, one_of: ['on', 'off', nil]

--- a/lib/razor/command/set_node_ipmi_credentials.rb
+++ b/lib/razor/command/set_node_ipmi_credentials.rb
@@ -1,6 +1,30 @@
 # -*- encoding: utf-8 -*-
 
 class Razor::Command::SetNodeIPMICredentials < Razor::Command
+  summary "Set the IPMI host, and credentials, for a node"
+  description <<-EOT
+Razor can store IPMI credentials on a per-node basis.  These are the hostname
+(or IP address), the username, and the password to use when contacting the
+BMC/LOM/IPMI lan or lanplus service to check or update power state and other
+node data.
+
+This is an atomic operation: all three data items are set or reset in a single
+operation.  Partial updates must be handled client-side.  This eliminates
+conflicting update and partial update combination surprises for users.
+
+As with the IPMI authentication standard, both username and password are
+optional, and the system will work with either or both absent.
+  EOT
+
+  example <<-EOT
+    {
+      "name":          "node17",
+      "ipmi-hostname": "bmc17.example.com",
+      "ipmi-username": null,
+      "ipmi-password": "sekretskwirrl"
+    }
+  EOT
+
   authz '%{name}'
   attr  'name', type: String, required: true, references: Razor::Data::Node
   attr  'ipmi-hostname', type: String, size: 1..255

--- a/lib/razor/command/update_node_metadata.rb
+++ b/lib/razor/command/update_node_metadata.rb
@@ -1,6 +1,19 @@
 # -*- encoding: utf-8 -*-
 
 class Razor::Command::UpdateNodeMetadata < Razor::Command
+  summary "Update one key in a nodes metadata"
+  description <<-EOT
+This is a shortcut to `modify-node-metadata` that allows for updating or
+adding removing a single key, in a simpler form that the full
+editing language.
+  EOT
+
+  example <<-EOT
+Set a single key from a node:
+
+    {"node": "node1", "key": "my_key", "value": "twelve"}
+  EOT
+
   attr 'node',       type: String, required: true, references: [Razor::Data::Node, :name]
   attr 'key',        type: String, exclude: 'all', size: 1..Float::INFINITY
   attr 'all',        type: [String, :bool], exclude: 'key'

--- a/lib/razor/command/update_tag_rule.rb
+++ b/lib/razor/command/update_tag_rule.rb
@@ -1,6 +1,27 @@
 # -*- encoding: utf-8 -*-
 
 class Razor::Command::UpdateTagRule < Razor::Command
+  summary "Update the matching rule for an existing tag"
+  description <<-EOT
+This will change the rule of the given tag to the new rule. The tag will be
+reevaluated against all nodes and each node's tag attribute will be updated to
+reflect whether the tag now matches or not, i.e., the tag will be added
+to/removed from each node's tag as appropriate.
+
+If the tag is used by any policies, the update will only be performed if the
+optional parameter `force` is set to `true`. Otherwise, it will fail.
+  EOT
+
+  example <<-EOT
+An example of updating a tag rule, and forcing reevaluation:
+
+    {
+      "name": "small",
+      "rule": ["<=", ["fact", "processorcount"], "2"],
+      "force": true
+    }
+  EOT
+
   authz '%{name}'
   attr  'name',  type: String, required: true, references: Razor::Data::Tag
   attr  'rule',  type: Array


### PR DESCRIPTION
This adds user-facing help to all commands, based on the existing
documentation.  This will be automatically exposed to the client through the
new command metadata API, and will permit this information to be shared with
the client automatically -- as well as future updates to help about the
commands as we improve the software.

Signed-off-by: Daniel Pittman daniel@rimspace.net
