### PR TITLE
Standardizing spec tests

### DIFF
--- a/spec/app/add_policy_tag_spec.rb
+++ b/spec/app/add_policy_tag_spec.rb
@@ -2,7 +2,7 @@
 require_relative '../spec_helper'
 require_relative '../../app'
 
-describe "policy-add-tag" do
+describe Razor::Command::AddPolicyTag do
   include Razor::Test::Commands
 
   let(:app) { Razor::App }
@@ -31,9 +31,7 @@ describe "policy-add-tag" do
       }
     end
 
-    describe Razor::Command::AddPolicyTag do
-      it_behaves_like "a command"
-    end
+    it_behaves_like "a command"
 
     it "should advise that that tag is already on policy" do
       count = policy.tags.count

--- a/spec/app/create_broker_spec.rb
+++ b/spec/app/create_broker_spec.rb
@@ -4,7 +4,7 @@ require_relative '../../app'
 
 require 'pathname'
 
-describe "create broker command" do
+describe Razor::Command::CreateBroker do
   include Razor::Test::Commands
 
   let(:app) { Razor::App }
@@ -27,9 +27,7 @@ describe "create broker command" do
       }
     end
 
-    describe Razor::Command::CreateBroker do
-      it_behaves_like "a command"
-    end
+    it_behaves_like "a command"
 
     def create_broker(params)
       command 'create-broker', params

--- a/spec/app/create_policy_spec.rb
+++ b/spec/app/create_policy_spec.rb
@@ -2,7 +2,7 @@
 require_relative '../spec_helper'
 require_relative '../../app'
 
-describe "create policy command" do
+describe Razor::Command::CreatePolicy do
   include Razor::Test::Commands
 
   let('app') { Razor::App }
@@ -34,9 +34,7 @@ describe "create policy command" do
       }
     end
 
-    describe Razor::Command::CreatePolicy do
-      it_behaves_like "a command"
-    end
+    it_behaves_like "a command"
 
     def create_policy(input = nil)
       input ||= command_hash

--- a/spec/app/create_repo_spec.rb
+++ b/spec/app/create_repo_spec.rb
@@ -2,7 +2,7 @@
 require_relative '../spec_helper'
 require_relative '../../app'
 
-describe "command and query API" do
+describe Razor::Command::CreateRepo do
   include Razor::Test::Commands
 
   let(:app) { Razor::App }

--- a/spec/app/create_tag_spec.rb
+++ b/spec/app/create_tag_spec.rb
@@ -2,7 +2,7 @@
 require_relative '../spec_helper'
 require_relative '../../app'
 
-describe "create tag command" do
+describe Razor::Command::CreateTag do
   include Razor::Test::Commands
 
   let(:app) { Razor::App }
@@ -25,9 +25,7 @@ describe "create tag command" do
       command 'create-tag', input
     end
 
-    describe Razor::Command::CreateTag do
-      it_behaves_like "a command"
-    end
+    it_behaves_like "a command"
 
     it "should reject bad JSON" do
       create_tag '{"json": "not really..."'

--- a/spec/app/create_task_spec.rb
+++ b/spec/app/create_task_spec.rb
@@ -2,7 +2,7 @@
 require_relative '../spec_helper'
 require_relative '../../app'
 
-describe "create task command" do
+describe Razor::Command::CreateTask do
   include Razor::Test::Commands
 
   let(:app) { Razor::App }
@@ -26,9 +26,7 @@ describe "create task command" do
       command 'create-task', (input || command_hash)
     end
 
-    describe Razor::Command::CreateTask do
-      it_behaves_like "a command"
-    end
+    it_behaves_like "a command"
 
     it "should reject bad JSON" do
       create_task '{"json": "not really..."'

--- a/spec/app/delete_broker_spec.rb
+++ b/spec/app/delete_broker_spec.rb
@@ -2,7 +2,7 @@
 require_relative '../spec_helper'
 require_relative '../../app'
 
-describe "delete-broker" do
+describe Razor::Command::DeleteBroker do
   include Razor::Test::Commands
 
   let(:app) { Razor::App }
@@ -16,9 +16,7 @@ describe "delete-broker" do
     command 'delete-broker', { "name" => name }
   end
 
-  describe Razor::Command::DeleteBroker do
-    it_behaves_like "a command"
-  end
+  it_behaves_like "a command"
 
   before :each do
     header 'content-type', 'application/json'

--- a/spec/app/delete_node_spec.rb
+++ b/spec/app/delete_node_spec.rb
@@ -2,7 +2,7 @@
 require_relative '../spec_helper'
 require_relative '../../app'
 
-describe "delete-node" do
+describe Razor::Command::DeleteNode do
   include Razor::Test::Commands
 
   let(:app) { Razor::App }
@@ -21,9 +21,7 @@ describe "delete-node" do
       header 'content-type', 'application/json'
     end
 
-    describe Razor::Command::DeleteNode do
-      it_behaves_like "a command"
-    end
+    it_behaves_like "a command"
 
     it "should delete an existing node" do
       node = Fabricate(:node)

--- a/spec/app/delete_policy_spec.rb
+++ b/spec/app/delete_policy_spec.rb
@@ -2,7 +2,7 @@
 require_relative '../spec_helper'
 require_relative '../../app'
 
-describe "delete-policy" do
+describe Razor::Command::DeletePolicy do
   include Razor::Test::Commands
 
   let(:app) { Razor::App }
@@ -18,9 +18,7 @@ describe "delete-policy" do
     command 'delete-policy', params
   end
 
-  describe Razor::Command::DeletePolicy do
-    it_behaves_like "a command"
-  end
+  it_behaves_like "a command"
 
   before :each do
     header 'content-type', 'application/json'

--- a/spec/app/delete_repo_spec.rb
+++ b/spec/app/delete_repo_spec.rb
@@ -2,7 +2,7 @@
 require_relative '../spec_helper'
 require_relative '../../app'
 
-describe "delete-repo" do
+describe Razor::Command::DeleteRepo do
   include Razor::Test::Commands
 
   let(:app) { Razor::App }
@@ -21,9 +21,7 @@ describe "delete-repo" do
       header 'content-type', 'application/json'
     end
 
-    describe Razor::Command::DeleteRepo do
-      it_behaves_like "a command"
-    end
+    it_behaves_like "a command"
 
     it "should delete an existing repo" do
       repo = Fabricate(:repo)

--- a/spec/app/delete_tag_spec.rb
+++ b/spec/app/delete_tag_spec.rb
@@ -2,7 +2,7 @@
 require_relative '../spec_helper'
 require_relative '../../app'
 
-describe "delete-tag" do
+describe Razor::Command::DeleteTag do
   include Razor::Test::Commands
 
   let(:app) { Razor::App }
@@ -22,9 +22,7 @@ describe "delete-tag" do
     header 'content-type', 'application/json'
   end
 
-  describe Razor::Command::DeleteTag do
-    it_behaves_like "a command"
-  end
+  it_behaves_like "a command"
 
   it "should delete an existing tag" do
     tag = Fabricate(:tag)

--- a/spec/app/ipmi_spec.rb
+++ b/spec/app/ipmi_spec.rb
@@ -2,7 +2,7 @@
 require_relative '../spec_helper'
 require_relative '../../app'
 
-describe "set-node-ipmi-credentials" do
+describe Razor::Command::SetNodeIPMICredentials do
   include Razor::Test::Commands
 
   let(:app)  { Razor::App }
@@ -14,9 +14,7 @@ describe "set-node-ipmi-credentials" do
     authorize 'fred', 'dead'
   end
 
-  describe Razor::Command::SetNodeIPMICredentials do
-    it_behaves_like "a command"
-  end
+  it_behaves_like "a command"
 
   it "should report 'no such node' if the name isn't found" do
     command 'set-node-ipmi-credentials', {:name => 'bananaman'}
@@ -44,7 +42,7 @@ describe "set-node-ipmi-credentials" do
   end
 end
 
-describe "reboot-node" do
+describe Razor::Command::RebootNode do
   include Razor::Test::Commands
   include TorqueBox::Injectors
 
@@ -58,9 +56,7 @@ describe "reboot-node" do
     authorize 'fred', 'dead'
   end
 
-  describe Razor::Command::RebootNode do
-    it_behaves_like "a command"
-  end
+  it_behaves_like "a command"
 
   it "should work" do
     command 'reboot-node', {'name' => node.name}
@@ -128,7 +124,7 @@ EOT
   end
 end
 
-describe "set-node-desired-power-state" do
+describe Razor::Command::SetNodeDesiredPowerState do
   include Razor::Test::Commands
 
   let(:app)   { Razor::App }
@@ -140,9 +136,7 @@ describe "set-node-desired-power-state" do
     authorize 'fred', 'dead'
   end
 
-  describe Razor::Command::SetNodeDesiredPowerState do
-    it_behaves_like "a command"
-  end
+  it_behaves_like "a command"
 
   it "should 404 if the node does not exist" do
     command 'set-node-desired-power-state', {name: node.name + '-really'}

--- a/spec/app/modify_node_metadata_spec.rb
+++ b/spec/app/modify_node_metadata_spec.rb
@@ -2,7 +2,7 @@
 require_relative '../spec_helper'
 require_relative '../../app'
 
-describe "modify node metadata command" do
+describe Razor::Command::ModifyNodeMetadata do
   include Razor::Test::Commands
 
   let(:node) do

--- a/spec/app/modify_policy_max_count_spec.rb
+++ b/spec/app/modify_policy_max_count_spec.rb
@@ -2,7 +2,7 @@
 require_relative '../spec_helper'
 require_relative '../../app'
 
-describe "modify-policy-max-count" do
+describe Razor::Command::ModifyPolicyMaxCount do
   include Razor::Test::Commands
 
   let(:app) { Razor::App }
@@ -21,9 +21,7 @@ describe "modify-policy-max-count" do
       authorize 'fred', 'dead'
     end
 
-    describe Razor::Command::ModifyPolicyMaxCount do
-      it_behaves_like "a command"
-    end
+    it_behaves_like "a command"
 
     it "should accept a string for max-count" do
       set_max_count("2")

--- a/spec/app/move_policy_spec.rb
+++ b/spec/app/move_policy_spec.rb
@@ -2,7 +2,7 @@
 require_relative '../spec_helper'
 require_relative '../../app'
 
-describe "move policy command" do
+describe Razor::Command::MovePolicy do
   include Razor::Test::Commands
 
   let(:app) { Razor::App }
@@ -34,9 +34,7 @@ describe "move policy command" do
     Policy.all.map { |p| p.id }.should == list.map { |x| x.id }
   end
 
-  describe Razor::Command::MovePolicy do
-    it_behaves_like "a command"
-  end
+  it_behaves_like "a command"
 
   describe "spec" do
     it "requires a name for the policy to move" do

--- a/spec/app/register_node_spec.rb
+++ b/spec/app/register_node_spec.rb
@@ -2,7 +2,7 @@
 require_relative '../spec_helper'
 require_relative '../../app'
 
-describe "register node" do
+describe Razor::Command::RegisterNode do
   include Razor::Test::Commands
 
   let :app do Razor::App end
@@ -36,9 +36,7 @@ describe "register node" do
     end
   end
 
-  describe Razor::Command::RegisterNode do
-    it_behaves_like "a command"
-  end
+  it_behaves_like "a command"
 
   it "should create a new node based on the input data" do
     register_node 'installed' => true, 'hw-info' => {'net0' => '00:0c:29:08:06:e0'}

--- a/spec/app/reinstall_node_spec.rb
+++ b/spec/app/reinstall_node_spec.rb
@@ -2,7 +2,7 @@
 require_relative '../spec_helper'
 require_relative '../../app'
 
-describe "reinstall-node" do
+describe Razor::Command::ReinstallNode do
   include Razor::Test::Commands
 
   let(:app) { Razor::App }
@@ -22,9 +22,7 @@ describe "reinstall-node" do
       header 'content-type', 'application/json'
     end
 
-    describe Razor::Command::ReinstallNode do
-      it_behaves_like "a command"
-    end
+    it_behaves_like "a command"
 
     it "should reinstall a bound node" do
       node = Fabricate(:bound_node)

--- a/spec/app/remove_node_metadata_spec.rb
+++ b/spec/app/remove_node_metadata_spec.rb
@@ -2,7 +2,7 @@
 require_relative '../spec_helper'
 require_relative '../../app'
 
-describe "remove node metadata command" do
+describe Razor::Command::RemoveNodeMetadata do
   include Razor::Test::Commands
 
   let(:app) { Razor::App }
@@ -22,9 +22,7 @@ describe "remove node metadata command" do
     authorize 'fred', 'dead'
   end
 
-  describe Razor::Command::RemoveNodeMetadata do
-    it_behaves_like "a command"
-  end
+  it_behaves_like "a command"
 
   def remove_metadata(data)
     command 'remove-node-metadata', data

--- a/spec/app/remove_policy_tag_spec.rb
+++ b/spec/app/remove_policy_tag_spec.rb
@@ -2,7 +2,7 @@
 require_relative '../spec_helper'
 require_relative '../../app'
 
-describe "policy-remove-tag" do
+describe Razor::Command::RemovePolicyTag do
   include Razor::Test::Commands
 
   let(:app) { Razor::App }
@@ -29,9 +29,7 @@ describe "policy-remove-tag" do
       }
     end
 
-    describe Razor::Command::RemovePolicyTag do
-      it_behaves_like "a command"
-    end
+    it_behaves_like "a command"
 
     it "should remove a tag from a policy" do
       count = policy.tags.count

--- a/spec/app/set_node_hw_info_spec.rb
+++ b/spec/app/set_node_hw_info_spec.rb
@@ -36,9 +36,7 @@ describe Razor::Command::SetNodeHWInfo do
     end
   end
 
-  describe Razor::Command::SetNodeHWInfo do
-    it_behaves_like "a command"
-  end
+  it_behaves_like "a command"
 
   it "should fail if the node does not exist" do
     command_hash['node'] = 'freddy'

--- a/spec/app/update_node_metadata_spec.rb
+++ b/spec/app/update_node_metadata_spec.rb
@@ -2,7 +2,7 @@
 require_relative '../spec_helper'
 require_relative '../../app'
 
-describe "update node metadata command" do
+describe Razor::Command::UpdateNodeMetadata do
   include Razor::Test::Commands
 
   let(:app) { Razor::App }
@@ -28,9 +28,7 @@ describe "update node metadata command" do
     command 'update-node-metadata', data
   end
 
-  describe Razor::Command::UpdateNodeMetadata do
-    it_behaves_like "a command"
-  end
+  it_behaves_like "a command"
 
   it "should require no-replace to equal true" do
     data = { 'node' => "node#{node.id}", 'key' => 'k1', 'value' => 'v1', 'no-replace' => 'not true' }

--- a/spec/app/update_tag_rule_spec.rb
+++ b/spec/app/update_tag_rule_spec.rb
@@ -2,7 +2,7 @@
 require_relative '../spec_helper'
 require_relative '../../app'
 
-describe "update-tag-rule" do
+describe Razor::Command::UpdateTagRule do
   include Razor::Test::Commands
 
   let(:app) { Razor::App }
@@ -30,9 +30,7 @@ describe "update-tag-rule" do
     }
   end
 
-  describe Razor::Command::UpdateTagRule do
-    it_behaves_like "a command"
-  end
+  it_behaves_like "a command"
 
   it "should update an existing tag" do
     update_tag_rule(tag.name, ["!=", 1, 1])


### PR DESCRIPTION
Since the `to_s` has been fixed for Razor::Command, the standard for spec tests should be `describe Razor::Command::$command_name do...`. This removes a redundancy too in `it_behaves_like "a command"`.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-240
