### PR TITLE
(maint) Remove raring and quantal cows, as they are EOL

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -2,7 +2,7 @@
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
 default_cow: 'base-squeeze-i386.cow'
-cows: 'base-lucid-i386.cow base-precise-i386.cow base-raring-i386.cow base-quantal-i386.cow base-saucy-i386.cow base-sid-i386.cow base-squeeze-i386.cow base-stable-i386.cow base-testing-i386.cow base-unstable-i386.cow base-wheezy-i386.cow'
+cows: 'base-lucid-i386.cow base-precise-i386.cow base-saucy-i386.cow base-sid-i386.cow base-squeeze-i386.cow base-stable-i386.cow base-testing-i386.cow base-unstable-i386.cow base-wheezy-i386.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppet'
 gpg_name: 'info@puppetlabs.com'


### PR DESCRIPTION
Ubuntu raring[1] and quantal[2] are EOL, so we should no longer be
building packages for them. This commit removes them from the build
defaults file.

[1] - http://fridge.ubuntu.com/2014/01/28/ubuntu-13-04-raring-ringtail-end-of-life-reached-on-january-27-2014/
[2] - http://fridge.ubuntu.com/2014/05/17/ubuntu-12-10-quantal-quetzal-end-of-life-reached-on-may-16-2014/
