### PR TITLE
Add `locales` data and template to packages

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -42,3 +42,5 @@ files:
   - vendor
   - '*.md'
   - LICENSE
+  - 'locales/*.po'
+  - 'locales/*.pot'


### PR DESCRIPTION
The locales directory will be shipped, with both the PO file template, and any
PO files that we have included that support translations.  This supports our
translation efforts.

Signed-off-by: Daniel Pittman daniel@rimspace.net
