### PR TITLE
Case-insensitive uniqueness

### DIFF
--- a/db/migrate/019_task_and_tag_unique_constraint_case_sensitivity.rb
+++ b/db/migrate/019_task_and_tag_unique_constraint_case_sensitivity.rb
@@ -1,0 +1,63 @@
+# -*- encoding: utf-8 -*-
+require_relative './util'
+require_relative '../../lib/razor/initialize'
+require_relative '../../lib/razor'
+
+def get_new_name(class_name, current_name, differentiator = 1)
+  if class_name.find(name: current_name + differentiator.to_s).nil?
+    # Not there, ship it
+    current_name + differentiator.to_s
+  else
+    # This is not the name you're looking for
+    get_new_name(class_name, current_name, differentiator + 1) unless exists
+  end
+end
+
+def resolve_duplicates(class_name)
+  # Get all tags, grouped by lowercase name
+  all = class_name.all
+  uniq = Hash.new { Array.new }
+  all.each do |item|
+    key = item.send(:name).downcase
+    uniq.store(key, uniq[key] << item)
+    # Sorting and reversing so "abc" will be before "Abc".
+    # Kind of arbitrary, but it's more deterministic this way.
+    uniq[key] = uniq[key].sort_by(&:name).reverse
+  end
+  uniq.each do |_, items|
+    _, *rest = *items
+    # The first can remain the same, but the rest need to change.
+    rest.each do |item|
+      old_name = item.send(:name)
+      item.send("#{:name.to_s}=", get_new_name(Razor::Data::Tag, item.send(:name)))
+      puts "#{class_name}: Changing #{old_name} to #{item.name} to resolve duplicate issue"
+      item.save
+    end
+  end
+end
+
+# Create a case-insensitive uniqueness constraint on the `tags` table's `name` field.
+# This requires a resolution for renaming existing tags. If 'mytag' and 'MyTag' both
+# exist in the database, this will rename 'MyTag' to 'MyTag1'.
+Sequel.migration do
+  up do
+    extension(:constraint_validations)
+
+    alter_table :tags do
+      resolve_duplicates(Razor::Data::Tag)
+
+      drop_constraint :tags_name_key
+      add_index  Sequel.function(:lower, :name), :unique => true, :name => 'tags_name_index'
+      validate do
+        format NAME_RX, :name,        :name => 'tag_name_is_simple'
+      end
+    end
+
+    # This does not need to modify the :tasks table because the 'tasks_name_index'
+    # in place already performs the case-insensitive uniqueness comparison.
+  end
+
+  down do
+    # Cannot be reversed since the original names of the duplicates are gone.
+  end
+end

--- a/spec/app/create_broker_spec.rb
+++ b/spec/app/create_broker_spec.rb
@@ -82,10 +82,11 @@ describe Razor::Command::CreateBroker do
     # Successful creation
     it "should return 202 when repeated with the same parameters" do
       command = create_broker command_hash
+      command_hash['name'] = command_hash['name'].upcase
       command = create_broker command_hash
 
-      last_response.status.should == 202
-      last_response.json['id'].should =~ %r'/api/collections/brokers/#{URI.escape(command_hash['name'])}\Z'
+      last_response.status.should == 409
+      last_response.json['error'].should == "The broker #{command_hash['name'].upcase} already exists, and the name fields do not match"
     end
   end
 end


### PR DESCRIPTION
When the user tried to create the same entity twice but with different
case-sensitivities, the server would reach an infinite loop or allow both
entities to exist in the case of Tag. This fix converges those to more
standard behavior by universally rejecting the request to create the entity
twice. The fitting error message will be: "...already exists, and the name
fields do not match".

Fixes https://tickets.puppetlabs.com/browse/RAZOR-313
