### PR TITLE
Add fedora/el-7 systemd support

### DIFF
--- a/ext/debian/rules
+++ b/ext/debian/rules
@@ -10,7 +10,9 @@ override_dh_install:
 # The hackery to put our init script into place is kind of evil, but whatever.
 override_dh_auto_install:
 	mv ext/razor-server.init debian/razor-server.init
-	rm ext/redhat/razor-server.spec ext/debian/changelog ext/debian/control
+	rm ext/redhat/razor-server.spec ext/redhat/razor-server-tmpfiles.conf \
+        ext/redhat/razor-server.env ext/redhat/razor-server.service \
+        ext/debian/changelog ext/debian/control
 	rmdir ext/debian ext/redhat
 	rmdir ext		# should be emptied by now
 

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -24,6 +24,9 @@ update_version_file: true
 # files and gem_files are space separated lists (or arrays)
 files:
   - ext/razor-server.init.erb
+  - ext/redhat/razor-server.service
+  - ext/redhat/razor-server.env
+  - ext/redhat/razor-server-tmpfiles.conf
   - 'Gemfile*'
   - .bundle
   - config.ru

--- a/ext/redhat/razor-server-tmpfiles.conf
+++ b/ext/redhat/razor-server-tmpfiles.conf
@@ -1,0 +1,1 @@
+d /run/razor-server 0755 razor razor -

--- a/ext/redhat/razor-server.env
+++ b/ext/redhat/razor-server.env
@@ -1,0 +1,10 @@
+TORQUEBOX_HOME=/opt/razor-torquebox
+JBOSS_HOME=/opt/razor-torquebox/jboss
+JRUBY_HOME=/opt/razor-torquebox/jruby
+JBOSS_LOG_DIR=/var/log/razor-server
+JBOSS_USER=razor
+JBOSS_CONFIG=standalone.xml
+JBOSS_MODULES_SYSTEM_PKGS=org.jboss.byteman
+LAUNCH_JBOSS_IN_BACKGROUND=true
+LANG=en_US.UTF-8
+JAVA_OPTS="-Xms128m -Xmx1024m -XX:MaxPermSize=256m -Djava.net.preferIPv4Stack=true"

--- a/ext/redhat/razor-server.service
+++ b/ext/redhat/razor-server.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Puppet Enterprise Razor Server
+After=network.target
+
+[Service]
+EnvironmentFile=/usr/share/razor-server/razor-server.env
+User=razor
+ExecStart=/opt/razor-torquebox/jboss/bin/standalone.sh -Djboss.server.log.dir=${JBOSS_LOG_DIR} -Dhttp.port=${RAZOR_PORT} -b 0.0.0.0
+Type=simple
+PIDFile=/run/razor-server/torquebox.pid
+
+[Install]
+WantedBy=multi-user.target

--- a/ext/redhat/razor-server.spec.erb
+++ b/ext/redhat/razor-server.spec.erb
@@ -5,6 +5,12 @@
 # They are not actually a problem, though, since we handle them carefully.
 %define _binaries_in_noarch_packages_terminate_build   0
 
+# Recent Fedora, EL >= 7 use systemd
+%if 0%{?fedora} >= 18 || 0%{?rhel} >= 7
+%global _with_systemd  1
+%endif
+
+
 Summary:        <%= @summary %>
 Name:           razor-server
 Version:        %{rpmversion}
@@ -27,6 +33,13 @@ Requires(pre): razor-torquebox
 
 Requires:       libarchive-devel
 
+%if 0%{?_with_systemd}
+Requires(post): systemd
+Requires(preun): systemd
+Requires(postun): systemd
+BuildRequires: systemd
+%endif
+
 %description
 <%= @description %>
 
@@ -39,14 +52,24 @@ Requires:       libarchive-devel
 rm -rf %{buildroot}
 
 # These are used at runtime.
-mkdir -p %{buildroot}/var/run/razor-server
 mkdir -p %{buildroot}/var/log/razor-server
 mkdir -p %{buildroot}/var/lib/razor/repo-store
 
-# Install the init script and sysconfig file
+# Install the init script
+%if 0%{?_with_systemd}
+install -d -m0755  %{buildroot}%{_unitdir}
+install -m0644 ext/redhat/%{name}.service %{buildroot}%{_unitdir}/
+install -d -m0755 %{buildroot}%{_datadir}/%{name}
+install -m0644 ext/redhat/%{name}.env %{buildroot}%{_datadir}/%{name}/
+install -d -m0755 %{buildroot}/run/%{name}
+install -d %{buildroot}%{_tmpfilesdir}
+install -m0644 ext/redhat/%{name}-tmpfiles.conf %{buildroot}%{_tmpfilesdir}/%{name}.conf
+%else
+# Install the init script
+mkdir -p %{buildroot}/var/run/razor-server
 mkdir -p %{buildroot}%{_initrddir}
 cp -p ext/razor-server.init %{buildroot}%{_initrddir}/razor-server
-
+%endif
 # OK, all the ext stuff is done...
 rm -rf ext
 
@@ -71,7 +94,11 @@ done
 
 %post -p /bin/bash
 # Register the service
-/sbin/chkconfig --add razor-server
+%if 0%{?_with_systemd}
+%systemd_post %{name}.service
+%else
+/sbin/chkconfig --add %{name} || :
+%endif
 
 # Cause our application to be deployed to TorqueBox, but only the first time
 # we are installed.  Upgrades do not automatically trigger this, because a
@@ -89,21 +116,39 @@ exit 0
 # Undeploy our application from TorqueBox.
 source /etc/razor/razor-torquebox.sh
 torquebox undeploy /opt/razor || :
-
+%if 0%{?_with_systemd}
+%systemd_preun %{name}.service
+%else
 /sbin/service razor-server stop >&/dev/null || :
 /sbin/chkconfig --del razor-server || :
+%endif
+
+%postun
+%if 0%{?_with_systemd}
+%systemd_postun_with_restart %{name}.service
+%else
+if [ "${1}" -ge 1 ]; then
+  /sbin/service %{name} reload >/dev/null 2>&1 || :
+fi
+%endif
 
 %clean
 rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
-%attr(-,razor,razor) %dir /var/run/razor-server
 %attr(-,razor,razor) %dir /var/log/razor-server
 %attr(-,razor,razor) %dir /var/lib/razor
 %attr(-,razor,razor) %dir /var/lib/razor/repo-store
-
-%attr(755,root,root) %{_initrddir}/razor-server
+%if 0%{?_with_systemd}
+%{_unitdir}/%{name}.service
+%{_datadir}/%{name}/%{name}.env
+%attr(-,razor,razor) %dir /run/%{name}/
+%{_tmpfilesdir}/%{name}.conf
+%else
+%attr(-,razor,razor) %dir /var/run/razor-server
+%attr(755,root,root) %{_initrddir}/%{name}
+%endif
 
 /opt/razor
 


### PR DESCRIPTION
This updates the packaging and adds a systemd service file
and supporting files to support systemd on Fedora >= 18 and
EL >= 7.

In addition to the razor-server.service file itself, the
razor-server-tmpfiles.conf used the systemd tmpfiles.d
mechanism to ensure that the /run/razor-server
directory is created on boot with the proper ownership
as /run is now using tmpfs.

The /usr/share/razor-server/razor-server.env file
simply wraps up environment variables that were
being set in the init script in a form suitable
for systemd.
