### PR TITLE
(RAZOR-421) Support overriding protect_new_nodes by subnet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'jdbc-postgres'
 gem 'archive'
 gem 'hashie', '~> 2.0.5'
 gem 'fast_gettext', '~> 0.8.1'
+gem 'netaddr', '>= 1.5.0'
 
 ## support for various tasks and utility
 # This allows us to encrypt plain-text-in-the-DB passwords when they travel,

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,7 @@ GEM
     kramdown (1.2.0)
     locale (2.1.0)
     multi_json (1.8.2)
+    netaddr (1.5.0)
     parslet (1.4.0)
       blankslate (~> 2.0)
     rack (1.5.2)
@@ -103,6 +104,7 @@ DEPENDENCIES
   jdbc-postgres
   json-schema (~> 2.0)
   kramdown
+  netaddr (>= 1.5.0)
   rack-test
   rspec (~> 2.13.0)
   rspec-core (~> 2.13.1)

--- a/app.rb
+++ b/app.rb
@@ -199,7 +199,7 @@ and requires full control over the database (eg: add and remove tables):
         net_id = "net#{index - 1}"
         vars[net_id] = "${#{net_id}/mac:hexhyp}"
       end
-      ["dhcp_mac", "serial", "asset", "uuid"].each { |k| vars[k] = "${#{k}}" }
+      ["dhcp_mac", "serial", "asset", "uuid", "ip_addr"].each { |k| vars[k] = "${#{k}}" }
       q = vars.map { |k,v| "#{k}=#{v}" }.join("&")
       url "/svc/boot?#{q}"
     end

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -50,6 +50,12 @@ all:
 
   # Should newly discovered nodes be marked installed?
   protect_new_nodes: false
+  
+  # Invert the 'protect_new_nodes' value for the following subnets
+  # List subnets in the CIDR format (a.a.a.a/bb)
+  #
+  # invert_protect_new_nodes_for_subnets:
+  #   - 192.168.1.0/24
 
   # How to match nodes to possibly existing nodes in the database. The node
   # sends us the MAC addresses of its network interfaces, serial number,

--- a/lib/razor/config.rb
+++ b/lib/razor/config.rb
@@ -78,6 +78,7 @@ module Razor
       validate_rx_array("facts.match_on")
       validate_repo_store_root
       validate_match_nodes_on
+      validate_invert_protect_new_nodes_for_subnets
     end
 
     private
@@ -149,6 +150,32 @@ module Razor
       (match_on - HW_INFO_KEYS).empty? or
         raise_ice(key,
         _("must only contain '%{keys}'") % {keys: HW_INFO_KEYS.join("', '")})
+    end
+    
+    def validate_invert_protect_new_nodes_for_subnets
+      key   = 'invert_protect_new_nodes_for_subnets'
+      if value = self[key]
+        value.is_a?(Array) or
+          raise_ice(key, _("If present, must be an array"))
+
+        value.each do |net|
+          ip, mask = net.split('/')
+          ip and mask or
+            raise_ice(key, _("Values must be in the form a.a.a.a/b[b]"))
+          
+          octs = ip.split('.')
+          octs.length == 4 or
+            raise_ice(key, _("Values must be in the form a.a.a.a/b[b]"))
+
+          octs.each do |oct|
+            oct =~ /^\d+$/ and oct.to_i >= 0 and oct.to_i <= 255 or
+              raise_ice(key, _("#{net} is not a valid subnet"))
+          end
+          
+          mask =~ /^\d+$/ and mask.to_i >= 0 and mask.to_i <= 32 or
+            raise_ice(key, _("#{net} is not a valid subnet"))
+        end
+      end
     end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -39,7 +39,7 @@ describe Razor::Config do
 
     def validate(content)
       key = content.keys.first
-      # For the mandatroy keys, fill htem in with default values, unless
+      # For the mandatroy keys, fill them in with default values, unless
       # they are set to :none which indicates that the test wants to test a
       # config where that entry is entirely missing
       CONFIG_DEFAULTS.keys.each do |k|
@@ -104,6 +104,42 @@ describe Razor::Config do
             validate('repo_store_root' => "sub").should be_false
           end
         end
+      end
+    end
+
+    describe "invert_protect_new_nodes_for_subnets" do
+      it "should reject non arrays" do
+        validate("invert_protect_new_nodes_for_subnets" => "192.168.1.0/24").should be_false
+      end
+
+      it "should reject arrays that have values that are not a CIDR address" do
+        data = [
+          '192.168.2.0/255.255.255.0', #not a CIDR
+        ]
+        validate("invert_protect_new_nodes_for_subnets" => data).should be_false
+      end
+
+      it "should reject arrays that have values that are not valid IP addresses" do
+        data = [
+          '192.168.256.0/24', # 256 not valid in an IP address
+        ]
+        validate("invert_protect_new_nodes_for_subnets" => data).should be_false
+      end
+
+      it "should reject arrays that have values with invalid subnet masks" do
+        data = [
+          '192.168.2.0/33', # 33 not valid mask (max 32)
+        ]
+        validate("invert_protect_new_nodes_for_subnets" => data).should be_false
+      end
+
+      it "should accept arrays with all valid CIDRs" do
+        data = [
+          '192.168.1.0/24',
+          '172.16.0.0/16',
+          '10.0.0.0/8',
+        ]
+        validate("invert_protect_new_nodes_for_subnets" => data).should be_true
       end
     end
 

--- a/spec/data/node_spec.rb
+++ b/spec/data/node_spec.rb
@@ -262,15 +262,52 @@ describe Razor::Data::Node do
     end
   end
 
-
   context "protect_new_nodes" do
     it "should treat a new node as installed if set to true" do
       Razor.config['protect_new_nodes'] = true
+      node = Fabricate(:node_with_ip)
       node.save.reload.installed.should be_true
     end
 
     it "should treat a new node as 'not installed' if set to false" do
+      node = Fabricate(:node_with_ip)
       Razor.config['protect_new_nodes'] = false
+      node.save.reload.installed.should be_false
+    end
+
+    it "should treat a new node as installed if set to false and invert_protect_new_nodes_for_subnets contains 192.168.0.0/24" do
+      Razor.config['protect_new_nodes'] = false
+
+      #Test the NetAddr::CIDR.contains? condition
+      Razor.config['invert_protect_new_nodes_for_subnets'] = [
+        '192.168.0.0/24',
+      ]
+      node = Fabricate(:node_with_ip)
+      node.save.reload.installed.should be_true
+
+      #Test the NetAddr::CIDR.== condition for /32
+      Razor.config['invert_protect_new_nodes_for_subnets'] = [
+        '192.168.0.10/32',
+      ]
+      node = Fabricate(:node_with_ip)
+      node.save.reload.installed.should be_true
+    end
+
+    it "should treat a new node as 'not installed' if set to true and invert_protect_new_nodes_for_subnets contains 192.168.0.0/24" do
+      Razor.config['protect_new_nodes'] = true
+
+      #Test the NetAddr::CIDR.contains? condition
+      Razor.config['invert_protect_new_nodes_for_subnets'] = [
+        '192.168.0.0/24',
+      ]
+      node = Fabricate(:node_with_ip)
+      node.save.reload.installed.should be_false
+
+      #Test the NetAddr::CIDR.== condition for /32
+      Razor.config['invert_protect_new_nodes_for_subnets'] = [
+        '192.168.0.10/32',
+      ]
+      node = Fabricate(:node_with_ip)
       node.save.reload.installed.should be_false
     end
   end

--- a/spec/fabricators/fabricator.rb
+++ b/spec/fabricators/fabricator.rb
@@ -91,6 +91,11 @@ Fabricator(:node_with_metadata, from: :node) do
   metadata { { "m1" => "a" } }
 end
 
+Fabricator(:node_with_ip, from: :node) do
+  hw_info  { [ "mac=#{random_mac}", "asset=#{random_asset}" ] }
+  metadata { { "ip" => '192.168.0.10' } }
+end
+
 Fabricator(:installed_node, from: :node) do
   installed "+test"
   installed_at { Time.now }

--- a/tasks/microkernel.task/bootstrap.erb
+++ b/tasks/microkernel.task/bootstrap.erb
@@ -14,6 +14,7 @@ set maxtries:uint32 60
 <%# (see https://bugzilla.redhat.com/show_bug.cgi?id=1002734)              %>
 isset ${ip} || goto dhcp_net0
 set dhcp_mac ${mac:hexhyp}
+set ip_addr ${ip}
 goto chain_boot
 
 <% @nic_max ||= 4 %>
@@ -27,6 +28,7 @@ isset ${<%= net_id %>/mac} && dhcp <%= net_id %> || goto dhcp_net<%= index %>
 <% end %>
 echo <%= net_id %> has DHCP
 set dhcp_mac <%= net_id %>$${<%= net_id %>/mac:hexhyp}
+set ip_addr <%= net_id %>$${<%= net_id %>/ip}
 
 <% end %>
 


### PR DESCRIPTION
Adding a configuration option called 'invert_protect_new_nodes_for_subnets' that accepts a list of subnets in CIDR notation (a.a.a.a/bb) for which the 'protect_new_nodes' should be reversed.  This will allow the user to set a default protection value and then override it for specific subnets.