### PR TITLE
Handle cases where command's attribute has no datatype

### DIFF
--- a/lib/razor/validation/hash_attribute.rb
+++ b/lib/razor/validation/hash_attribute.rb
@@ -68,7 +68,11 @@ class Razor::Validation::HashAttribute
   end
 
   def to_json(arg)
-    {'type' => ruby_type_to_json(@type[:type])}.to_json
+    if @type.nil?
+      {}.to_json
+    else
+      {'type' => ruby_type_to_json(@type[:type])}.to_json
+    end
   end
 
   def expand(path, name)


### PR DESCRIPTION
Fixes https://tickets.puppetlabs.com/browse/RAZOR-268
