### PR TITLE
Query IPMI Details

### DIFF
--- a/lib/razor/view.rb
+++ b/lib/razor/view.rb
@@ -153,6 +153,8 @@ module Razor
         }.delete_if { |k,v| v.nil? },
         :hostname      => node.hostname,
         :root_password => node.root_password,
+        :ipmi          => { :hostname => node.ipmi_hostname,
+                            :username => node.ipmi_username },
         :last_checkin  => ts(node.last_checkin)
       ).delete_if {|k,v| v.nil? or ( v.is_a? Hash and v.empty? ) }
     end

--- a/spec/app/api_spec.rb
+++ b/spec/app/api_spec.rb
@@ -665,6 +665,10 @@ describe "command and query API" do
             }
           },
           'additionalProperties' => false,
+        },
+        'ipmi' => {
+            'hostname' => nil,
+            'username' => nil
         }
       },
       'additionalProperties' => false,


### PR DESCRIPTION
IPMI details had no way of being queried. This places username and hostname
in the node details, and so can be queried via `razor --full nodes $name`.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-277
