### PR TITLE
Significantly change how we identify nodes to reduce the risk of data loss

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -97,3 +97,15 @@ all:
       - /swap.*/
       - timezone
       - /uptime.*/
+    # Facts that should be used to match nodes on; these are useful if the
+    # primary hardware information like MAC addresses has changed (e.g.,
+    # because of a motherboard replacement), but you want to make sure that
+    # an existing node is still identified as the 'old' node. These facts
+    # must be unique across all nodes that Razor manages - otherwise, it
+    # will erroneously identify two physically different nodes as the same.
+    #
+    # The entries in the array follow the same format as those for
+    # facts.blacklist
+    #match_on:
+    #  - unique_fact
+    #  - /other_facts_.*/

--- a/lib/razor/config.rb
+++ b/lib/razor/config.rb
@@ -65,8 +65,13 @@ module Razor
       !! facts_blacklist_rx.match(name)
     end
 
+    def fact_match_on?(name)
+      !! facts_match_on_rx.match(name)
+    end
+
     def validate!
-      validate_facts_blacklist_rx
+      validate_rx_array("facts.blacklist")
+      validate_rx_array("facts.match_on")
       validate_repo_store_root
       validate_match_nodes_on
     end
@@ -87,14 +92,21 @@ module Razor
     end
 
     def facts_blacklist_rx
-      @facts_blacklist_rx ||=
-        Regexp.compile("\\A((" + Array(self["facts.blacklist"]).map do |s|
-                         if s =~ %r{\A/(.*)/\Z}
-                           $1
-                         else
-                           Regexp.quote(s)
-                         end
-                       end.join(")|(") + "))\\Z")
+      @facts_blacklist_rx ||= rx_from_array("facts.blacklist")
+    end
+
+    def facts_match_on_rx
+      @facts_match_on_rx ||= rx_from_array("facts.match_on")
+    end
+
+    def rx_from_array(name)
+      Regexp.compile("\\A((" + Array(self[name]).map do |s|
+                       if s =~ %r{\A/(.*)/\Z}
+                         $1
+                       else
+                         Regexp.quote(s)
+                       end
+                     end.join(")|(") + "))\\Z")
     end
 
     # Validations
@@ -102,13 +114,13 @@ module Razor
       raise InvalidConfigurationError.new(key, msg)
     end
 
-    def validate_facts_blacklist_rx
-      list = Array(self["facts.blacklist"])
+    def validate_rx_array(name)
+      list = Array(self[name])
       list.map { |s| s =~ %r{\A/(.*)/\Z} and $1 }.compact.each do |s|
         begin
           Regexp.compile(s)
         rescue RegexpError => e
-          raise_ice("facts.blacklist",
+          raise_ice(name,
                     _("entry %{raw} is not a valid regular expression: %{error}") % {raw: s, error: e.message})
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,6 +73,7 @@ class Razor::Config
 
   def reset!
     @facts_blacklist_rx = nil
+    @facts_match_on_rx = nil
     @values['match_nodes_on'] = Razor::Config::HW_INFO_KEYS
   end
 end


### PR DESCRIPTION
This is an alternative to PR 142, which is less intrusive and also addresses https://tickets.puppetlabs.com/browse/RAZOR-218. Since this is a fairly intrusive change in a core part of Razor, I'd highly appreciate all reviews.

We used to assume that calls to /svc/boot would completely identify nodes;
this had two important shortcomings:
- it was not possible for users to identify nodes based on facts (e.g.,
  HDD UUID's) so that even changing the mainboard of a machine will not
  lead to assuming a node is new; changing a mainboard is fairly common
  in large operations, and it is generally hard to coordinate that with
  manually changing the Razor database
- if the HW info that iPXE sent us did not give us the complete picture
  of the hardware, e.g. by using undionly.kpxe, which will only send us
  the MAC address on which the machine did its DHCP, we could
  accidentally identify the same physical node as two separate nodes in
  the database (if DHCP happened sometimes on one NIC and sometimes on
  another NIC) with the attendant risk of data loss

With this change, Razor makes another attempt at identifying the hardware
during requests to /svc/checkin at which point we have the full facts about
the node. If a previous request to /svc/boot misidentified the node and
created a new entry in the database, /svc/checkin will now detect that and
clean up the database by merging the newly created node (which will not
have facts yet as these are not set by /svc/boot) into the existing node.

Most of the work of deduplication is done in Node.register.

Users can now guide deduplication by having Node.register match on certain
facts, controlled by the facts.match_on configuration setting, which by
default is empty. Users must ensure that the facts they use to identify
nodes are truly distinct across their machines, otherwise physically
distinct nodes might get coalesced in the database.
