### PR TITLE
Use short form for references

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@
   + `create-repo` now requires a `task` argument. The argument must have the form:
     { "name" => "TASK_NAME" } # Where TASK_NAME is the name of an existing task, whether
     that be stock or custom.
+  + The `create-policy` function no longer creates tags in addition to creating a policy.
 + DHCP will be retried when it fails, to better support networks that take
   time to configure.  (802.1x, trunking, and similar issues are common causes.)
 + `sanboot` metadata field support: if this is set to (boolean) true in

--- a/lib/razor/command/create_policy.rb
+++ b/lib/razor/command/create_policy.rb
@@ -26,9 +26,7 @@ A sample policy installing CentOS 6.4:
       "root-password": "secret",
       "max-count":     20,
       "before":        "other policy",
-      "tags": [
-        {"name": "small", "rule": ["<=", ["num", ["fact", "processorcount"]], 2]}
-      ]
+      "tags":          ["small"]
     }
   EOT
 
@@ -60,78 +58,52 @@ A sample policy installing CentOS 6.4:
     If omitted, the policy is 'unlimited', and no maximum is applied.
   HELP
 
-  object 'before', exclude: 'after', help: _(<<-HELP) do
-    The policy to create this policy before in the policy list.
+  attr 'before', type: String, references: Razor::Data::Policy, exclude: 'after', help: _(<<-HELP)
+    The name of the policy to create this policy before in the policy list.
   HELP
-    attr 'name', type: String, required: true, references: Razor::Data::Policy,
-                 help: _('The name of the policy to create this policy before.')
-  end
 
-  object 'after', exclude: 'before', help: _(<<-HELP) do
-    The policy to create this policy after in the policy list.
+  attr 'after', type: String, exclude: 'before', references: Razor::Data::Policy, help: _(<<-HELP)
+    The name of the policy to create this policy after in the policy list.
   HELP
-    attr 'name', type: String, required: true, references: Razor::Data::Policy,
-                 help: _('The name of the policy to create this policy after.')
-  end
 
   array 'tags', help: _(<<-HELP) do
-    The array of tags that are used for matching nodes to this policy.
+    The array of names of tags that are used for matching nodes to this policy.
 
     When a node has all these tags matched on it, it will be a candidate
     for binding to this policy.
   HELP
-    object do
-      attr 'name', type: String, required: true, help: _('The name of the tag.')
-      array 'rule', help: _(<<-HELP)
-        The `rule` is optional.  If you supply this, you are creating a new tag
-        rather than adding an existing tag to the policy.  In that case this
-        contains the tag rule.
-
-        Creating a tag while adding it to the policy is atomic: if it fails for
-        any reason, the policy will not be modified, and the tag will not be
-        created.  You cannot end up with one change without the other.
-      HELP
-    end
+    element type: String, references: Razor::Data::Tag
   end
 
-  object 'repo', required: true, help: _(<<-HELP) do
-    The repository containing the OS to be installed by this policy.  This
-    should match the task assigned, or bad things will happen.
+  attr 'repo', type: String, required: true, references: Razor::Data::Repo, help: _(<<-HELP)
+    The name of the repository containing the OS to be installed by this policy.
+    This should match the task assigned, or bad things will happen.
   HELP
-    attr 'name', type: String, required: true, references: Razor::Data::Repo,
-                 help: _('The name of the repository to use.')
-  end
 
-  object 'broker', required: true, help: _(<<-HELP) do
-    The broker to use when the node is fully installed, and is ready to hand
-    off to the final configuration management system.  If you have no ongoing
-    configuration management, the supplied `noop` broker will do nothing.
+  attr 'broker', type: String, required: true, references: Razor::Data::Broker, help: _(<<-HELP)
+    The name of the broker to use when the node is fully installed, and is ready
+    to hand off to the final configuration management system.  If you have no
+    ongoing configuration management, the supplied `noop` broker will do nothing.
 
     Please note that this is a broker created with the `create-broker` command,
     which is distinct from the broker types found on disk.
   HELP
-    attr 'name', type: String, required: true, references: Razor::Data::Broker,
-                 help: _('The name of the broker to use.')
-  end
 
-  object 'task', help: _(<<-HELP) do
-    The task used to install nodes that match this policy.  This must match
-    the selected repo, as it references files contained within that repository.
+  attr 'task', type: String, required: true, help: _(<<-HELP)
+    The name of the task used to install nodes that match this policy.  This must
+    match the selected repo, as it references files contained within that repository.
   HELP
-    attr 'name', type: String, required: true,
-                 help: _('The name of the task to apply.')
-  end
 
   def run(request, data)
     tags = (data.delete("tags") || []).map do |t|
-      Razor::Data::Tag.find_or_create_with_rule(t)
+      Razor::Data::Tag.find(name: t)
     end.uniq
 
-    data["repo"]   &&= Razor::Data::Repo[:name => data["repo"]["name"]]
-    data["broker"] &&= Razor::Data::Broker[:name => data["broker"]["name"]]
+    data["repo"]   &&= Razor::Data::Repo[:name => data["repo"]]
+    data["broker"] &&= Razor::Data::Broker[:name => data["broker"]]
 
     if data["task"]
-      data["task_name"] = data.delete("task")["name"]
+      data["task_name"] = data.delete("task")
     end
 
     data["hostname_pattern"] = data.delete("hostname")
@@ -139,7 +111,7 @@ A sample policy installing CentOS 6.4:
     # Handle positioning in the policy table
     if data["before"] or data["after"]
       position = data["before"] ? "before" : "after"
-      neighbor = Razor::Data::Policy[:name => data.delete(position)["name"]]
+      neighbor = Razor::Data::Policy[:name => data.delete(position)]
     end
 
     data["enabled"] = true if data["enabled"].nil?
@@ -159,15 +131,15 @@ A sample policy installing CentOS 6.4:
 
   def self.conform!(data)
     data.tap do |_|
-      data['before'] = { 'name' => data['before'] } if data['before'].is_a?(String)
-      data['after'] = { 'name' => data['after'] } if data['after'].is_a?(String)
+      data['before'] = data['before']['name'] if data['before'].is_a?(Hash) and data['before'].keys == ['name']
+      data['after'] = data['after']['name'] if data['after'].is_a?(Hash) and data['after'].keys == ['name']
       data['tag'] = Array[data['tag']] unless data['tag'].nil? or data['tag'].is_a?(Array)
       data['tags'] = [] if data['tags'].nil?
       data['tags'] = (data['tags'] + data.delete('tag')).uniq if data['tags'].is_a?(Array) and data['tag'].is_a?(Array)
-      data['tags'] = data['tags'].map { |item| item.is_a?(String) ? { 'name' => item } : item } if data['tags'].is_a?(Array)
-      data['repo'] = { 'name' => data['repo'] } if data['repo'].is_a?(String)
-      data['broker'] = { 'name' => data['broker'] } if data['broker'].is_a?(String)
-      data['task'] = { 'name' => data['task'] } if data['task'].is_a?(String)
+      data['tags'] = data['tags'].map { |item| item.is_a?(Hash) && item.keys == ['name'] ? item['name'] : item } if data['tags'].is_a?(Array)
+      data['repo'] = data['repo']['name'] if data['repo'].is_a?(Hash) and data['repo'].keys == ['name']
+      data['broker'] = data['broker']['name'] if data['broker'].is_a?(Hash) and data['broker'].keys == ['name']
+      data['task'] = data['task']['name'] if data['task'].is_a?(Hash) and data['task'].keys == ['name']
       data['root-password'] = data.delete('root_password') if data['root_password']
       data['max-count'] = data.delete('max_count') if data['max_count']
     end

--- a/lib/razor/command/create_repo.rb
+++ b/lib/razor/command/create_repo.rb
@@ -53,14 +53,11 @@ downloaded onto the Razor server:
     command.
   HELP
 
-  object 'task', required: true, help: _(<<-HELP) do
-    The task associated with this repository.  This is used to install
-    nodes that match a policy using this repository; generally it should
-    match the OS that the URL or ISO-URL attributes point to.
+  attr 'task', type: String, required: true, help: _(<<-HELP)
+    The name of the task associated with this repository.  This is used to
+    install nodes that match a policy using this repository; generally it
+    should match the OS that the URL or ISO-URL attributes point to.
   HELP
-    attr 'name', type: String, required: true,
-                 help: _('The name of the task.')
-  end
 
   require_one_of 'url', 'iso-url'
 
@@ -70,16 +67,14 @@ downloaded onto the Razor server:
     # same transactional context, ensuring we don't send a message to our
     # background workers without also committing this data to our database.)
     data["iso_url"] = data.delete("iso-url")
-    if data["task"]
-      data["task_name"] = data.delete("task")["name"]
-    end
+    data["task_name"] = data.delete("task")
 
     Razor::Data::Repo.import(data, @command).first
   end
 
   def self.conform!(data)
     data.tap do |_|
-      data['task'] = { 'name' => data['task'] } if data['task'].is_a?(String)
+      data['task'] = data['task']['name'] if data['task'].is_a?(Hash) and data['task'].keys == ['name']
     end
   end
 end

--- a/lib/razor/command/move_policy.rb
+++ b/lib/razor/command/move_policy.rb
@@ -23,24 +23,18 @@ Move a policy after another policy:
 
   require_one_of 'before', 'after'
 
-  object 'before', exclude: 'after', help: _(<<-HELP) do
-    The policy to move this policy before.
+  attr 'before', type: String, exclude: 'after', references: Razor::Data::Policy, help: _(<<-HELP)
+    The name of the policy to move this policy before.
   HELP
-    attr 'name', type: String, required: true, references: Razor::Data::Policy,
-                 help: _('The name of the policy to move before.')
-  end
 
-  object 'after', exclude: 'before', help: _(<<-HELP) do
-    The policy to move this policy after.
+  attr 'after', type: String, exclude: 'before', references: Razor::Data::Policy, help: _(<<-HELP)
+    The name of the policy to move this policy after.
   HELP
-    attr 'name', type: String, required: true, references: Razor::Data::Policy,
-                 help: _('The name of the policy to move after.')
-  end
 
   def run(request, data)
     policy = Razor::Data::Policy[:name => data['name']]
     position = data["before"] ? "before" : "after"
-    name = data[position]["name"]
+    name = data[position]
     neighbor = Razor::Data::Policy[:name => name]
 
     policy.move(position, neighbor)
@@ -51,8 +45,8 @@ Move a policy after another policy:
 
   def self.conform!(data)
     data.tap do |_|
-      data['before'] = { 'name' => data['before'] } if data['before'].is_a?(String)
-      data['after'] = { 'name' => data['after'] } if data['after'].is_a?(String)
+      data['before'] = data['before']['name'] if data['before'].is_a?(Hash) and data['before'].keys == ['name']
+      data['after'] = data['after']['name'] if data['after'].is_a?(Hash) and data['after'].keys == ['name']
     end
   end
 end

--- a/spec/app/create_policy_spec.rb
+++ b/spec/app/create_policy_spec.rb
@@ -5,32 +5,32 @@ require_relative '../../app'
 describe "create policy command" do
   include Razor::Test::Commands
 
-  let(:app) { Razor::App }
-  before :each do
+  let('app') { Razor::App }
+  before 'each' do
     authorize 'fred', 'dead'
   end
 
   context "/api/commands/create-policy" do
-    before :each do
+    before 'each' do
       use_task_fixtures
       header 'content-type', 'application/json'
     end
 
-    let(:repo)   { Fabricate(:repo) }
-    let(:broker) { Fabricate(:broker) }
+    let(:repo)   { Fabricate('repo') }
+    let(:broker) { Fabricate('broker') }
 
-    let (:tag1) { Fabricate(:tag) }
+    let (:tag1) { Fabricate('tag') }
 
-    let(:command_hash) do
+    let('command_hash') do
       # FIXME: Once we have proper helpers to generate these URL's,
       # use them in these tests
-      { :name          => "test policy",
-        :repo          => { "name" => repo.name },
-        :task          => {"name" => "some_os"},
-        :broker        => { "name" => broker.name },
-        :hostname      => "host${id}.example.com",
+      { 'name'          => "test policy",
+        'repo'          => repo.name,
+        'task'          => 'some_os',
+        'broker'        => broker.name,
+        'hostname'      => "host${id}.example.com",
         'root-password' => "geheim",
-        :tags          => [ { "name" => tag1.name } ]
+        'tags'          => [ tag1.name ]
       }
     end
 
@@ -54,32 +54,32 @@ describe "create policy command" do
     end
 
     it "should fail if 'tags' is wrong datatype" do
-      command_hash[:tags] = ''
+      command_hash['tags'] = ''
       create_policy
       last_response.status.should == 422
     end
 
     it "should fail if a nonexisting tag is referenced" do
-      command_hash[:tags] = [ { "name" => "not_a_tag"} ]
+      command_hash['tags'] = [ { "name" => "not_a_tag"} ]
       create_policy
-      last_response.json['error'].should =~ /A rule must be provided for new tag 'not_a_tag'/
-      last_response.status.should == 400
+      last_response.json['error'].should == "tags[0] must be the name of an existing tag, but is 'not_a_tag'"
+      last_response.status.should == 404
     end
 
     it "should fail if a nonexisting repo is referenced" do
-      command_hash[:repo] = { "name" => "not_an_repo" }
+      command_hash['repo'] = { "name" => "not_an_repo" }
       create_policy
       last_response.status.should == 404
     end
 
     it "should fail if the name is empty" do
-      command_hash[:name] = ""
+      command_hash['name'] = ""
       create_policy
       last_response.status.should == 422
     end
 
     it "should fail if the name is missing" do
-      command_hash.delete(:name)
+      command_hash.delete('name')
       create_policy
       last_response.status.should == 422
     end
@@ -91,14 +91,14 @@ describe "create policy command" do
     end
 
     it "should fail without repo" do
-      command_hash.delete(:repo)
+      command_hash.delete('repo')
       create_policy
       last_response.status.should == 422
       last_response.json['error'].should == "repo is a required attribute, but it is not present"
     end
 
     it "should fail without broker" do
-      command_hash.delete(:broker)
+      command_hash.delete('broker')
       create_policy
       last_response.status.should == 422
       last_response.json['error'].should == "broker is a required attribute, but it is not present"
@@ -113,21 +113,21 @@ describe "create policy command" do
     it "should create a policy in the database" do
       create_policy
 
-      Razor::Data::Policy[:name => command_hash[:name]].should be_an_instance_of Razor::Data::Policy
+      Razor::Data::Policy[:name => command_hash['name']].should be_an_instance_of Razor::Data::Policy
     end
 
     it "should default to enabling the policy" do
       create_policy
 
-      Razor::Data::Policy[:name => command_hash[:name]].enabled.should be_true
+      Razor::Data::Policy[:name => command_hash['name']].enabled.should be_true
     end
 
     it "should allow creating a disabled policy" do
-      command_hash[:enabled] = false
+      command_hash['enabled'] = false
 
       create_policy
 
-      Razor::Data::Policy[:name => command_hash[:name]].enabled.should be_false
+      Razor::Data::Policy[:name => command_hash['name']].enabled.should be_false
     end
 
     it "should allow creating a policy with max count" do
@@ -135,13 +135,13 @@ describe "create policy command" do
 
       create_policy
 
-      Razor::Data::Policy[:name => command_hash[:name]].max_count.should == 10
+      Razor::Data::Policy[:name => command_hash['name']].max_count.should == 10
     end
 
     it "should fail with the wrong datatype for repo" do
-      command_hash[:repo] = { }
+      command_hash['repo'] = { }
       create_policy
-      last_response.json['error'].should =~ /repo\.name is a required attribute, but it is not present/
+      last_response.json['error'].should == 'repo should be a string, but was actually a object'
     end
 
     it "should fail with the wrong datatype for max-count" do
@@ -158,132 +158,111 @@ describe "create policy command" do
     end
 
     it "should conform tag array into tags" do
-      tag2 = Fabricate(:tag)
+      tag2 = Fabricate('tag')
       command_hash['tag'] = [tag2.name]
       create_policy
       last_response.status.should == 202
-      ([tag1, tag2] & Razor::Data::Policy[:name => command_hash[:name]].tags).should == [tag1, tag2]
+      ([tag1, tag2] & Razor::Data::Policy[:name => command_hash['name']].tags).should == [tag1, tag2]
     end
 
     it "should conform tag string into tags" do
-      tag2 = Fabricate(:tag)
+      tag2 = Fabricate('tag')
       command_hash['tag'] = tag2.name
       create_policy
       last_response.status.should == 202
-      ([tag1, tag2] & Razor::Data::Policy[:name => command_hash[:name]].tags).should == [tag1, tag2]
+      ([tag1, tag2] & Razor::Data::Policy[:name => command_hash['name']].tags).should == [tag1, tag2]
     end
 
     it "should fail with the wrong datatype for tag" do
       command_hash['tag'] = 123
       create_policy
-      last_response.json['error'].should == "tags[1] should be a object, but was actually a number"
+      last_response.json['error'].should == "tags[1] should be a string, but was actually a number"
       last_response.status.should == 422
     end
 
     it "should fail with the wrong datatype for task" do
-      command_hash[:task] = { }
+      command_hash['task'] = { }
       create_policy
-      last_response.json['error'].should =~ /task\.name is a required attribute, but it is not present/
+      last_response.json['error'].should == 'task should be a string, but was actually a object'
     end
 
     it "should fail with the wrong datatype for broker" do
-      command_hash[:broker] = { }
+      command_hash['broker'] = { }
       create_policy
-      last_response.json['error'].should =~ /broker\.name is a required attribute, but it is not present/
+      last_response.json['error'].should == 'broker should be a string, but was actually a object'
     end
 
     it "should fail with the wrong datatype for tags" do
-      command_hash[:tags] = { }
+      command_hash['tags'] = { }
       create_policy
-      last_response.json['error'].should =~ /tags should be a array, but was actually a object/
-      command_hash[:tags] = [ { } ]
+      last_response.json['error'].should == 'tags should be a array, but was actually a object'
+      command_hash['tags'] = [ { } ]
       create_policy
-      last_response.json['error'].should =~ /tags\[0\].name is a required attribute, but it is not present/
+      last_response.json['error'].should == 'tags[0] should be a string, but was actually a object'
     end
 
-    it "should conform the shortcut syntax" do
-      command_hash[:repo] = repo.name
-      command_hash[:task] = 'some_os'
-      command_hash[:broker] = broker.name
-      command_hash[:tags] = [ tag1.name ]
+    it "should conform the long syntax" do
+      command_hash['repo'] = {'name' => repo.name}
+      command_hash['task'] = {'name' => 'some_os'}
+      command_hash['broker'] = {'name' => broker.name}
+      command_hash['tags'] = [ {'name' => tag1.name} ]
 
       create_policy
 
       last_response.json['error'].should be_nil
-      Razor::Data::Policy[:name => command_hash[:name]].should be_an_instance_of Razor::Data::Policy
+      Razor::Data::Policy[:name => command_hash['name']].should be_an_instance_of Razor::Data::Policy
     end
 
     it "should allow mixed forms" do
-      command_hash[:repo] = { 'name' => repo.name }
-      command_hash[:task] = 'some_os'
-      command_hash[:broker] = { 'name' => broker.name }
-      command_hash[:tags] = [ tag1.name, {'name' => tag1.name} ]
+      command_hash['repo'] = { 'name' => repo.name }
+      command_hash['task'] = 'some_os'
+      command_hash['broker'] = { 'name' => broker.name }
+      command_hash['tags'] = [ tag1.name, {'name' => tag1.name} ]
 
       create_policy
 
       last_response.json['error'].should be_nil
-      Razor::Data::Policy[:name => command_hash[:name]].should be_an_instance_of Razor::Data::Policy
+      Razor::Data::Policy[:name => command_hash['name']].should be_an_instance_of Razor::Data::Policy
     end
 
     context "ordering" do
-      before(:each) do
-        @p1 = Fabricate(:policy)
-        @p2 = Fabricate(:policy)
+      before('each') do
+        @p1 = Fabricate('policy')
+        @p2 = Fabricate('policy')
       end
 
       def check_order(where, policy, list)
         command_hash[where.to_s] = { "name" => policy.name } unless where.nil?
         create_policy
         last_response.status.should == 202
-        p = Razor::Data::Policy[:name => command_hash[:name]]
+        p = Razor::Data::Policy[:name => command_hash['name']]
 
-        list = list.map { |x| x == :_ ? p.id : x.id }
+        list = list.map { |x| x == '_' ? p.id : x.id }
         Policy.all.map { |p| p.id }.should == list
       end
 
       it "should append to the policy list by default" do
-        check_order nil, nil, [@p1, @p2, :_]
+        check_order nil, nil, [@p1, @p2, '_']
       end
 
       describe 'before' do
         it "p1 creates at the head of the table" do
-          check_order(:before, @p1, [:_, @p1, @p2])
+          check_order('before', @p1, ['_', @p1, @p2])
         end
 
         it "p2 goes between p1 and p2" do
-          check_order(:before, @p2, [@p1, :_, @p2])
+          check_order('before', @p2, [@p1, '_', @p2])
         end
       end
 
       describe "after" do
         it "p1 goes between p1 and p2" do
-          check_order(:after, @p1, [@p1, :_, @p2])
+          check_order('after', @p1, [@p1, '_', @p2])
         end
 
         it "p2 goes to the end of the table" do
-          check_order(:after, @p2, [@p1, @p2, :_])
+          check_order('after', @p2, [@p1, @p2, '_'])
         end
-      end
-    end
-
-    context "creating references" do
-      it "creates tags that have rules" do
-        command_hash[:tags] = [
-            {'name' => 'small', 'rule' => ['<=', ['num', %w(fact processorcount)], 2]}
-        ]
-
-        create_policy
-
-        Razor::Data::Tag.find(name: 'small').should_not be_nil
-      end
-      it "fails when rule does not match existing rule" do
-        command_hash[:tags] = [
-            {'name' => tag1.name, 'rule' => ['<=', ['num', %w(fact processorcount)], 2]}
-        ]
-
-        create_policy
-
-        last_response.json['error'].should =~ /Provided rule and existing rule for existing tag '#{tag1.name}' must be equal/
       end
     end
   end

--- a/spec/app/create_repo_spec.rb
+++ b/spec/app/create_repo_spec.rb
@@ -10,7 +10,7 @@ describe "command and query API" do
     {
         "name" => "magicos",
         "iso-url" => "file:///dev/null",
-        "task"    => {'name' => "some_os"},
+        "task"    => "some_os",
     }
   end
   before :each do
@@ -59,7 +59,7 @@ describe "command and query API" do
         "name"      => "magicos",
         "iso-url"   => "file:///dev/null",
         "banana"    => "> orange",
-        "task"      => {'name' => "some_os"},
+        "task"      => "some_os",
       }.to_json
       last_response.json['error'].should =~ /extra attribute banana was present in the command, but is not allowed/
       last_response.status.should == 422
@@ -69,7 +69,7 @@ describe "command and query API" do
       command 'create-repo', {
         "name" => "magicos",
         "iso-url" => "file:///dev/null",
-        "task"    => {'name' => "some_os"},
+        "task"    => "some_os",
       }, :status => :pending
 
       last_response.status.should == 202
@@ -86,7 +86,7 @@ describe "command and query API" do
         data = {
           'name'    => repo.name,
           'iso-url' => repo.iso_url,
-          'task'    => {'name' => repo.task.name}
+          'task'    => repo.task.name
         }
 
         command 'create-repo', data
@@ -99,7 +99,7 @@ describe "command and query API" do
         data = {
           'name' => repo.name,
           'url'  => repo.iso_url,
-          'task' => {'name' => repo.task.name}
+          'task' => repo.task.name
         }
 
         command 'create-repo', data
@@ -114,17 +114,17 @@ describe "command and query API" do
       command 'create-repo', {
         "name" => "magicos",
         "iso-url" => "file:///dev/null",
-        "task"    => {'name' => "some_os"},
+        "task"    => "some_os",
       }, :status => :pending
 
       Repo.find(:name => "magicos").should be_an_instance_of Repo
     end
 
-    it "should conform to allow task-name shortcut" do
+    it "should conform to allow task-name long form" do
       command 'create-repo', {
           "name" => "magicos",
           "iso-url" => "file:///dev/null",
-          "task"    => "some_os",
+          "task"    => {'name' => 'some_os'},
       }, :status => :pending
 
       Repo.find(:name => "magicos").should be_an_instance_of Repo

--- a/spec/app/move_policy_spec.rb
+++ b/spec/app/move_policy_spec.rb
@@ -63,7 +63,7 @@ describe "move policy command" do
           :name => @p1.name,
           :before => { },
       }
-      last_response.json['error'].should =~ /before.name is a required attribute, but it is not present/
+      last_response.json['error'].should == 'before should be a string, but was actually a object'
       last_response.status.should == 422
     end
 
@@ -72,7 +72,7 @@ describe "move policy command" do
           :name => @p1.name,
           :after => { },
       }
-      last_response.json['error'].should =~ /after.name is a required attribute, but it is not present/
+      last_response.json['error'].should == 'after should be a string, but was actually a object'
       last_response.status.should == 422
     end
 
@@ -107,13 +107,13 @@ describe "move policy command" do
     check_order @p1, @p3, @p2
   end
 
-  it "should conform to allow the shortcut in 'before' spec" do
+  it "should conform to allow the long form in 'before' spec" do
     input = {'name' => @p3.name, 'before' => @p1.name }
     command 'move-policy', input
     check_order @p3, @p1, @p2
   end
 
-  it "should conform to allow the shortcut in 'after' spec" do
+  it "should conform to allow the long form in 'after' spec" do
     input = {'name' => @p1.name, 'after' => @p3.name }
     command 'move-policy', input
     check_order @p2, @p3, @p1


### PR DESCRIPTION
Since documentation is now derived from the validation framework, it makes sense that our internal representation should match the user's ideal representation. When a command needs an attribute to reference an existing object, the code previously used a long form (`{"name": "value"}`) rather than the shortcut form (`"value"`). This corrects the internal representation without affecting the external.

One side effect of this change is that `create-policy` will no longer create tags as a side effect.
