### PR TITLE
Add like operator to Matcher

### DIFF
--- a/lib/razor/matcher.rb
+++ b/lib/razor/matcher.rb
@@ -60,6 +60,7 @@ class Razor::Matcher
         "tag"      => {:expects => [[String]],        :returns => Mixed   },
         "state"    => {:expects => [[String], [String]], :returns => Mixed   },
         "eq"       => {:expects => [Mixed],           :returns => Boolean },
+        "like"     => {:expects => [String],          :returns => Boolean },
         "neq"      => {:expects => [Mixed],           :returns => Boolean },
         "in"       => {:expects => [Mixed],           :returns => Boolean },
         "num"      => {:expects => [Mixed],           :returns => Number  },
@@ -117,6 +118,15 @@ class Razor::Matcher
 
     def eq(*args)
       args[0] == args[1]
+    end
+
+    def like(*args)
+      pos = args[0] =~ Regexp.new(args[1])
+      unless pos.nil?
+        return true
+      else
+        return false
+      end
     end
 
     def neq(*args)

--- a/lib/razor/matcher.rb
+++ b/lib/razor/matcher.rb
@@ -22,6 +22,7 @@ require 'json'
 #             If not, an error is raised unless a second argument is given, in
 #             which case it is returned as the default.
 #   num     - converts arg1 to a numeric value if possible; raises if not
+#   str     - converts arg1 to a string value if possible; raises if not
 #   <, <=   - true if arg1 </<= arg2
 #   >, >=   - true if arg1 >/>= arg2
 #
@@ -65,6 +66,7 @@ class Razor::Matcher
         "neq"      => {:expects => [Mixed],           :returns => Boolean },
         "in"       => {:expects => [Mixed],           :returns => Boolean },
         "num"      => {:expects => [Mixed],           :returns => Number  },
+        "str"      => {:expects => [Mixed],           :returns => [String] },
         "gte"      => {:expects => [[Numeric]],       :returns => Boolean },
         "gt"       => {:expects => [[Numeric]],       :returns => Boolean },
         "lte"      => {:expects => [[Numeric]],       :returns => Boolean },
@@ -150,6 +152,18 @@ class Razor::Matcher
       end
 
       raise RuleEvaluationError.new _("can't convert %{raw} to number") % {raw: value.inspect}
+    end
+
+    def str(*args)
+      value = args[0]
+      begin
+        return value if value.is_a?(String)
+        return String(value)
+      rescue ArgumentError => e
+        # Ignore this here, since a RuleEvaluationError will be raised later
+      end
+
+      raise RuleEvaluationError.new "can't convert #{value.inspect} to string"
     end
 
     def gte(*args)

--- a/lib/razor/matcher.rb
+++ b/lib/razor/matcher.rb
@@ -16,6 +16,7 @@ require 'json'
 # The builtin operators are (see +Functions+)
 #   and, or - true if anding/oring arguments is true
 #   =, !=   - true if arg1 =/!= arg2
+#   like    - true if arg1 =~ arg2 (interpreting arg2 as Regex)
 #   in      - true if arg1 is one of arg2 .. argn
 #   fact    - retrieves the fact named arg1 from the node if it exists
 #             If not, an error is raised unless a second argument is given, in
@@ -60,7 +61,7 @@ class Razor::Matcher
         "tag"      => {:expects => [[String]],        :returns => Mixed   },
         "state"    => {:expects => [[String], [String]], :returns => Mixed   },
         "eq"       => {:expects => [Mixed],           :returns => Boolean },
-        "like"     => {:expects => [String],          :returns => Boolean },
+        "like"     => {:expects => [[String], [String]], :returns => Boolean },
         "neq"      => {:expects => [Mixed],           :returns => Boolean },
         "in"       => {:expects => [Mixed],           :returns => Boolean },
         "num"      => {:expects => [Mixed],           :returns => Number  },
@@ -122,11 +123,7 @@ class Razor::Matcher
 
     def like(*args)
       pos = args[0] =~ Regexp.new(args[1])
-      unless pos.nil?
-        return true
-      else
-        return false
-      end
+      not pos.nil?
     end
 
     def neq(*args)

--- a/spec/matcher_spec.rb
+++ b/spec/matcher_spec.rb
@@ -147,6 +147,22 @@ describe Razor::Matcher do
       end
     end
 
+    describe "str" do
+      it "should behave for valid integers" do
+        match("=", ["str", 9      ], "9" ).should == true
+        match("=", ["str", "10"   ], "0" ).should == false
+        match("=", ["str", "0xf"  ], "0xf").should == true
+        match("=", ["str", "0b110"], "0b110" ).should == true
+        match("=", ["str", "027"  ], "027").should == true
+      end
+
+      it "should behave for valid floats" do
+        match("=", ["str", 5.4  ], "5.4").should == true
+        match("=", ["str", "2.7"], "2.7").should == true
+        match("=", ["str", "1e5"], "1e5").should == true
+      end
+    end
+
     it "gte should behave" do
       match("gte", 3.5, 4).should == false
       match(">=",  4,   4).should == true
@@ -205,6 +221,14 @@ describe Razor::Matcher do
       Matcher.new(["=", true, false]).should be_valid
       Matcher.new(["eq", 1, ["=", 5, "ten"]]).should be_valid
       Matcher.new(["eq", 6.3, 3]).should be_valid
+    end
+
+    it "should allow strings for 'like' function" do
+      Matcher.new(["like", true, false]).should_not be_valid
+      Matcher.new(["like", 1, 2]).should_not be_valid
+      Matcher.new(["like", "abc", false]).should_not be_valid
+      Matcher.new(["like", 1, "abc"]).should_not be_valid
+      Matcher.new(["like", "abc", "def"]).should be_valid
     end
 
     it "should allow strings for 'like' function" do
@@ -287,7 +311,11 @@ describe Razor::Matcher do
     end
 
     it "should type the return of num as Numeric" do
-      Matcher.new([">", ["num", "7"], 3]). should be_valid
+      Matcher.new([">", ["num", "7"], 3]).should be_valid
+    end
+
+    it "should type the return of num as String" do
+      Matcher.new(["=", ["str", 7], "7"]).should be_valid
     end
 
     it "should validate nested functions" do

--- a/spec/matcher_spec.rb
+++ b/spec/matcher_spec.rb
@@ -103,6 +103,13 @@ describe Razor::Matcher do
       match("=", "abc", "abcd").should == false
     end
 
+    it "like should behave" do
+      match("like", "abc", "abc").should == true
+      match("like", "abc", "def").should == false
+      match("like", "abc", "ab").should == true
+      match("like", "abc", "z").should == false
+    end
+
     it "neq should behave" do
       match("!=", 1, 1).should == false
       match("!=", 1, 2).should == true
@@ -198,6 +205,14 @@ describe Razor::Matcher do
       Matcher.new(["=", true, false]).should be_valid
       Matcher.new(["eq", 1, ["=", 5, "ten"]]).should be_valid
       Matcher.new(["eq", 6.3, 3]).should be_valid
+    end
+
+    it "should allow strings for 'like' function" do
+      Matcher.new(["like", true, false]).should_not be_valid
+      Matcher.new(["like", 1, 2]).should_not be_valid
+      Matcher.new(["like", "abc", false]).should_not be_valid
+      Matcher.new(["like", 1, "abc"]).should_not be_valid
+      Matcher.new(["like", "abc", "def"]).should be_valid
     end
 
     it "should allow all types for '!=' function" do


### PR DESCRIPTION
I added an extra operator called 'like' to the Matcher, so you can use Regex matching. In our use case, we use a Regex to match a certain range of mac addresses.