### PR TITLE
Wrong error for multiple create-broker commands

### DIFF
--- a/lib/razor/broker_type.rb
+++ b/lib/razor/broker_type.rb
@@ -61,6 +61,9 @@ class Razor::BrokerType
 
   alias_method 'to_s', 'name'
 
+  def ==(o)
+    o.is_a?(Razor::BrokerType) && o.name == name
+  end
 
   # Return the fully interpolated install script, ready to run on a node.
   #

--- a/spec/app/create_broker_spec.rb
+++ b/spec/app/create_broker_spec.rb
@@ -79,5 +79,13 @@ describe Razor::Command::CreateBroker do
 
       Razor::Data::Broker[:name => command['name']].should be_an_instance_of Razor::Data::Broker
     end
+    # Successful creation
+    it "should return 202 when repeated with the same parameters" do
+      command = create_broker command_hash
+      command = create_broker command_hash
+
+      last_response.status.should == 202
+      last_response.json['id'].should =~ %r'/api/collections/brokers/#{URI.escape(command_hash['name'])}\Z'
+    end
   end
 end


### PR DESCRIPTION
Running `create-broker` multiple times with the
same arguments was causing the broker types to
be compared incorrectly. This corrects that behavior.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-251
