### PR TITLE
(RAZOR-433) Facilitate the retrival of full objects in collection

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -512,9 +512,17 @@ and requires full control over the database (eg: add and remove tables):
   #
   # @todo danielp 2013-06-26: this should be some sort of discovery, not a
   # hand-coded list, but ... it will do, for now.
-  COLLECTIONS = [:brokers, :repos, :tags, :policies,
-                 [:nodes, {'start' => {"type" => "number"}, 'limit' => {"type" => "number"}}], :tasks, :commands,
-                 [:events, {'start' => {"type" => "number"}, 'limit' => {"type" => "number"}}], :hooks]
+  COLLECTIONS = [
+    [:nodes,    {'expand' => {"type" => "boolean"}, 'start' => {"type" => "number"}, 'limit' => {"type" => "number"}}],
+    [:events,   {'expand' => {"type" => "boolean"}, 'start' => {"type" => "number"}, 'limit' => {"type" => "number"}}], 
+    [:brokers,  {'expand' => {"type" => "boolean"}}],
+    [:repos,    {'expand' => {"type" => "boolean"}}],
+    [:tags,     {'expand' => {"type" => "boolean"}}],
+    [:policies, {'expand' => {"type" => "boolean"}}],
+    [:tasks,    {'expand' => {"type" => "boolean"}}],
+    [:commands, {'expand' => {"type" => "boolean"}}],
+    [:hooks,    {'expand' => {"type" => "boolean"}}],
+  ]
 
   #
   # The main entry point for the public/management API
@@ -568,7 +576,7 @@ and requires full control over the database (eg: add and remove tables):
   end
 
   get '/api/collections/tags' do
-    collection_view Razor::Data::Tag, "tags"
+    collection_view Razor::Data::Tag, "tags", expand: params[:expand]
   end
 
   get '/api/collections/tags/:name' do
@@ -590,7 +598,7 @@ and requires full control over the database (eg: add and remove tables):
   end
 
   get '/api/collections/brokers' do
-    collection_view Razor::Data::Broker, 'brokers'
+    collection_view Razor::Data::Broker, 'brokers', expand: params[:expand]
   end
 
   get '/api/collections/brokers/:name' do
@@ -606,7 +614,7 @@ and requires full control over the database (eg: add and remove tables):
   end
 
   get '/api/collections/policies' do
-    collection_view Razor::Data::Policy.order(:rule_number), 'policies'
+    collection_view Razor::Data::Policy.order(:rule_number), 'policies', expand: params[:expand]
   end
 
   get '/api/collections/policies/:name' do
@@ -622,7 +630,7 @@ and requires full control over the database (eg: add and remove tables):
   end
 
   get '/api/collections/tasks' do
-    collection_view Razor::Task, 'tasks'
+    collection_view Razor::Task, 'tasks', expand: params[:expand]
   end
 
   get '/api/collections/tasks/*' do |name|
@@ -636,7 +644,7 @@ and requires full control over the database (eg: add and remove tables):
   end
 
   get '/api/collections/repos' do
-    collection_view Razor::Data::Repo, 'repos'
+    collection_view Razor::Data::Repo, 'repos', expand: params[:expand]
   end
 
   get '/api/collections/repos/:name' do
@@ -647,7 +655,7 @@ and requires full control over the database (eg: add and remove tables):
 
   get '/api/collections/commands' do
     collection_view Razor::Data::Command.order(:submitted_at).reverse,
-      'commands'
+      'commands', expand: params[:expand]
   end
 
   get '/api/collections/commands/:id' do
@@ -667,7 +675,7 @@ and requires full control over the database (eg: add and remove tables):
     # Need to also order by ID here in case the granularity of timestamp is
     # not enough to maintain a consistent ordering.
     cursor = Razor::Data::Event.order(:timestamp).order(:id).reverse
-    collection_view cursor, 'events', limit: params[:limit], start: params[:start]
+    collection_view cursor, 'events', limit: params[:limit], start: params[:start], expand: params[:expand]
   end
 
   get '/api/collections/events/:id' do
@@ -681,7 +689,7 @@ and requires full control over the database (eg: add and remove tables):
   get '/api/collections/hooks' do
     check_permissions!("query:hooks")
 
-    collection_view Razor::Data::Hook, 'hooks'
+    collection_view Razor::Data::Hook, 'hooks', expand: params[:expand]
   end
 
   get '/api/collections/hooks/:name' do
@@ -702,7 +710,7 @@ and requires full control over the database (eg: add and remove tables):
   end
 
   get '/api/collections/nodes' do
-    collection_view Razor::Data::Node.search(params).order(:name), 'nodes', limit: params[:limit], start: params[:start]
+    collection_view Razor::Data::Node.search(params).order(:name), 'nodes', limit: params[:limit], start: params[:start], expand: params[:expand]
   end
 
   get '/api/collections/nodes/:name' do

--- a/spec/app/api_spec.rb
+++ b/spec/app/api_spec.rb
@@ -150,6 +150,24 @@ describe "command and query API" do
         policy.keys.should =~ %w[id name spec]
       end
     end
+
+    context "policy collection expanding" do
+      it "should state that 'expand' is a valid parameter" do
+        get '/api'
+        params = last_response.json['collections'].select {|c| c['name'] == 'policies'}.first['params']
+        params.should == {'expand' => {"type" => "boolean"}}
+      end
+
+      it "should show the full details for each item when expand is true" do
+        2.times { Fabricate(:policy, :repo => @repo) }
+        get "/api/collections/policies?expand=true"
+        last_response.status.should == 200
+
+        last_response.json['items'].each do |e|
+          e.keys.should =~ %w{spec id name broker configuration enabled nodes repo tags task}
+        end
+      end
+    end
   end
 
   context "/api/collections/policies/ID - get policy" do
@@ -201,6 +219,24 @@ describe "command and query API" do
         tag.keys.should =~ %w[id name spec]
       end
     end
+
+    context "tag collection expanding" do
+      it "should state that 'expand' is a valid parameter" do
+        get '/api'
+        params = last_response.json['collections'].select {|c| c['name'] == 'tags'}.first['params']
+        params.should == {'expand' => {"type" => "boolean"}}
+      end
+
+      it "should show the full details for each item when expand is true" do
+        2.times { Fabricate(:tag) }
+        get "/api/collections/tags?expand=true"
+        last_response.status.should == 200
+
+        last_response.json['items'].each do |e|
+          e.keys.should =~ %w{spec id name nodes policies rule}
+        end
+      end
+    end
   end
 
   context "/api/collections/tags/ID - get tag" do
@@ -231,6 +267,24 @@ describe "command and query API" do
       repos.size.should == 2
       repos.map { |repo| repo["name"] }.should =~ %w[ repo1 repo2 ]
       repos.all? { |repo| repo.keys.should =~ %w[id name spec] }
+    end
+
+    context "repo collection expanding" do
+      it "should state that 'expand' is a valid parameter" do
+        get '/api'
+        params = last_response.json['collections'].select {|c| c['name'] == 'repos'}.first['params']
+        params.should == {'expand' => {"type" => "boolean"}}
+      end
+
+      it "should show the full details for each item when expand is true" do
+        2.times { Fabricate(:repo) }
+        get "/api/collections/repos?expand=true"
+        last_response.status.should == 200
+
+        last_response.json['items'].each do |e|
+          e.keys.should =~ %w{spec id name iso_url task url}
+        end
+      end
     end
   end
 
@@ -506,6 +560,25 @@ describe "command and query API" do
 
       it_should_behave_like "a broker collection", 10
     end
+
+    context "broker collection expanding" do
+      it "should state that 'expand' is a valid parameter" do
+        get '/api'
+        params = last_response.json['collections'].select {|c| c['name'] == 'brokers'}.first['params']
+        params.should == {'expand' => {"type" => "boolean"}}
+      end
+
+      it "should show the full details for each item when expand is true" do
+        2.times { Fabricate(:broker) }
+        get "/api/collections/brokers?expand=true"
+        last_response.status.should == 200
+
+        last_response.json['items'].each do |e|
+          e.keys.should =~ %w{spec id name broker-type configuration policies}
+        end
+      end
+    end
+
   end
 
   context "/api/collections/nodes" do
@@ -737,10 +810,10 @@ describe "command and query API" do
       it_should_behave_like "a node collection", 10
     end
 
-    it "should state that 'start' and 'limit' are valid parameters" do
+    it "should state that 'start', 'limit' and 'expand' are valid parameters" do
       get '/api'
       params = last_response.json['collections'].select {|c| c['name'] == 'nodes'}.first['params']
-      params.should == {'start' => {"type" => "number"}, 'limit' => {"type" => "number"}}
+      params.should == {'start' => {"type" => "number"}, 'limit' => {"type" => "number"}, 'expand' => {"type" => "boolean"}}
     end
 
     context "limiting" do
@@ -759,6 +832,20 @@ describe "command and query API" do
         last_response.status.should == 200
 
         last_response.json['items'].map {|e| e['name']}.should == names[2..3]
+      end
+    end
+    
+    context "expanding" do
+      before :each do
+        2.times { Fabricate(:node) }
+      end
+      it "should show the full details for each item" do
+        get "/api/collections/nodes?expand=true"
+        last_response.status.should == 200
+
+        last_response.json['items'].each do |e|
+          e.keys.should =~ %w{spec id name hw_info state log tags}
+        end
       end
     end
   end
@@ -953,6 +1040,24 @@ describe "command and query API" do
       last_response.json['errors'][0]['message'].should == "Exception 1"
       last_response.json['errors'][1]['message'].should == "Exception 2"
     end
+
+    context "command collection expanding" do
+      it "should state that 'expand' is a valid parameter" do
+        get '/api'
+        params = last_response.json['collections'].select {|c| c['name'] == 'commands'}.first['params']
+        params.should == {'expand' => {"type" => "boolean"}}
+      end
+
+      it "should show the full details for each item when expand is true" do
+        2.times { Fabricate(:command) }
+        get "/api/collections/commands?expand=true"
+        last_response.status.should == 200
+
+        last_response.json['items'].each do |e|
+          e.keys.should =~ %w{spec id name command errors status submitted_at}
+        end
+      end
+    end
   end
 
   context "/api/collections/hooks" do
@@ -1077,6 +1182,24 @@ describe "command and query API" do
       end
 
       it_should_behave_like "a hook collection", 10
+    end
+
+    context "hook collection expanding" do
+      it "should state that 'expand' is a valid parameter" do
+        get '/api'
+        params = last_response.json['collections'].select {|c| c['name'] == 'hooks'}.first['params']
+        params.should == {'expand' => {"type" => "boolean"}}
+      end
+
+      it "should show the full details for each item when expand is true" do
+        2.times { Fabricate(:hook) }
+        get "/api/collections/hooks?expand=true"
+        last_response.status.should == 200
+
+        last_response.json['items'].each do |e|
+          e.keys.should =~ %w{spec id name hook-type log}
+        end
+      end
     end
   end
 
@@ -1244,10 +1367,10 @@ describe "command and query API" do
     end
 
     context "event limiting" do
-      it "should state that 'start' and 'limit' are valid parameters" do
+      it "should state that 'start', 'limit' and 'expand' are valid parameters" do
         get '/api'
         params = last_response.json['collections'].select {|c| c['name'] == 'events'}.first['params']
-        params.should == {'start' => {"type" => "number"}, 'limit' => {"type" => "number"}}
+        params.should == {'start' => {"type" => "number"}, 'limit' => {"type" => "number"}, 'expand' => {"type" => "boolean"}}
       end
       it "should view all results by default" do
         21.times { Fabricate(:event) }
@@ -1298,6 +1421,18 @@ describe "command and query API" do
         events.count.should == 4
         last_response.json['total'].should == 6
         validate! ObjectRefCollectionSchema, last_response.body
+      end
+    end
+
+    context "event collection expanding" do
+      it "should show the full details for each item when expand is true" do
+        2.times { Fabricate(:event) }
+        get "/api/collections/events?expand=true"
+        last_response.status.should == 200
+
+        last_response.json['items'].each do |e|
+          e.keys.should =~ %w{spec id name timestamp entry severity node policy}
+        end
       end
     end
   end


### PR DESCRIPTION
Add an "expand" parameter to collections so that the full opbjects are listed in a collection. E.g. /api/collections/nodes?expand=true will return all nodes with all their details.

This will better support interface integration to the API where previously, one would have to issue a call against the nodes collection and then another call for each of the nodes returned to build the full picture.  This allows the same in one call.
