### PR TITLE
Fixing entry serialization

### DIFF
--- a/lib/razor/data/event.rb
+++ b/lib/razor/data/event.rb
@@ -46,5 +46,21 @@ module Razor::Data
 
       new(hash).save
     end
+
+    # This is a hack around the fact that the auto_validates plugin does
+    # not play nice with the JSON serialization plugin (the serializaton
+    # happens in the before_save hook, which runs after validation)
+    #
+    # To avoid spurious error messages, we tell the validation machinery to
+    # expect a Hash
+    #
+    # FIXME: Figure out a way to address this issue upstream
+    def schema_type_class(k)
+      if k == :entry
+        Hash
+      else
+        super
+      end
+    end
   end
 end

--- a/spec/data/event_spec.rb
+++ b/spec/data/event_spec.rb
@@ -1,0 +1,26 @@
+# -*- encoding: utf-8 -*-
+require 'spec_helper'
+
+describe Razor::Data::Event do
+  describe "entry" do
+    it "should require that entry is present" do
+      expect { Razor::Data::Event.new.save }.
+          to raise_error(Sequel::ValidationFailed, 'entry is not present')
+    end
+
+    it "should accept and save an empty hash" do
+      Razor::Data::Event.new(
+          :entry => {}
+      ).save
+    end
+
+    it "should round-trip a rich entry" do
+      entry = {"one" => 1, "two" => 2.0, "three" => ['a', {'b'=>'b'}, ['c']]}
+      Fabricate(:node).log_append(entry)
+
+      # Round-trip to avoid symbol vs. string key comparison issues.
+      entry = JSON.parse(Razor::Data::Event.last.entry.to_json)
+      entry.should == entry
+    end
+  end
+end


### PR DESCRIPTION
The same serialization issue that has affected policies, hooks, etc. also
affected events. The validation plugin was validating an object before
the serialization plugin acts on the object to make it valid.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-439