### PR TITLE
fix subtle weird hyphen ultimate time sink problem

### DIFF
--- a/tasks/windows.task/second-stage.ps1.erb
+++ b/tasks/windows.task/second-stage.ps1.erb
@@ -32,7 +32,7 @@ write-host "notify Razor that the installer completed"
 write-host "download broker script"
 $broker_url = "<%= broker_install_url('install.ps1') %>"
 # This file needs to have a .ps1 extension for when it's passed to Powershell.
-$broker_path = [IO.Path]::GetTempFileName() | Rename-Item -NewName { $_ -replace 'tmp$', 'ps1' } –PassThru
+$broker_path = [IO.Path]::GetTempFileName() | Rename-Item -NewName { $_ -replace 'tmp$', 'ps1' } -PassThru
 (new-object System.Net.WebClient).DownloadFile($broker_url, $broker_path)
 
 write-host "set broker to run after reboot"


### PR DESCRIPTION
note the corrected hyphen before PassThru. It's subtle but it was erroneously an en dash instead of a hyphen (you can see it was ever so slightly longer). It was breaking the script.