### PR TITLE
Asynchronous execution of hooks

### DIFF
--- a/lib/razor/data/event.rb
+++ b/lib/razor/data/event.rb
@@ -26,7 +26,11 @@ module Razor::Data
     def self.log_append(entry)
       entry[:severity] ||= 'info'
       hook = entry.delete(:hook)
+      hook = Hook[id: hook] unless hook.is_a?(Hook)
       node = entry.delete(:node)
+      node = Node[id: node] unless node.is_a?(Node)
+      policy = entry.delete(:policy)
+      policy = Policy[id: policy] unless policy.is_a?(Policy)
       # Roundtrip the hash through JSON to make sure we always have the
       # same entries in the log that we would get from loading from DB
       # (otherwise we could have symbols, which will turn into strings on
@@ -34,8 +38,9 @@ module Razor::Data
       entry = JSON::parse(entry.to_json)
       hash = {
           :entry => entry,
-          :hook_id => hook ? hook.id : nil,
-          :node_id => node ? node.id : nil
+          :hook_id => hook.is_a?(Hook) && hook.exists? ? hook.id : nil,
+          :node_id => node.is_a?(Node) && node.exists? ? node.id : nil,
+          :policy_id => policy.is_a?(Policy) && policy.exists? ? policy.id : policy
       }.reject {|_, v| v.nil?}
 
       new(hash).save

--- a/lib/razor/messaging/sequel.rb
+++ b/lib/razor/messaging/sequel.rb
@@ -342,6 +342,7 @@ class Razor::Messaging::Sequel < TorqueBox::Messaging::MessageProcessor
           raise ArgumentError, _("wrong number of arguments sending %{class}.%{message} (%{count} for %{arity}") % {class: self.class, message: message, count: count, arity: arity}
         end
 
+        queue_name = arguments.delete('queue') || '/queues/razor/sequel-instance-messages'
         # Looks good, publish it; EDN encoding has reasonably good fidelity
         # for transmitting Ruby values over the wire, and this allows us to
         # enforce that during sending.
@@ -355,7 +356,7 @@ class Razor::Messaging::Sequel < TorqueBox::Messaging::MessageProcessor
           command.store('pending') if command.id.nil?
           msg['command'] = command.pk_hash
         end
-        fetch('/queues/razor/sequel-instance-messages').
+        fetch(queue_name).
           publish(msg, :encoding => :edn)
 
         return self

--- a/torquebox.rb
+++ b/torquebox.rb
@@ -24,6 +24,19 @@ TorqueBox.configure do
     end
   end
 
+  # Deploy the queue for hooks messaging, which requires sequential
+  # processing.
+  queue '/queues/razor/sequel-hooks-messages' do
+    processor Razor::Messaging::Sequel do
+      # Concurrency of 1 + singleton are crucial for the correctness
+      # of hook processing order.
+      singleton    true
+      concurrency  1
+      # For the moment, no XA support in these handlers.
+      xa           false
+    end
+  end
+
   # The naming is because we want the filename to be `ipmi.rb`.
   job Razor::ScheduledJobs::Ipmi do
     description 'IPMI power state poller'


### PR DESCRIPTION
Hooks could potentially be long-running. Previously, hooks
were run sequentially, meaning the hook must complete
before the original event can show as completed. That means
that e.g. the delete-node command would not finish/return
until all hooks for that event have completed.

Hooks will be executed sequentially on their own singleton
queue, and arguments (node, hook config, policy) will be
cached and then reloaded if necessary prior to running the
hook.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-370
