### PR TITLE
Add a command to modify node hw_info data

### DIFF
--- a/lib/razor/command/set_node_hw_info.rb
+++ b/lib/razor/command/set_node_hw_info.rb
@@ -1,0 +1,64 @@
+# -*- encoding: utf-8 -*-
+
+class Razor::Command::SetNodeHWInfo < Razor::Command
+  summary "Change the hardware info on an existing node"
+  description <<-EOT
+    When hardware is changed in a node, such as a network card being replaced,
+    the Razor server may need to be informed so that it can correctly match
+    the new hardware with the existing node definition.
+
+    This command enables replacing the existing hardware info data with new
+    data, making it possible to update the existing node record prior to
+    booting the new node on the network.
+
+    The supplied hardware info must include at least one key that is configured
+    as part of the matching process; on your razor-server that is one of:
+    #{Razor.config['match_nodes_on'].map{|n| " * #{n}"}.join("\n")}
+  EOT
+
+  example <<-EOT
+Update `node172` with new hardware information:
+
+    {
+      "node": "node172",
+      "hw_info": {
+        "net0":   "78:31:c1:be:c8:00",
+        "net1":   "72:00:01:f2:13:f0",
+        "net2":   "72:00:01:f2:13:f1",
+        "serial": "xxxxxxxxxxx",
+        "asset":  "Asset-1234567890",
+        "uuid":   "Not Settable"
+      }
+    }
+  EOT
+
+  authz  '%{node}'
+  attr   'node', required: true, references: Razor::Data::Node, help: _(<<-HELP)
+    The node to modify the hardware information of
+  HELP
+
+  object 'hw_info', required: true, size: 1..Float::INFINITY, help: _(<<-HELP) do
+    The new hardware information for the node
+  HELP
+    extra_attrs /^net[0-9]+$/, type: String, help: _(<<-HELP)
+      The MAC address of a network adapter associated with the node.
+    HELP
+
+    attr 'serial', type: String, help: _('The DMI serial number of the node')
+    attr 'asset', type: String, help: _('The DMI asset tag of the node')
+    attr 'uuid', type: String, help: _('The DMI UUID of the node')
+  end
+
+  def run(request, data)
+    if (data['hw_info'].keys & Razor.config['match_nodes_on']).empty?
+      msg = _('hw_info must contain at least one of the match keys: %{keys}') %
+        {keys: Razor.config['match_nodes_on'].join(', ')}
+      raise Razor::ValidationFailure.new(msg)
+    else
+      Razor::Data::Node[name: data['node']].tap do |node|
+        node.hw_hash = data['hw_info']
+        node.save
+      end
+    end
+  end
+end

--- a/spec/app/set_node_hw_info_spec.rb
+++ b/spec/app/set_node_hw_info_spec.rb
@@ -1,0 +1,74 @@
+# -*- encoding: utf-8 -*-
+require_relative '../spec_helper'
+require_relative '../../app'
+
+describe Razor::Command::SetNodeHWInfo do
+  include Razor::Test::Commands
+
+  let :app do Razor::App end
+
+  before :each do
+    authorize 'fred', 'dead'
+    header    'content-type', 'application/json'
+  end
+
+  def set_node_hw_info(params)
+    command 'set-node-hw-info', params
+  end
+
+  # Build something suitable for sending in, from the hardware info stored in
+  # the node; sadly the two are in pretty radically different formats.
+  def node_hw_hash_to_hw_info(hw_hash)
+      hw_hash.inject({}) do |hash, (k, v)|
+      if k == 'mac'
+        v.each_with_index {|v,n| hash["net#{n}"] = v }
+      else
+        hash[k] = v
+      end
+      hash
+    end
+  end
+
+  it "should fail if the node does not exist" do
+    set_node_hw_info(node: 'freddy', hw_info: {serial: '1234'})
+    last_response.json['error'].
+      should == "node must be the name of an existing node, but is 'freddy'"
+     last_response.status.should == 404
+  end
+
+  it "should fail if the hw_info is not present" do
+    node = Fabricate(:node)
+    set_node_hw_info(node: node.name)
+    last_response.json['error'].
+      should == "hw_info is a required attribute, but it is not present"
+     last_response.status.should == 422
+  end
+
+  it "should fail if the hw_info does not contain any match keys" do
+    Razor.config['match_nodes_on'] = ['mac'] # default, but be safe!
+    node = Fabricate(:node)
+    set_node_hw_info(node: node.name, hw_info: {serial: '1234'})
+    last_response.json['error'].
+      should == "hw_info must contain at least one of the match keys: mac"
+     last_response.status.should == 422
+  end
+
+  it "should succeed but not change the node hw_info if it is the same" do
+    node = Fabricate(:node)
+    set_node_hw_info(node: node.name, hw_info: node_hw_hash_to_hw_info(node.hw_hash))
+    last_response.status.should == 202
+    Razor::Data::Node[id: node.id].hw_hash.should == node.hw_hash
+  end
+
+  it "should update the node hw_info if it is different" do
+    node = Fabricate(:node)
+    before = node.hw_hash
+    before.should_not == {'serial' => '1234'}
+
+    set_node_hw_info(node: node.name, hw_info: {serial: '1234'})
+    last_response.status.should == 202
+
+    Razor::Data::Node[id: node.id].hw_hash.should == {'serial' => '1234'}
+    Razor::Data::Node[id: node.id].should_not == before
+  end
+end


### PR DESCRIPTION
If users need to move, e.g., a network card from one system to another, they
need to tell Razor that that is happening. To facilitate this, we need a
command that lets users selectively remove, add, or modify entries in the
nodes hw_info table.

This implements that, as a single atomic "set hw_info to" operation.  In cases
where partial change is desired, this can be implemented by modifying the data
read from the server -- since there is, in essence, only administrative change
performed to this data, we have no significant edit conflict risk.

https://tickets.puppetlabs.com/browse/RAZOR-69
Signed-off-by: Daniel Pittman daniel@rimspace.net
