### PR TITLE
Add `--no-content` argument to `create-repo`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,10 @@
 + Help text now exists for razor-client in addition to just the API.
   This is accessible via a GET on the command's endpoint, where the
   new 'examples' key in the help text has 'api' and 'cli' as sub-keys.
++ The `create-repo` command now accepts a `--no-content` argument,
+  which signifies that neither the `--iso-url` nor the `--url`
+  arguments will be supplied, and instead an empty directory will be
+  created.
 + `create-tag` is now idempotent.
 
 ### Task changes

--- a/db/migrate/022_no-content_unique_constraint_on_repo.rb
+++ b/db/migrate/022_no-content_unique_constraint_on_repo.rb
@@ -1,0 +1,32 @@
+# -*- encoding: utf-8 -*-
+require_relative './util'
+
+# Now that the no-content option is in place, we need a way to
+# create repos without requiring `url` or `iso-url`, since
+# nothing needs to be downloaded and/or extracted. This migration
+# changes the constraint on the `repos` relation to allow both to
+# be null.
+Sequel.migration do
+  up do
+    extension(:constraint_validations)
+
+    alter_table :repos do
+      drop_constraint        :repos_url_xor_iso_url_not_null
+
+      add_constraint        :repos_url_is_null_or_iso_url_is_null,
+                            "(iso_url is null or url is null)"
+    end
+  end
+
+  down do
+    extension(:constraint_validations)
+
+    alter_table :repos do
+      drop_constraint        :repos_url_is_null_or_iso_url_is_null
+
+      add_constraint        :repos_url_xor_iso_url_not_null,
+                            "(iso_url is null and url is not null)
+        or (iso_url is not null and url is null)"
+    end
+  end
+end

--- a/doc/api.md
+++ b/doc/api.md
@@ -101,9 +101,10 @@ when the command has finished.
 
 ### Create new repo
 
-There are two flavors of repositories: ones where Razor unpacks ISO's for
-you and serves their contents, and ones that are somewhere else, for
-example, on a mirror you maintain. The first form is created by creating a
+There are three flavors of repositories: ones where Razor unpacks ISO's for
+you and serves their contents, ones that are somewhere else (For example,
+on a mirror you maintain), and ones where a stub directory is created and
+the contents can be entered manually. The first form is created by creating a
 repo with the `iso-url` property; the server will download and unpack the
 ISO image into its file system:
 
@@ -114,12 +115,24 @@ ISO image into its file system:
     }
 
 The second form is created by providing a `url` property when you create
-the repository; this form is merely a pointer to a resource somehwere and
+the repository; this form is merely a pointer to a resource somewhere and
 nothing will be downloaded onto the Razor server:
 
     {
       "name": "fedora19",
       "url": "http://mirrors.n-ix.net/fedora/linux/releases/19/Fedora/x86_64/os/"
+      "task": "noop"
+    }
+
+The third form is created by providing a `no-content` property when you
+create the repository. This format will create an empty directory in the
+repo-store directory where files can be added manually. This is useful
+for ISOs which have issues being uncompressed normally due to e.g.
+forward references:
+
+    {
+      "name": "fedora19",
+      "no-content": true
       "task": "noop"
     }
 

--- a/lib/razor/data/repo.rb
+++ b/lib/razor/data/repo.rb
@@ -54,8 +54,6 @@ module Razor::Data
       super
       if url and iso_url
         errors.add(:urls, _("only one of the 'url' and 'iso_url' attributes can be set at the same time"))
-      elsif url.nil? and iso_url.nil?
-        errors.add(:urls, _("you must set one of the 'url' or 'iso_url' attributes"))
       end
     end
 
@@ -70,12 +68,17 @@ module Razor::Data
     # @warning this should not be called inside a transaction.
     def make_the_repo_accessible(command)
       command.store('running')
-      url = URI.parse(iso_url)
-      if url.scheme.downcase == 'file'
-        File.readable?(url.path) or raise _("unable to read local file %{path}") % {path: url.path}
-        publish 'unpack_repo', command, url.path
+      if url.nil? and iso_url.nil?
+        # This is done to create a stub directory to manually install the repo.
+        publish 'unpack_repo', command, nil
       else
-        publish 'unpack_repo', command, download_file_to_tempdir(url)
+        url = URI.parse(iso_url)
+        if url.scheme.downcase == 'file'
+          File.readable?(url.path) or raise _("unable to read local file %{path}") % {path: url.path}
+          publish 'unpack_repo', command, url.path
+        else
+          publish 'unpack_repo', command, download_file_to_tempdir(url)
+        end
       end
     end
 
@@ -172,7 +175,7 @@ module Razor::Data
     def unpack_repo(command, path)
       destination = iso_location
       destination.mkpath        # in case it didn't already exist
-      Archive.extract(path, destination)
+      Archive.extract(path, destination) if path
       self.publish('release_temporary_repo', command)
     end
 


### PR DESCRIPTION
Windows ISO extraction is a current known issue.
To subvert this issue, users can manually extract
the ISO and place it in the repo_store directory.
However, previous to this commit, users would
need to enter a stub iso-url to make the
repo's directory in the repo_store. This new
`--no-content` flag will allow the creation of a
repo without an iso-url or url so the repo_store
directory can be manually configured.

For https://tickets.puppetlabs.com/browse/RAZOR-361
