### PR TITLE
Allow marking newly discovered nodes as 'installed'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## 0.15.0 - 2014-??-??
 
++ `protect_new_nodes` configuration setting will mark all
+   nodes to be marked as "installed" when first discovered, causing them
+   to boot locally until explicitly reinstalled.
 + incompatible changes
   + the way that tasks and templates are stored on disk has changed.
     The metadata file is changed from `tasks/{name}.yaml` to

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -39,6 +39,9 @@ all:
     debug_level: debug
     kernel_args:
 
+  # Should newly discovered nodes be marked installed?
+  protect_new_nodes: false
+
   # How to match nodes to possibly existing nodes in the database. The node
   # sends us the MAC addresses of its network interfaces, serial number,
   # asset tag, and UUID. We consider two nodes to be the same if they agree

--- a/lib/razor/data/node.rb
+++ b/lib/razor/data/node.rb
@@ -63,6 +63,16 @@ module Razor::Data
       publish('eval_tags') if need_eval_tags
     end
 
+    def before_create
+      # Support users configuring that we mark all newly discovered nodes as
+      # "installed" already, despite having no policy.
+      if Razor.config['protect_new_nodes']
+        self.installed    = true
+        self.installed_at = Time.now
+      end
+      super
+    end
+
     # Set the hardware info from a hash.
     def hw_hash=(hw_hash)
       self.hw_info = self.class.canonicalize_hw_info(hw_hash)

--- a/spec/data/node_spec.rb
+++ b/spec/data/node_spec.rb
@@ -7,8 +7,7 @@ describe Razor::Data::Node do
   end
 
   let (:policy) { Fabricate(:policy) }
-
-  let (:node) { Fabricate(:node) }
+  let (:node)   { Fabricate(:node) }
 
   context "canonicalize_hw_info" do
     def canonicalize(hw_info)
@@ -198,6 +197,18 @@ describe Razor::Data::Node do
     end
   end
 
+
+  context "protect_new_nodes" do
+    it "should treat a new node as installed if set to true" do
+      Razor.config['protect_new_nodes'] = true
+      node.save.reload.installed.should be_true
+    end
+
+    it "should treat a new node as 'not installed' if set to false" do
+      Razor.config['protect_new_nodes'] = false
+      node.save.reload.installed.should be_false
+    end
+  end
 
   describe "binding on checkin" do
     hw_id = "001122334455"


### PR DESCRIPTION
This adds a configuration option, `protect_new_nodes`, which if set to a true
value causes all newly discovered nodes to be marked installed at the exact
same moment.

This will result in the default behaviour of Razor changing from "install
based on policy" to "install based on policy once a node reinstall is
explicitly requested", a much safer default for users.

By default Razor will continue to assume that it controls everything on your
network, and treat any newly discovered node as a candidate for immediate
installation according to policy.

https://tickets.puppetlabs.com/browse/RAZOR-152

Signed-off-by: Daniel Pittman daniel@rimspace.net
