### PR TITLE
`create-tag` should be idempotent

### DIFF
--- a/lib/razor/data.rb
+++ b/lib/razor/data.rb
@@ -70,7 +70,12 @@ module Razor::Data
         # do that.
         new_obj = new(data)
         different = fields_for_command_comparison.reject do |key|
-          duplicate.send(key) == new_obj.send(key)
+          attr = duplicate.send(key)
+          if attr.respond_to?('equals?')
+            attr.equals?(new_obj.send(key))
+          else
+            attr == new_obj.send(key)
+          end
         end
 
         # If we found differences, we want to inform the user of them.

--- a/lib/razor/matcher.rb
+++ b/lib/razor/matcher.rb
@@ -204,6 +204,10 @@ class Razor::Matcher
     { "rule" => @rule }.to_json
   end
 
+  def equals?(other)
+    other.is_a?(Razor::Matcher) && @rule == other.rule
+  end
+
   attr_reader :rule
   # +rule+ must be an Array
   def initialize(rule)

--- a/spec/app/create_tag_spec.rb
+++ b/spec/app/create_tag_spec.rb
@@ -63,5 +63,12 @@ describe Razor::Command::CreateTag do
 
       Razor::Data::Tag[:name => command_hash[:name]].should be_an_instance_of Razor::Data::Tag
     end
+
+    it "should no-op on multiple calls" do
+      create_tag
+      Razor::Data::Tag[:name => command_hash[:name]].should be_an_instance_of Razor::Data::Tag
+      create_tag
+      last_response.json['error'].should be_nil
+    end
   end
 end


### PR DESCRIPTION
Running multiple identical `create-tag` statements
was not identifying that both `rule` arguments were
identical. This fixes that by allowing each property
of each entity to define how it should be considered
equal via an `equals?` method.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-274
