### PR TITLE
Fix Trusty's preseed file's url to squashfs

### DIFF
--- a/tasks/ubuntu_trusty_amd64.task/preseed.erb
+++ b/tasks/ubuntu_trusty_amd64.task/preseed.erb
@@ -5,7 +5,7 @@ d-i netcfg/get_hostname string <%= node.hostname %>
 d-i netcfg/get_domain string <%= node.domainname %>
 d-i netcfg/no_default_route boolean true
 # This is the only line that differs from the `ubuntu` preseed file.
-d-i live-installer/net-image string <%= repo_file("install/filesystem.squashfs") %>
+d-i live-installer/net-image string <%= repo_url("install/filesystem.squashfs") %>
 d-i mirror/protocol string <%= repo_uri.scheme %>
 d-i mirror/country string manual
 d-i mirror/http/hostname string <%= "#{repo_uri.host}:#{repo_uri.port}" %>

--- a/tasks/ubuntu_trusty_i386.task/preseed.erb
+++ b/tasks/ubuntu_trusty_i386.task/preseed.erb
@@ -5,7 +5,7 @@ d-i netcfg/get_hostname string <%= node.hostname %>
 d-i netcfg/get_domain string <%= node.domainname %>
 d-i netcfg/no_default_route boolean true
 # This is the only line that differs from the `ubuntu` preseed file.
-d-i live-installer/net-image string <%= repo_file("install/filesystem.squashfs") %>
+d-i live-installer/net-image string <%= repo_url("install/filesystem.squashfs") %>
 d-i mirror/protocol string <%= repo_uri.scheme %>
 d-i mirror/country string manual
 d-i mirror/http/hostname string <%= "#{repo_uri.host}:#{repo_uri.port}" %>


### PR DESCRIPTION
The previous squashfs file was pointing to a local file path on the razor
server, rather than a URL to that file.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-365
