### PR TITLE
Fixing validation for `create-policy`

### DIFF
--- a/lib/razor/command/create_policy.rb
+++ b/lib/razor/command/create_policy.rb
@@ -36,6 +36,8 @@ A sample policy installing CentOS 6.4:
   attr   'name',          type: String, required: true, size: 1..Float::INFINITY
   attr   'hostname',      type: String, required: true, size: 1..Float::INFINITY
   attr   'root_password', type: String, size: 1..Float::INFINITY
+  attr   'enabled',       type: :bool
+  attr   'max_count',     type: Integer
 
   object 'before', exclude: 'after' do
     attr 'name', type: String, required: true, references: Razor::Data::Policy
@@ -83,6 +85,8 @@ A sample policy installing CentOS 6.4:
       position = data["before"] ? "before" : "after"
       neighbor = Razor::Data::Policy[:name => data.delete(position)["name"]]
     end
+
+    data["enabled"] = true if data["enabled"].nil?
 
     # Create the policy
     policy = Razor::Data::Policy.new(data).save

--- a/spec/app/create_policy_spec.rb
+++ b/spec/app/create_policy_spec.rb
@@ -87,10 +87,38 @@ describe "create policy command" do
       Razor::Data::Policy[:name => policy_hash[:name]].should be_an_instance_of Razor::Data::Policy
     end
 
+    it "should default to enabling the policy" do
+      create_policy
+
+      Razor::Data::Policy[:name => policy_hash[:name]].enabled.should be_true
+    end
+
+    it "should allow creating a disabled policy" do
+      policy_hash[:enabled] = false
+
+      create_policy
+
+      Razor::Data::Policy[:name => policy_hash[:name]].enabled.should be_false
+    end
+
+    it "should allow creating a policy with max count" do
+      policy_hash[:max_count] = 10
+
+      create_policy
+
+      Razor::Data::Policy[:name => policy_hash[:name]].max_count.should == 10
+    end
+
     it "should fail with the wrong datatype for repo" do
       policy_hash[:repo] = { }
       create_policy
       last_response.json['error'].should =~ /repo\.name is a required attribute, but it is not present/
+    end
+
+    it "should fail with the wrong datatype for max_count" do
+      policy_hash[:max_count] = { }
+      create_policy
+      last_response.json['error'].should =~ /max_count should be a number, but was actually a object/
     end
 
     it "should fail with the wrong datatype for task" do


### PR DESCRIPTION
The command validation for `create-policy` was not allowing the properties `enabled` and `max_count` to be included, even though the documentation includes them.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-203
