### PR TITLE
Put `node-metadata` back in `create-policy`

### DIFF
--- a/spec/app/create_policy_spec.rb
+++ b/spec/app/create_policy_spec.rb
@@ -138,6 +138,13 @@ describe "create policy command" do
       Razor::Data::Policy[:name => command_hash['name']].max_count.should == 10
     end
 
+    it "should allow creating a policy with node_metadata" do
+      metadata = { "key1" => "value1", "key2" => "value2" }
+      command_hash['node-metadata'] = metadata
+      create_policy
+      Razor::Data::Policy[:name => command_hash['name']].node_metadata.should == metadata
+    end
+
     it "should fail with the wrong datatype for repo" do
       command_hash['repo'] = { }
       create_policy


### PR DESCRIPTION
The create-policy command should accept the node-metadata attribute to allow the policy to seed metadata onto nodes that bind to it. This was previously implemented but the parameter on the create-policy command was lost in the move to the new validation framework. This just adds it back in.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-207
