### PR TITLE
When /svc/boot boots locally it should not log 'repo' => 'microkernel'

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -360,9 +360,12 @@ and requires full control over the database (eg: add and remove tables):
     end
 
     @task = @node.task
+    template = @task.boot_template(@node)
 
     if @node.policy
       @repo = @node.policy.repo
+      @node.log_append(:event => :boot, :task => @task.name,
+                       :template => template, :repo => @repo.name)
     else
       # @todo lutter 2013-08-19: We have no policy on the node, and will
       # therefore boot into the MK. This is a gigantic hack; all we need is
@@ -375,11 +378,10 @@ and requires full control over the database (eg: add and remove tables):
       @repo = Razor::Data::Repo.new(:name => "microkernel",
                                     :iso_url => "file:///dev/null",
                                     :task_name => @task.name)
-    end
-    template = @task.boot_template(@node)
 
-    @node.log_append(:event => :boot, :task => @task.name,
-                     :template => template, :repo => @repo.name)
+      @node.log_append(:event => :boot, :task => @task.name,
+                       :template => template)
+    end
     @node.save
     render_template(template)
   end

--- a/spec/app/provisioning_spec.rb
+++ b/spec/app/provisioning_spec.rb
@@ -74,8 +74,7 @@ describe "provisioning API" do
           "severity" => "info",
           "event" => "boot",
           "task" => "microkernel",
-          "template" => "boot",
-          "repo" => "microkernel"
+          "template" => "boot"
         }
       end
 
@@ -117,7 +116,6 @@ describe "provisioning API" do
         entry.delete("timestamp").should_not be_nil
         entry.should == {
           "severity" => "info",
-          "repo" => "microkernel",
           "event" => "boot",
           "task" => "noop",
           "template" => "boot_local"


### PR DESCRIPTION
The repo field in this log message was deceiving, since the node doesn't
technically have a policy. The log message will now omit that field if the
node does not have a policy.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-266
