### PR TITLE
Allow powershell (& other arbitrary) install files inside a broker type

### DIFF
--- a/lib/razor/broker_type.rb
+++ b/lib/razor/broker_type.rb
@@ -19,6 +19,7 @@ end
 # Signal that a broker was not found when requested by name.
 class Razor::BrokerTypeNotFoundError < RuntimeError; end
 class Razor::BrokerTypeInvalidError  < RuntimeError; end
+class Razor::InstallTemplateNotFoundError < RuntimeError; end
 
 class Razor::BrokerType
   # Since we behave more or less like a Razor::Data object, we need to include
@@ -68,10 +69,11 @@ class Razor::BrokerType
   # Return the fully interpolated install script, ready to run on a node.
   #
   # @param node [Razor::Data::Node] the node instance to generate for.
+  # @param script [String] the name of the script requested by the node.
   #
   # The node is directly exposed to the script, in case any data from it is
   # required, but only the broker metadata is exposed.
-  def install_script(node, broker)
+  def install_script(node, broker, script = 'install')
     # While this is unlikely, if you could pass an arbitrary object here you
     # could theoretically exploit this to do bad things based on the
     # template actions.  Better safe than sorry...
@@ -96,7 +98,12 @@ class Razor::BrokerType
     # @todo danielp 2013-08-09: this is only a shallow clone, and a shallow
     # freeze; we can do deeper versions of both, but that is time expensive in
     # Ruby, which has crappy support for them.  I feel like this is sufficient.
-    Tilt.new(install_template_path.to_s).render(
+    script = script + '.erb' unless script.end_with?('.erb')
+    install_template_path(script).exist? && install_template_path(script).readable? or
+        raise Razor::InstallTemplateNotFoundError,
+              _('could not find install template \'%{name}\' for broker \'%{broker_name}\'') %
+                  {name: install_template_path(script).basename, broker_name: broker.name}
+    Tilt.new(install_template_path(script).to_s).render(
       # The namespace to work in: a new, blank, disconnected, immutable
       # object, to prevent users getting odd expectations or visibility into,
       # eg, our local scope.
@@ -138,17 +145,20 @@ class Razor::BrokerType
     @name = path.basename('.broker').to_s
 
     # The only mandatory part of the broker is the script to run on the node,
-    # the `install.erb` file.  We assert nothing about it beyond the most
-    # basic existence.
-    install_template_path.exist? or
-      raise Razor::BrokerTypeInvalidError, _("%{name} has no install template") % {name: @name}
-    install_template_path.readable? or
-      raise Razor::BrokerTypeInvalidError, _("%{name} has an install template, but it is unreadable") % {name: @name}
+    # e.g. the `install.erb` file. However, any `.erb` file may exist, so
+    # this just verifies that there exists some value for which this broker
+    # can successfully return a script, i.e. there is a readable `.erb` file.
+    Dir.glob(@path + '*.erb').any? do |script_path|
+      # If an install template path exists, it needs to be readable too
+      Pathname(script_path).readable? or raise Razor::BrokerTypeInvalidError,
+          _("%{name} has install template %{file}, but it is unreadable") %
+              {name: @name, file: Pathname(script_path).basename}
+    end or raise Razor::BrokerTypeInvalidError, _("%{name} has no install script template") % {name: @name}
   end
 
   # Return the name of the installer template file.
-  def install_template_path
-    @path + 'install.erb'
+  def install_template_path(script)
+    @path + script
   end
 
   def configuration_path

--- a/lib/razor/data/broker.rb
+++ b/lib/razor/data/broker.rb
@@ -57,9 +57,11 @@ class Razor::Data::Broker < Sequel::Model
   #
   # @param node [Razor::Data::Node] the node we are producing an install
   # script for.
+  # @param script [String] the name of the resulting install script, excluding
+  # its `.erb` extension. If this is omitted, it will look for `install.erb`
   #
   # @return [String] the compiled installation script, ready to run.
-  def install_script_for(node)
-    broker_type.install_script(node, self)
+  def install_script_for(node, script = 'install')
+    broker_type.install_script(node, self, script)
   end
 end

--- a/spec/app/broker_install_script_spec.rb
+++ b/spec/app/broker_install_script_spec.rb
@@ -27,6 +27,7 @@ describe "provisioning API" do
   it "should 409 if the node is not bound to a policy" do
     get "/svc/broker/#{node.id}/install"
     last_response.status.should == 409
+    last_response.json['error'].should == "node #{node.id} not bound to a policy yet"
   end
 
   context "with a bound node" do
@@ -43,6 +44,15 @@ describe "provisioning API" do
       last_response.status.should == 200
       last_response.content_type.should =~ /text\/plain/
       last_response.body.should == "# there is no meaningful content here\n"
+    end
+
+    it "should fail if script does not exist" do
+      get "/svc/broker/#{node.id}/install?script=does-not-exist"
+
+      last_response.json['error'].should == 'install template does-not-exist.erb does not exist'
+      last_response.json['details'].should == "could not find install template 'does-not-exist.erb' for broker '#{policy.broker.name}'"
+      last_response.status.should == 404
+      last_response.content_type.should =~ /text\/plain/
     end
   end
 end


### PR DESCRIPTION
Windows machines, being unable to run Bash files, will need an alternative
file format for each broker. In order for a broker to receive a different
install file, its task needs to call
`/svc/broker/${id}/install?script=${file}`, where `$id` is the node id and
$file is the file that should be returned. For powershell, `$file` will equal
`install.ps1` and the file in the `.task` folder will be `install.ps1.erb`.
Calling this without the `script` argument is equivalent to calling it with
`script=install` for `install.erb`, meaning this is a backwards-compatible
change.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-355
