### PR TITLE
Match 'Policy' API documentation to Razor Command Reference

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -248,15 +248,15 @@ will return with status code 400.
 
     {
       "name": "a policy",
-      "repo": "some_repo",
-      "task": "redhat6",
-      "broker": "puppet",
+      "repo": { "name": "some_repo" },
+      "task": { "name": "redhat6" },
+      "broker": { "name": "puppet" },
       "hostname": "host${id}.example.com",
       "root_password": "secret",
       "max_count": "20",
-      "before"|"after": "other policy",
+      "before"|"after": { "name": "other policy" },
       "node_metadata": { "key1": "value1", "key2": "value2" },
-      "tags": ["existing_tag",
+      "tags": [{ "name": "existing_tag"},
                { "name": "new_tag", "rule": ["=", "dollar", "dollar"]}]
     }
 
@@ -293,7 +293,7 @@ body like:
 
     {
       "name": "a policy",
-      "before"|"after": "other policy"
+      "before"|"after": { "name": "other policy" }
     }
 
 This will change the policy table so that `a policy` will appear before or


### PR DESCRIPTION
While I was getting up and running with Razor I noticed at least one discrepancy between the documentation provided for Policies on the [Razor Command Reference](http://docs.puppetlabs.com/pe/latest/razor_reference.html#create-policy) and what is in doc/api.md. The information in the razor-server repo appears to be outdated, while the information on docs.puppetlabs.com appears to match the current version of razor-server.

While I have located and fixed this once instance, perhaps the real issue to address is whether there is way to make both of these documentation references come from the same source?
