### PR TITLE
Implement `sanboot` metadata field to activate workaround

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## 0.15.0 - 2014-??-??
 
++ `sanboot` metadata field support: if this is set to (boolean) true in
+   the node metadata, the `sanboot` workaround for firmware PXE booting
+   bugs will be enabled on that specific node.
 + `protect_new_nodes` configuration setting will mark all
    nodes to be marked as "installed" when first discovered, causing them
    to boot locally until explicitly reinstalled.

--- a/spec/tasks/common/boot_local_spec.rb
+++ b/spec/tasks/common/boot_local_spec.rb
@@ -1,0 +1,45 @@
+# -*- encoding: utf-8 -*-
+require_relative '../../spec_helper'
+require_relative '../../../app'
+
+describe "tasks/common/boot_local" do
+  include Rack::Test::Methods
+  def app; Razor::App end
+
+  # I am a tiny bit uncomfortable depending on the noop task as a way to say
+  # "the boot_local template", but really, that is the defined purpose of the
+  # task, so it should be safe, right?
+  let :policy do Fabricate(:policy, task_name: 'noop') end
+
+  let :node do
+    Fabricate(:node).tap do |node|
+      node.facts = {'is_virtual' => 'false', 'virtual' => 'physical'}
+      node.bind(policy)
+      node.save
+    end
+  end
+
+  let :mac do node.hw_hash["mac"].first end
+
+  subject :boot_local do
+    get "/svc/boot?net0=#{mac}"
+    last_response.status.should == 200
+    last_response.body
+  end
+
+  it "should not use (or mention) sanboot by default" do
+    boot_local.should_not =~ /sanboot/
+  end
+
+  %w{parallels vmware virtualbox xenhvm xen0 xenu rhev ovirt hyperv}.each do |type|
+    it "should use sanboot if the machine is a #{type} virtual machine" do
+      node.set(facts: node.facts.merge('is_virtual' => 'true', 'virtual' => type)).save
+      boot_local.should =~ /sanboot .* 0x80/
+    end
+  end
+
+  it "should use sanboot if the `sanboot` metadata field is `true`" do
+    node.set(metadata: {'sanboot' => true}).save
+    boot_local.should =~ /sanboot .* 0x80/
+  end
+end

--- a/tasks/common/boot_local.erb
+++ b/tasks/common/boot_local.erb
@@ -13,7 +13,9 @@ sleep 3
 <%# testing "is_virtual" exists technically isn't necessary, since we have  %>
 <%# full control over the client, but just in case someone builds a custom  %>
 <%# kernel image that doesn't include it, or something...                   %>
-<% if !node.facts["is_virtual"] or node.facts["is_virtual"] != "false"  %>
+<% if !node.facts["is_virtual"] or
+       node.facts["is_virtual"] != "false" or
+       node.metadata['sanboot'] %>
 echo forcing local booting with sanboot 0x80
 sanboot --no-describe --drive 0x80
 <% end %>


### PR DESCRIPTION
A non-trivial number of systems in the field, both virtual and physical, have
an issue where the normal, standard-defined mechanism for continuing on to
local boot after finishing the PXE boot process does not work.

While the standard says that after a clean exit the system should proceed to
the next firmware configured boot device, some machines either return to PXE
booting, or simply report a boot failure, at that point.

In these cases we can implement a work-around in our boot code: instead of
returning to the firmware, we can simply load the boot sector from the first
hard disk and execute it directly.

This works, as the firmware is never again involved, so the boot process will
proceed -- at the cost that we ignore any firmware configuration for boot
sequence, logging, etc.

This commit adds the `sanboot` metadata field to nodes or, my accurately,
checks for the presence of that field.  If it is a boolean true, the
workaround is applied to the node during local boot.

This allows users who have such damaged systems, and cannot resolve the
problem correctly through, eg, a firmware update -- perhaps because the vendor
does not supply one -- to work around the problem to some degree.

Signed-off-by: Daniel Pittman daniel@rimspace.net
