### PR TITLE
Detect and report out-of-sync migrations via the API

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -27,6 +27,26 @@ class Razor::App < Sinatra::Base
     set :show_exceptions, false
   end
 
+  MigrationNeeded = _(
+"Hey.  Your database migrations are not current!  Without them being at the
+exact expected version you can expect all sorts of random looking failures.
+
+You should rerun the migrations now.  That will fix things and stop this
+error from getting in your way.  That is done with the `razor-admin` command,
+and requires full control over the database (eg: add and remove tables):
+
+    ] razor-admin migrate-database
+")
+
+  before do
+    # Verify that our migrations are current and functional, and if not,
+    # return a clear error message to the user.
+    unless Razor.database_is_current?
+      content_type 'text/plain'
+      halt [500, MigrationNeeded]
+    end
+  end
+
   before do
     # We serve static files from /svc/repo and will therefore let that
     # handler determine the most appropriate content type

--- a/lib/razor/initialize.rb
+++ b/lib/razor/initialize.rb
@@ -39,6 +39,11 @@ module Razor
       end
     end
 
+    def database_is_current?
+      @@database_migration_path ||= File.join(root, 'db', 'migrate')
+      Sequel::Migrator.is_current?(database, @@database_migration_path)
+    end
+
     def logger
       synchronize do
         @@logger ||= TorqueBox::Logger.new("razor")
@@ -77,6 +82,10 @@ module Razor
   # Establish a database connection now and load extensions
   Razor.database
   Razor.database.extension :pg_array
+
+  # Ensure the migration extension is available, now that we use it as part of
+  # each request to ensure that we catch missed migrations correctly.
+  Sequel.extension :migration
 
   # Ensure that we raise on ORM failures by default; while this is the default
   # in sufficiently recent versions of Sequel, it is better explicit than

--- a/spec/app/database_migration_spec.rb
+++ b/spec/app/database_migration_spec.rb
@@ -1,0 +1,22 @@
+# -*- encoding: utf-8 -*-
+require_relative '../spec_helper'
+require_relative '../../app'
+
+describe "database migration checks" do
+  include Razor::Test::Commands
+
+  let(:app)  { Razor::App }
+
+  before :each do
+    header 'content-type', 'application/json'
+    authorize 'fred', 'dead'
+  end
+
+  it "should fail if the migrations are not up to date" do
+    Razor.database[:schema_info].update(:version => 3)
+    get '/api'
+    last_response.body.should =~ /razor-admin migrate-database/
+    last_response.content_type.should =~ %r{text/plain}
+    last_response.status.should == 500
+  end
+end


### PR DESCRIPTION
When the Razor code and database migrations are out of sync, significant
problems can occur.  This adds code to detect when this situation has shown
up, report it, and refuse service to all callers.

For the client this will result in an error message to the user, including
instructions on how to fix the problem.

For MK images, etc, it will result in an error that they will observe and
retry in the near future; this is the best we can do, since we can't be sure
that the changes have not altered the behaviour they should undertake.

https://tickets.puppetlabs.com/browse/RAZOR-158
Signed-off-by: Daniel Pittman daniel@rimspace.net
