### PR TITLE
Cancel commands

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,8 @@
   e.g. "task": "TASK_NAME" instead of "task": { "name" => "TASK_NAME" }
 + The matching language for rules now allows both "upper" and "lower" for use
   as functions to convert string values to upper- and lower-case respectively.
++ Added `cancel-command` command to prevent commands (`create-repo` only for now)
+  from being requeued in certain failure cases that would otherwise requeue.
 
 ## 0.13.0 - 2014-01-21
 

--- a/db/migrate/019_add_cancelled_type_to_command.rb
+++ b/db/migrate/019_add_cancelled_type_to_command.rb
@@ -1,0 +1,45 @@
+# -*- encoding: utf-8 -*-
+require_relative './util'
+
+Sequel.migration do
+  up do
+    extension(:constraint_validations)
+
+    # rename the enum type you want to change
+    run %q{alter type command_status rename to command_status_temp}
+    # create new type
+    run %q{create type command_status as ENUM ('pending', 'running', 'failed', 'cancelled', 'finished')}
+    # rename column which uses the enum type
+    run %q{alter table commands rename column status to status_temp}
+    # add new column of new type
+    run %q{alter table commands add status command_status}
+    # copy values to the new column
+    run %q{update commands set status = status_temp::text::command_status}
+    # set back to not-null
+    run %q{alter table commands alter column status set not null}
+    # remove old column and type
+    run %q{alter table commands drop column status_temp}
+    run %q{drop type command_status_temp}
+  end
+
+  down do
+    extension(:constraint_validations)
+    # rename the enum type you want to change
+    run %q{alter type command_status rename to command_status_temp}
+    # create new type
+    run %q{create type command_status as ENUM ('pending', 'running', 'failed', 'finished')}
+    # rename column which uses the enum type
+    run %q{alter table commands rename column status to status_temp}
+    # add new column of new type
+    run %q{alter table commands add status command_status}
+    # change problematic columns
+    run %q{update commands set status_temp = 'failed' where status_temp = 'cancelled'}
+    # copy values to the new column
+    run %q{update commands set status = status_temp::text::command_status}
+    # set back to not-null
+    run %q{alter table commands alter column status set not null}
+    # remove old column and type
+    run %q{alter table commands drop column status_temp}
+    run %q{drop type command_status_temp}
+  end
+end

--- a/doc/api.md
+++ b/doc/api.md
@@ -552,6 +552,17 @@ with new hardware information:
         }
     }
 
+### Cancel Command
+
+When a user issues e.g. `create-repo --iso-url http://example.com/some.iso ...`
+and has a typo in that URL, there is no way for them to cancel that create-repo.
+The command will continue to be re-queued, assuming the ISO is not ready yet.
+This command will cause that `create-repo` command to cease being queued.
+For example, this will cancel a command with name 123:
+
+    {
+      "name": 123
+    }
 
 ## Collections
 

--- a/lib/razor/command/cancel_command.rb
+++ b/lib/razor/command/cancel_command.rb
@@ -1,0 +1,33 @@
+# -*- encoding: utf-8 -*-
+
+class Razor::Command::CancelCommand < Razor::Command
+  summary "Cancel a command"
+  description <<-EOT
+Cancel a command to prevent later retries.
+
+When a user issues e.g. `create-repo --iso-url http://example.com/some.iso ...`
+and has a typo in that URL, there is no way for them to cancel that create-repo.
+The command will continue to be re-queued, assuming the ISO is not ready yet.
+This command will cause that `create-repo` command to cease being queued.
+  EOT
+
+  example <<-EOT
+Cancel a command with name 123:
+
+    {
+      "name": 123
+    }
+
+  EOT
+
+  authz '%{name}'
+  attr  'name', type: Integer, required: true, references: [Razor::Data::Command, :id], help: _(<<-HELP)
+    The name (or ID) of the command, as it is referenced within Razor. This will be a number.
+  HELP
+
+  def run(request, data)
+    cmd = Razor::Data::Command[:id => data['name']]
+    cmd.store('cancelled')
+  end
+end
+

--- a/lib/razor/data/command.rb
+++ b/lib/razor/data/command.rb
@@ -48,6 +48,14 @@ module Razor::Data
       status == 'finished'
     end
 
+    def cancelled?
+      status == 'cancelled'
+    end
+
+    def failed?
+      status == 'failed'
+    end
+
     # Store (save) the command after setting its status to +status+. If its
     # status is +nil+ and no explicit +status+ is passed in, set it to
     # finished.
@@ -57,7 +65,7 @@ module Razor::Data
       else
         self.status = status if status
       end
-      self.finished_at ||= DateTime.now if finished?
+      self.finished_at ||= DateTime.now if finished? or cancelled? or failed?
       save
     end
 

--- a/lib/razor/messaging/sequel.rb
+++ b/lib/razor/messaging/sequel.rb
@@ -108,6 +108,7 @@ class Razor::Messaging::Sequel < TorqueBox::Messaging::MessageProcessor
     if body['command']
       # A command is optional for background processing
       command        = find_command(body['command'])
+      return nil if command.cancelled?
     end
     if instance.nil?
       # @todo danielp 2013-07-05: I genuinely don't know the correct way to

--- a/spec/app/cancel_command_spec.rb
+++ b/spec/app/cancel_command_spec.rb
@@ -1,0 +1,67 @@
+# -*- encoding: utf-8 -*-
+require_relative '../spec_helper'
+require_relative '../../app'
+
+describe "cancel command" do
+  include Razor::Test::Commands
+
+  let(:app) { Razor::App }
+  before :each do
+    authorize 'fred', 'dead'
+  end
+
+  context "/api/commands/cancel-command" do
+    before :each do
+      header 'content-type', 'application/json'
+    end
+    let(:cmd) do
+      Fabricate(:command)
+    end
+
+    let(:command_hash) do
+      { :name => cmd.id }
+    end
+
+    def cancel_command(input = nil)
+      input ||= command_hash
+      command 'cancel-command', input
+    end
+
+    it "should reject bad JSON" do
+      cancel_command '{"json": "not really..."'
+      last_response.status.should == 400
+      last_response.json["error"].should == 'unable to parse JSON'
+    end
+
+    ["foo", 100, 100.1, -100, true, false].map(&:to_json).each do |input|
+      it "should reject non-object inputs (like: #{input.inspect})" do
+        cancel_command input
+        last_response.status.should == 400
+      end
+    end
+
+    it "should fail if given invalid id" do
+      cancel_command name: cmd.id + 12
+      last_response.json['error'].should =~ /name must be the id of an existing command, but is '#{cmd.id + 12}'/
+      last_response.status.should == 404
+    end
+
+    # Successful cancellation
+    it "should return 202" do
+      cancel_command
+
+      last_response.status.should == 202
+      last_response.json?.should be_true
+      last_response.json.keys.should =~ %w[id name spec]
+    end
+
+    it "should cancel the command in the database" do
+      cancel_command
+
+      cmd = Razor::Data::Command[:id => command_hash[:name]]
+      cmd.should_not be_nil
+      cmd.cancelled?.should be_true
+      cmd.finished_at.should_not be_nil
+    end
+  end
+end

--- a/spec/data/command_spec.rb
+++ b/spec/data/command_spec.rb
@@ -101,6 +101,25 @@ describe Razor::Data::Command do
       cmd.finished_at.should_not be_nil
     end
 
+    it "should be cancellable" do
+      cmd = Command.start('hello', {}, nil)
+      cmd.should_not be_cancelled
+      cmd.finished_at.should be_nil
+      cmd.store('cancelled')
+      cmd.reload
+      cmd.should be_cancelled
+      cmd.finished_at.should_not be_nil
+    end
+
+    it "should be failable" do
+      cmd = Command.start('hello', {}, nil)
+      cmd.should_not be_failed
+      cmd.finished_at.should be_nil
+      cmd.store('failed')
+      cmd.should be_failed
+      cmd.finished_at.should_not be_nil
+    end
+
     it "should preserve status if non passed in" do
       cmd = Command.start('hello', {}, nil)
       cmd.status = 'pending'

--- a/spec/messaging_spec.rb
+++ b/spec/messaging_spec.rb
@@ -299,6 +299,21 @@ describe Razor::Messaging::Sequel do
       queue.should == []
     end
 
+    it "should stop if the command is cancelled" do
+      pk = Fabricate(:repo).pk_hash
+      cmd = Fabricate(:command)
+      cmd.store('cancelled')
+      content = {
+          'class'     => 'Razor::Data::Repo',
+          'instance'  => pk,
+          'message'   => 'doesnt_exist',
+          'command'   => {:id  => cmd.id },
+      }
+
+      handler.process!(message(content))
+      queue.should == []
+    end
+
     it "should not queue a retry if the command is not found" do
       pk = Fabricate(:repo).pk_hash
       content = {


### PR DESCRIPTION
Currently, if the user mistypes the URL for the ISO in a repo, that command will continue retrying. This command allows the user to transition a command instance into a new 'cancelled' status so it will not continue processing.