### PR TITLE
Provide expected argument datatype for commands

### DIFF
--- a/lib/razor/command.rb
+++ b/lib/razor/command.rb
@@ -85,7 +85,8 @@ Body is: '%{body}'
 
     {
       name: name,
-      help: self.class.help
+      help: self.class.help,
+      schema: self.class.schema
     }.to_json
   end
 

--- a/lib/razor/command/modify_node_metadata.rb
+++ b/lib/razor/command/modify_node_metadata.rb
@@ -23,7 +23,7 @@ modify an existing value already present on a node:
             "key2": "value2"
         }
         "remove": ["key3", "key4"],
-        "no_replace": true
+        "no-replace": true
     }
 
 Removing all node metadata:
@@ -38,12 +38,12 @@ Removing all node metadata:
 
   attr 'update',     type: Hash, help: _('The metadata to update')
   attr 'remove',     type: Array, help: _('The metadata to remove')
-  attr 'clear',      type: [String, :bool], exclude: ['update', 'remove'], help: _(<<-HELP)
+  attr 'clear',      type: :bool, exclude: ['update', 'remove'], help: _(<<-HELP)
     Remove all metadata from the node.  Cannot be used together with
     either 'update' or 'remove'.
   HELP
 
-  attr 'no_replace', type: [String, :bool], help: _(<<-HELP)
+  attr 'no-replace', type: :bool, help: _(<<-HELP)
     If true, the `update` operation will cause this command to fail if the
     metadata key is already present on the node.  No effect on `remove` or
     clear.
@@ -53,17 +53,25 @@ Removing all node metadata:
   def run(request, data)
     data['update'] or data['remove'] or data['clear'] or
       request.error 422, :error => _("at least one operation (update, remove, clear) required")
-    [nil, true, false, 'true', 'false'].include?(data['clear']) or
-      request.error 422, :error => _("clear must be boolean true or string 'true'")
-    [nil, true, false, 'true', 'false'].include?(data['no_replace']) or
-      request.error 422, :error => _("no_replace must be boolean true or string 'true'")
 
     if data['update'] and data['remove']
       data['update'].keys.concat(data['remove']).uniq! and
         request.error 422, :error => _('cannot update and remove the same key')
     end
 
+    data['no_replace'] = data['no-replace']
+
     node = Razor::Data::Node[:name => data.delete('node')]
     node.modify_metadata(data)
+  end
+
+  def self.conform!(data)
+    data.tap do |_|
+      data['no-replace'] = data.delete('no_replace') if data.has_key?('no_replace')
+      data['clear'] = true if data['clear'] == 'true'
+      data['clear'] = false if data['clear'] == 'false'
+      data['no-replace'] = true if data['no-replace'] == 'true'
+      data['no-replace'] = false if data['no-replace'] == 'false'
+    end
   end
 end

--- a/lib/razor/command/set_node_desired_power_state.rb
+++ b/lib/razor/command/set_node_desired_power_state.rb
@@ -22,7 +22,7 @@ Setting the power state for the node:
   attr  'name', type: String, required: true,  references: Razor::Data::Node,
                 help: _('The node to change the desired power state of.')
 
-  attr 'to', type: [String, nil], required: false, one_of: ['on', 'off', nil],
+  attr 'to', type: String, required: false, one_of: ['on', 'off', nil],
              help: _('The desired power state -- on, or off.')
 
   def run(request, data)
@@ -30,5 +30,11 @@ Setting the power state for the node:
 
     node.set(desired_power_state: data['to']).save
     {result: _("set desired power state to %{state}") % {state: data['to'] || 'ignored (null)'}}
+  end
+
+  def self.conform!(data)
+    data.tap do |_|
+      data.delete('to') if data['to'].nil?
+    end
   end
 end

--- a/lib/razor/util.rb
+++ b/lib/razor/util.rb
@@ -3,18 +3,19 @@ module Razor::Util; end
 
 # Make this uniformly available.
 class Object
-  def ruby_type_to_json(ruby)
+  def ruby_type_to_json(instance)
     # We want to work with the class, not the instance.
-    ruby = ruby.class unless ruby.is_a?(Module)
+    ruby = instance.is_a?(Module) ? instance : instance.class
 
     # These should not be translated, since they are technical terms from the
     # JSON specification.
-    if    ruby <= Hash       then 'object'
-    elsif ruby <= Array      then 'array'
+    if instance == [TrueClass, FalseClass] then 'boolean'
+    elsif ruby <= Hash       then 'object'
     elsif ruby <= String     then 'string'
     elsif ruby <= Numeric    then 'number'
-    elsif ruby <= TrueClass  then 'true'
-    elsif ruby <= FalseClass then 'false'
+    elsif ruby <= TrueClass  then 'boolean'
+    elsif ruby <= FalseClass then 'boolean'
+    elsif ruby <= Array      then 'array'
     elsif ruby <= NilClass   then 'null'
     elsif ruby <= URI        then 'string (URL)'
     # I don't believe we will ever, ever see this come up, but just in case...

--- a/lib/razor/validation/hash_attribute.rb
+++ b/lib/razor/validation/hash_attribute.rb
@@ -29,7 +29,7 @@ class Razor::Validation::HashAttribute
     end
 
     if @size
-      @type and @type.all? {|t| [String, Hash, Array].member? t[:type] } or
+      @type and [String, Hash, Array].member?(@type[:type]) or
         raise ArgumentError, "a type, from String, Hash, or Array, must be specified if you want to check the size of the #{@name} attribute"
     end
 
@@ -43,7 +43,7 @@ class Razor::Validation::HashAttribute
 - This attribute is required
 % end
 % if @type
-- It must be one of <%= @type.map{|entry| ruby_type_to_json(entry[:type])}.join(', ') %>.
+- It must be of type <%= ruby_type_to_json(@type[:type]) %>.
 % end
 % if @exclude
 - If present, <%= @exclude.join(', ') %> must not be present.
@@ -65,6 +65,10 @@ class Razor::Validation::HashAttribute
   def to_s
     # We indent so that nested attributes do the right thing.
     HelpTemplate.result(binding).gsub(/^/, '   ')
+  end
+
+  def to_json(arg)
+    {'type' => ruby_type_to_json(@type[:type])}.to_json
   end
 
   def expand(path, name)
@@ -92,27 +96,19 @@ class Razor::Validation::HashAttribute
     value = data[name]
 
     if @type
-      Array(@type).any? do |check|
-        # If we don't match the base type, go to the next one; if none match our
-        # final validation failure will trigger and raise.
-        next false unless value.class <= check[:type]
+      # If we don't match the base type, go to the next one; if none match our
+      # final validation failure will trigger and raise.
+      raise Razor::ValidationFailure, _("%{this} should be a %{expected}, but was actually a %{actual}") % {
+          this:     expand(path, name),
+          actual:   ruby_type_to_json(value),
+          expected: ruby_type_to_json(@type[:type])} unless Array(@type[:type]).any? { |_| value.class <= _ }
 
-        # If there is a validation
-        begin
-          check[:validate] and check[:validate].call(value)
-        rescue => e
-          raise Razor::ValidationFailure, _("%{this} should be a %{type}, but failed validation: %{error}") % {this: expand(path, name), type: ruby_type_to_json(check[:type]), error: e.to_s}
-        end
-
-        # If we got here we passed all the checks, and have a match, so we are good.
-        break true
-      end or raise Razor::ValidationFailure, n_(
-        "%{this} should be a %{expected}, but was actually a %{actual}",
-        "%{this} should be one of %{expected}, but was actually a %{actual}",
-        Array(@type).count) % {
-        this:     expand(path, name),
-        actual:   ruby_type_to_json(value),
-        expected: Array(@type).map {|x| ruby_type_to_json(x[:type]) }.join(', ')}
+      # If there is a validation
+      begin
+        @type[:validate] and @type[:validate].call(value)
+      rescue => e
+        raise Razor::ValidationFailure, _("%{this} should be a %{type}, but failed validation: %{error}") % {this: expand(path, name), type: ruby_type_to_json(@type[:type]), error: e.to_s}
+      end
     end
 
     if @references
@@ -177,25 +173,22 @@ class Razor::Validation::HashAttribute
   end
 
   def type(which)
-    which = Array(which)
-    which.empty? and raise ArgumentError, "type checks must be passed some type to check"
+    which.nil? and raise ArgumentError, "type checks must be passed some type to check"
 
-    @type = which.map do |entry|
-      case entry
+    @type = case which
       when nil    then {type: NilClass}
-      when :bool  then [{type: TrueClass}, {type: FalseClass}]
+      when :bool  then {type: [TrueClass, FalseClass]}
       when Module then
-        if entry <= URI then
+        if which <= URI then
           {type: String, validate: -> str { URI.parse(str) }}
-        elsif entry <= Hash then
+        elsif which <= Hash then
           {type: Hash, validate: -> hash { raise ArgumentError, "blank hash key not allowed" if hash.keys.include? '' }}
         else
-          {type: entry}
+          {type: which}
         end
       else
-        raise ArgumentError, "type checks must be passed a class, module, nil, or an array of the same (got #{which.inspect})"
+        raise ArgumentError, "type checks must be passed a class, module, or nil (got #{which.inspect})"
       end
-    end.flatten
   end
 
   def exclude(what)

--- a/lib/razor/validation/hash_schema.rb
+++ b/lib/razor/validation/hash_schema.rb
@@ -164,6 +164,10 @@ at https://tickets.puppetlabs.com/
     end
   end
 
+  def to_json(arg)
+    @attributes.to_json
+  end
+
   def authz(pattern)
     if pattern.is_a?(String)
       pattern.empty? and raise ArgumentError, "the authz pattern must not be empty"

--- a/spec/app/modify_node_metadata_spec.rb
+++ b/spec/app/modify_node_metadata_spec.rb
@@ -12,7 +12,7 @@ describe "modify node metadata command" do
     {
         "node" => node.name,
         'update' => { 'k1' => 'v2', 'k2' => 'v2'},
-        'no_replace' => true
+        'no-replace' => true
     }
   end
 
@@ -67,14 +67,14 @@ describe "modify node metadata command" do
     data = { 'node' => "node#{node.id}", 'clear' => 'something' }
     modify_metadata(data)
     last_response.status.should == 422
-    last_response.json["error"].should =~ /clear must be boolean true or string 'true'/
+    last_response.json["error"].should =~ /clear should be a boolean, but was actually a string/
   end
 
-  it "should complain if no_replace is not boolean true or string 'true'" do
-    data = { 'node' => "node#{node.id}", 'update' => { 'k1' => 'v1'}, 'no_replace' => 'something' }
+  it "should complain if no-replace is not boolean true or string 'true'" do
+    data = { 'node' => "node#{node.id}", 'update' => { 'k1' => 'v1'}, 'no-replace' => 'something' }
     modify_metadata(data)
     last_response.status.should == 422
-    last_response.json["error"].should =~ /no_replace must be boolean true or string 'true'/
+    last_response.json["error"].should =~ /no-replace should be a boolean, but was actually a string/
   end
 
   it "should reject blank attributes" do
@@ -106,7 +106,19 @@ describe "modify node metadata command" do
       node_metadata['k1'].should == 'v2'
     end
 
-    it "should NOT update the value of an existing tag if no_replace is set" do
+    it "should NOT update the value of an existing tag if no-replace is set" do
+      id = node.id
+      data = { 'node' => "node#{id}", 'update' => { 'k1' => 'v1'} }
+      modify_metadata(data)
+      data = { 'node' => "node#{id}", 'update' => { 'k1' => 'v2', 'k2' => 'v2'}, 'no-replace' => true }
+      modify_metadata(data)
+      last_response.status.should == 202
+      node_metadata = Node[:id => id].metadata
+      node_metadata['k1'].should == 'v1'  #should not have updated.
+      node_metadata['k2'].should == 'v2'  #still should have added this.
+    end
+
+    it "should work for no_replace" do
       id = node.id
       data = { 'node' => "node#{id}", 'update' => { 'k1' => 'v1'} }
       modify_metadata(data)

--- a/spec/app/register_node_spec.rb
+++ b/spec/app/register_node_spec.rb
@@ -137,14 +137,14 @@ describe "register node" do
   it "should fail if installed is a string true" do
     register_node 'installed' => "true", 'hw-info' => {'net0' => '00:0c:29:b0:96:df'}
     last_response.json['error'].should ==
-      'installed should be one of true, false, but was actually a string'
+      'installed should be a boolean, but was actually a string'
     last_response.status.should == 422
   end
 
   it "should fail if installed is a string false" do
     register_node 'installed' => "false", 'hw-info' => {'net0' => '00:0c:29:b0:96:df'}
     last_response.json['error'].should ==
-      'installed should be one of true, false, but was actually a string'
+      'installed should be a boolean, but was actually a string'
     last_response.status.should == 422
   end
 

--- a/spec/app/remove_node_metadata_spec.rb
+++ b/spec/app/remove_node_metadata_spec.rb
@@ -42,7 +42,7 @@ describe "remove node metadata command" do
     data = { 'node' => "node#{node.id}", 'all' => 'not true' }
     remove_metadata(data)
     last_response.status.should == 422
-    JSON.parse(last_response.body)["error"].should == "all should be a true, but was actually a string"
+    JSON.parse(last_response.body)["error"].should == "all should be a boolean, but was actually a string"
   end
 
   #Defer to the modify-node-metadata tests for the verification of the

--- a/spec/app/update_node_metadata_spec.rb
+++ b/spec/app/update_node_metadata_spec.rb
@@ -15,7 +15,7 @@ describe "update node metadata command" do
         'node' => node.name,
         'value' => 'v1',
         'key' => 'k1',
-        'no_replace' => 'true'
+        'no-replace' => 'true'
     }
   end
 
@@ -32,22 +32,29 @@ describe "update node metadata command" do
     it_behaves_like "a command"
   end
 
-  it "should require no_replace to equal true" do
+  it "should require no-replace to equal true" do
+    data = { 'node' => "node#{node.id}", 'key' => 'k1', 'value' => 'v1', 'no-replace' => 'not true' }
+    update_metadata(data)
+    last_response.status.should == 422
+    last_response.json["error"].should =~ /no-replace should be a boolean, but was actually a string/
+  end
+
+  it "should conform no_replace" do
     data = { 'node' => "node#{node.id}", 'key' => 'k1', 'value' => 'v1', 'no_replace' => 'not true' }
     update_metadata(data)
     last_response.status.should == 422
-    last_response.json["error"].should =~ /'no_replace' must be boolean true or string 'true'/
+    last_response.json["error"].should =~ /no-replace should be a boolean, but was actually a string/
   end
 
   it "should require all to equal true" do
     data = { 'node' => "node#{node.id}", 'value' => 'v1', 'all' => 'not true' }
     update_metadata(data)
     last_response.status.should == 422
-    last_response.json["error"].should =~ /'all' must be boolean true or string 'true'/
+    last_response.json["error"].should =~ /all should be a boolean, but was actually a string/
   end
 
-  it "should succeed with 'all' and 'no_replace'" do
-    data = { 'node' => "node#{node.id}", 'value' => 'v1', 'all' => 'true', 'no_replace' => 'true' }
+  it "should succeed with 'all' and 'no-replace'" do
+    data = { 'node' => "node#{node.id}", 'value' => 'v1', 'all' => 'true', 'no-replace' => 'true' }
     update_metadata(data)
     last_response.status.should == 202
   end

--- a/spec/validation/array_schema_spec.rb
+++ b/spec/validation/array_schema_spec.rb
@@ -47,7 +47,7 @@ describe Razor::Validation::ArraySchema do
 
     it "should document the requirements for all elements" do
       schema.elements type: String
-      should =~ /All elements must be one of string./
+      should =~ /All elements must be of type string./
     end
 
     it "should document 0..10 correctly" do

--- a/spec/validation/hash_attribute_spec.rb
+++ b/spec/validation/hash_attribute_spec.rb
@@ -247,14 +247,14 @@ describe Razor::Validation::HashAttribute do
     ["String", true, false, 1, 1.1, :string].each do |input|
       it "should fail unless the type is a class or module (#{input.inspect})" do
         expect { attr.type(input) }.
-          to raise_error(/type checks must be passed a class, module, nil, or an array of the same/)
+          to raise_error(/type checks must be passed a class, module, or nil/)
       end
     end
 
     [[], {}].each do |input|
       it "should fail if given an empty collection (#{input.inspect})" do
         expect { attr.type(input) }.
-          to raise_error(/type checks must be passed some type to check/)
+          to raise_error(/type checks must be passed a class, module, or nil/)
       end
     end
 
@@ -265,12 +265,12 @@ describe Razor::Validation::HashAttribute do
         String  => 'string',
         Array   => 'array',
         Hash    => 'object',
-        :bool   => 'true, false',
+        :bool   => 'boolean',
         Integer => 'number'
       }.each do |type, expect|
         it "should correctly report #{type} expectations" do
           attr.type type
-          should =~ /It must be one of #{expect}/
+          should =~ /It must be of type #{expect}/
         end
       end
     end


### PR DESCRIPTION
In order for the client to know how to format data for arbitrary commands, the server needs to provide this information. This includes the expected JSON datatype as interpreted from the validation framework.

There's one case where `create-policy` is using the `conform!` method to provide alias functionality. That needs to be included in the JSON too, so this alias functionality has been added to the framework. For now, this `alias` feature only exists to provide accurate argument datatype metadata.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-216
