### PR TITLE
Force Sinatra version above minimum

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ source 'https://rubygems.org'
 ruby '1.9.3', :engine => 'jruby', :engine_version => '1.7.13'
 
 gem 'torquebox', '~> 3.1.1'
-gem 'sinatra'
+gem 'sinatra', '>= 1.4.4'
 gem 'sequel'
 gem 'jdbc-postgres'
 gem 'archive'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ DEPENDENCIES
   rspec-mocks (~> 2.13.1)
   sequel
   simplecov
-  sinatra
+  sinatra (>= 1.4.4)
   timecop
   torquebox (~> 3.1.1)
   torquebox-server (~> 3.1.1)


### PR DESCRIPTION
On earlier versions of Sinatra, the initrd.gz download for e.g. Ubuntu would
hang at a specific percentage because the Content-Length was not being
included. This was fixed in version 1.4.4, and so this gem should be pinned
to this version or later.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-374
