### PR TITLE
Remove `all` from `update-node-metadata`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,12 @@
   could have existed as e.g. 'mytag' and 'MyTag'. A migration in this
   release will rename conflicting tags, appending a digit to the end,
   e.g. 'mytag' and 'MyTag1'.
++ The `update-node-metadata` command no longer accepts the `all`
+  argument. This argument should have never been accepted by the 
+  command, and had no effect. Instead, `modify-node-metadata` can be 
+  called with either the `clear` argument to remove all keys, or the 
+  `update` argument to set all keys to certain values, which achieves 
+  the same function. 
 
 ## 0.15.0 - 2014-05-22
 

--- a/lib/razor/command/update_node_metadata.rb
+++ b/lib/razor/command/update_node_metadata.rb
@@ -4,7 +4,7 @@ class Razor::Command::UpdateNodeMetadata < Razor::Command
   summary "Update one key in a nodes metadata"
   description <<-EOT
 This is a shortcut to `modify-node-metadata` that allows for updating or
-adding removing a single key, in a simpler form that the full
+adding a single key, in a simpler form than the full
 editing language.
   EOT
 
@@ -19,7 +19,7 @@ Set a single key from a node:
   attr 'node', type: String, required: true, references: [Razor::Data::Node, :name],
                help: _('The node for which to update metadata.')
 
-  attr 'key', type: String, exclude: 'all', size: 1..Float::INFINITY,
+  attr 'key', required: true, type: String, size: 1..Float::INFINITY,
               help: _('The key to change in the metadata.')
 
   attr 'value', required: true,
@@ -27,11 +27,6 @@ Set a single key from a node:
 
   attr 'no-replace', type: :bool,
                      help: _('If true, it is an error to try to change an existing key')
-
-  attr 'all', type: :bool, exclude: 'key',
-              help: _('If true, the update applies to all keys.')
-
-  require_one_of 'key', 'all'
 
   # Update/add specific metadata key (works with GET)
   def run(request, data)

--- a/spec/app/update_node_metadata_spec.rb
+++ b/spec/app/update_node_metadata_spec.rb
@@ -44,19 +44,6 @@ describe Razor::Command::UpdateNodeMetadata do
     last_response.json["error"].should =~ /no-replace should be a boolean, but was actually a string/
   end
 
-  it "should require all to equal true" do
-    data = { 'node' => "node#{node.id}", 'value' => 'v1', 'all' => 'not true' }
-    update_metadata(data)
-    last_response.status.should == 422
-    last_response.json["error"].should =~ /all should be a boolean, but was actually a string/
-  end
-
-  it "should succeed with 'all' and 'no-replace'" do
-    data = { 'node' => "node#{node.id}", 'value' => 'v1', 'all' => 'true', 'no-replace' => 'true' }
-    update_metadata(data)
-    last_response.status.should == 202
-  end
-
   #Defer to the modify-node-metadata tests for the verification of the
   #actual work.
 end


### PR DESCRIPTION
The `all` parameter was previously not functional. It was not mentioned in
the API.md document. It was declared as a valid boolean parameter, but had no
effect on the execution of the command. This removes that superfluous
parameter.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-364
