### PR TITLE
Fix `razor-admin` when run from different directory

### DIFF
--- a/bin/razor-admin
+++ b/bin/razor-admin
@@ -1,5 +1,9 @@
 #! /usr/bin/env jruby
 
+# In case this file is executed from a directory that has its own
+# Gemfile, change directories to the razor-server directory first.
+Dir.chdir File.expand_path('../..', __FILE__)
+
 require 'optparse'
 require 'bundler/setup'
 


### PR DESCRIPTION
If the directory where a user runs the `razor-admin` command
contains its own Gemfile, that Gemfile was being used instead
of razor-server's. This script will now change directories into
the razor-server directory in code.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-356
