### PR TITLE
RAZOR-207 Create-policy needs node_metadata attr

### DIFF
--- a/lib/razor/command/create_policy.rb
+++ b/lib/razor/command/create_policy.rb
@@ -26,6 +26,7 @@ A sample policy installing CentOS 6.4:
       "root_password": "secret",
       "max_count":     20,
       "before":        "other policy",
+      "node_metadata:  { "key1": "value1", "key2": "value2" },
       "tags": [
         {"name": "small", "rule": ["<=", ["num", ["fact", "processorcount"]], 2]}
       ]
@@ -38,6 +39,7 @@ A sample policy installing CentOS 6.4:
   attr   'root_password', type: String, size: 1..Float::INFINITY
   attr   'enabled',       type: :bool
   attr   'max_count',     type: Integer
+  attr   'node_metadata', type: Hash
 
   object 'before', exclude: 'after' do
     attr 'name', type: String, required: true, references: Razor::Data::Policy

--- a/spec/app/create_policy_spec.rb
+++ b/spec/app/create_policy_spec.rb
@@ -109,6 +109,13 @@ describe "create policy command" do
       Razor::Data::Policy[:name => policy_hash[:name]].max_count.should == 10
     end
 
+    it "should allow creating a policy with node_metadata" do
+      metadata = { "key1" => "value1", "key2" => "value2" }
+      policy_hash[:node_metadata] = metadata
+      create_policy
+      Razor::Data::Policy[:name => policy_hash[:name]].node_metadata.should == metadata
+    end
+
     it "should fail with the wrong datatype for repo" do
       policy_hash[:repo] = { }
       create_policy


### PR DESCRIPTION
The create-policy command should accept the node_metadata attribute to allow the policy to seed metadata onto nodes that bind too it.  This was previously implememted but the parameter on the create-policy command was lost at some point.  This PR just adds it back in.
