### PR TITLE
Check references when verifying duplicate creation

### DIFF
--- a/lib/razor/command/create_policy.rb
+++ b/lib/razor/command/create_policy.rb
@@ -120,11 +120,13 @@ A sample policy installing CentOS 6.4:
     data["root_password"] = data.delete("root-password") if data["root-password"]
 
     # Create the policy
-    policy = Razor::Data::Policy.import(data).first
+    policy, is_new = Razor::Data::Policy.import(data)
 
-    tags.each { |t| policy.add_tag(t) }
-    position and policy.move(position, neighbor)
-    policy.save
+    if is_new
+      tags.each { |t| policy.add_tag(t) }
+      position and policy.move(position, neighbor)
+      policy.save
+    end
 
     return policy
   end

--- a/lib/razor/data.rb
+++ b/lib/razor/data.rb
@@ -65,8 +65,9 @@ module Razor::Data
         # this open-codes the comparison here.  Perhaps we should make this
         # generic, but I would rather have at least one more example before we
         # do that.
+        new_obj = new(data)
         different = fields_for_command_comparison.reject do |key|
-          duplicate.send(key) == data[key]
+          duplicate.send(key) == new_obj.send(key)
         end
 
         # If we found differences, we want to inform the user of them.

--- a/lib/razor/data/policy.rb
+++ b/lib/razor/data/policy.rb
@@ -80,6 +80,10 @@ module Razor::Data
       end
     end
 
+    def self.fields_for_command_comparison
+      super - %w{rule_number}
+    end
+
     def self.bind(node)
       node_tags = node.tags
       # The policies that could be bound must

--- a/spec/app/create_policy_spec.rb
+++ b/spec/app/create_policy_spec.rb
@@ -225,6 +225,29 @@ describe "create policy command" do
       Razor::Data::Policy[:name => command_hash['name']].should be_an_instance_of Razor::Data::Policy
     end
 
+    it "should return 202 if the policy is identical" do
+      create_policy
+      create_policy
+
+      last_response.json['error'].should be_nil
+      last_response.json['name'].should == command_hash['name']
+      last_response.status.should == 202
+    end
+
+    it "should return 409 if the policy is not identical" do
+      create_policy
+      other_repo = Fabricate(:repo)
+      other_broker = Fabricate(:broker)
+      command_hash['repo'] = other_repo.name
+      command_hash['broker'] = other_broker.name
+
+      create_policy
+
+      last_response.json['error'].should ==
+          "The policy #{command_hash['name']} already exists, and the repo_id, broker_id fields do not match"
+      last_response.status.should == 409
+    end
+
     context "ordering" do
       before('each') do
         @p1 = Fabricate('policy')


### PR DESCRIPTION
When issuing the same `create-policy` command twice in a row, the code currently reports that several fields — including all fields that reference other objects — do not match. This fixes that by generating a new object that will be used in the comparison.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-248
