### PR TITLE
(maint) Remove unused files and dirs under ext during packaging

### DIFF
--- a/ext/debian/rules
+++ b/ext/debian/rules
@@ -10,6 +10,8 @@ override_dh_install:
 # The hackery to put our init script into place is kind of evil, but whatever.
 override_dh_auto_install:
 	mv ext/razor-server.init debian/razor-server.init
+	rm ext/redhat/razor-server.spec ext/debian/changelog ext/debian/control
+	rmdir ext/debian ext/redhat
 	rmdir ext		# should be emptied by now
 
 	mkdir -p $(ROOT)/etc/razor


### PR DESCRIPTION
Currently, razor debian builds are failing because rmdir is called
on ext during the dh_install in the debian/rules, but ext still has
contents. This commit adds a line to remove the files that are still in
ext and the directories that are still in ext to allow the rmdir to
succeed cleanly.

The failures look like this:

```
rmdir ext       # should be emptied by now
rmdir: failed to remove 'ext': Directory not empty
make[1]: *** [override_dh_auto_install] Error 1
```
