### PR TITLE
Use node's root_password in Windows task

### DIFF
--- a/tasks/windows.task/unattended.xml.erb
+++ b/tasks/windows.task/unattended.xml.erb
@@ -58,7 +58,7 @@
     <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <UserAccounts>
         <AdministratorPassword>
-          <Value>razor</Value>
+          <Value><%= node.root_password %></Value>
           <PlainText>true</PlainText>
         </AdministratorPassword>
       </UserAccounts>


### PR DESCRIPTION
The default Windows task for 8-pro defaulted
to 'razor' as the root password, rather than
using the property defined on the node.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-414
