### PR TITLE
Securing /api endpoint with `secure_api` config

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # Razor Server Release Notes
 
+## Next - TBD
+
++ NEW: The `secure_api` config property can be used to ensure that
+  communications with /api are secure. When this is true, all calls to the
+  namespace need to be over HTTPS with SSL, and otherwise will return a 404.
+  The actual configuration of this happens in Torquebox's configuration. By
+  default, this property is false (no change from current behavior).
+
 ## 0.16.1 - 2015-01-12
 
 ### Other

--- a/app.rb
+++ b/app.rb
@@ -64,6 +64,10 @@ and requires full control over the database (eg: add and remove tables):
     # --daniel 2013-06-26
     request.preferred_type('application/json') or
       halt [406, {"error" => _("only application/json content is available")}.to_json]
+
+    if Razor.config['secure_api']
+      request.secure? or halt [404, {"error" => _("API requests must be over SSL (secure_api config property is enabled)")}.to_json]
+    end
   end
 
   #

--- a/build-winpe/build-razor-winpe.ps1
+++ b/build-winpe/build-razor-winpe.ps1
@@ -1,13 +1,13 @@
 # -*- powershell -*-
 # Run this script as:
 #   powershell -executionpolicy bypass -file build-razor-winpe.ps1 \
-#     -razorurl http://razor:8080/svc -workdir C:\build-winpe
+#     -razorurl http://razor:8150/svc -workdir C:\build-winpe
 #
 # Produce a WinPE image suitable for use with Razor
 
 # Parameters
 #   - razorurl: the URL of the Razor server, something like
-#     http://razor-server:8080/svc (note the /svc at the end, not /api)
+#     http://razor-server:8150/svc (note the /svc at the end, not /api)
 #   - workdir: where to create the WinPE image and intermediate files
 #              Defaults to the directory containing this script
 param([String] $workdir, [Parameter(Mandatory=$true)][String] $razorurl)

--- a/build-winpe/razor-client.ps1
+++ b/build-winpe/razor-client.ps1
@@ -1,7 +1,7 @@
 # -*- powershell -*-
 
 # If we have a configuration file, source it in. The file must set
-# $baseurl to something like http://razor:8080/svc
+# $baseurl to something like http://razor:8150/svc
 $configfile = join-path $env:SYSTEMDRIVE "razor-client-config.ps1"
 if (test-path $configfile) {
     write-host "sourcing configuration from $configfile"
@@ -22,7 +22,7 @@ if (test-path $configfile) {
                   select -uniq -first 1 -expandproperty dhcpserver
 
     write-host "using server $server"
-    $baseurl = "http://${server}:8080/svc"
+    $baseurl = "http://${server}:8150/svc"
 }
 
 # Figure out our node hardware ID details, since we can't get at anything more

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -48,6 +48,10 @@ all:
     #
     # extension-zip: /etc/razor/mk-extension.zip
 
+  # Should communications with /api be secured? This property determines
+  # whether to require HTTPS/SSL when making calls in the /api namespace.
+  secure_api: false
+
   # Should newly discovered nodes be marked installed?
   protect_new_nodes: false
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -9,7 +9,7 @@ As developers, we promise good compatibility and support for your client if
 you follow the simple rule: use navigation, rather than client-side knowledge
 of the URL structure.
 
-To do that, implement any action by starting at `http://razor:8080/api`,
+To do that, implement any action by starting at `https://razor:8150/api`,
 rather than anywhere else in the API namespace.  This document then allows you
 to navigate -- much like a web browser can navigate a website -- through the
 various query options available to you.
@@ -53,7 +53,7 @@ type on the same server.
 
 ### `/api` document reference
 
-When you fetch `http://razor:8080/api`, you fetch the top level entry point
+When you fetch `https://razor:8150/api`, you fetch the top level entry point
 for navigating through our command and query facilities.  The structure of
 this document is a JSON object with the following keys:
 
@@ -612,14 +612,14 @@ key-value pairs. For example, here is a sample tag listing:
 
     [
       {
-        "spec": "http://localhost:8080/spec/object/tag",
-        "id": "http://localhost:8080/api/collections/objects/14",
+        "spec": "https://localhost:8150/spec/object/tag",
+        "id": "https://localhost:8150/api/collections/objects/14",
         "name": "virtual",
         "rule": [ "=", [ "fact", "is_virtual" ], true ]
       },
       {
-        "spec": "http://localhost:8080/spec/object/tag",
-        "id": "http://localhost:8080/api/collections/objects/27",
+        "spec": "https://localhost:8150/spec/object/tag",
+        "id": "https://localhost:8150/api/collections/objects/27",
         "name": "group 4",
         "rule": [
           "in", [ "fact", "dhcp_mac" ],
@@ -658,7 +658,7 @@ For example the UUID could be queried to return the associated node
     {
       "items": [
         {
-            "id": "http://razor.example.com:8080/api/collections/nodes/node14",
+            "id": "https://razor.example.com:8150/api/collections/nodes/node14",
             "name": "node14",
             "spec": "http://api.puppetlabs.com/razor/v1/collections/nodes/member"
         }],

--- a/spec/app/api_spec.rb
+++ b/spec/app/api_spec.rb
@@ -119,6 +119,30 @@ describe "command and query API" do
         last_response.status.should == 200
       end
     end
+
+    describe "securing /api" do
+      it "should allow secure when secure_api is true" do
+        Razor.config['secure_api'] = true
+        get "/api", {}, 'HTTPS' => 'on'
+        last_response.status.should == 200
+      end
+      it "should allow secure when secure_api is false" do
+        Razor.config['secure_api'] = false
+        get "/api", {}, 'HTTPS' => 'on'
+        last_response.status.should == 200
+      end
+      it "should disallow insecure when secure_api is true" do
+        Razor.config['secure_api'] = true
+        get "/api", {}, 'HTTPS' => 'off'
+        last_response.status.should == 404
+        last_response.json['error'].should == 'API requests must be over SSL (secure_api config property is enabled)'
+      end
+      it "should allow insecure when secure_api is false" do
+        Razor.config['secure_api'] = false
+        get "/api", {}, 'HTTPS' => 'off'
+        last_response.status.should == 200
+      end
+    end
   end
 
   context "/api/collections/policies - policy list" do


### PR DESCRIPTION
The /api namespace would benefit from security control. The actual configuring
of ports and certificates is done in Torquebox configuration, but we can ensure
that communications are secure in each call to /api endpoints. This change adds
a config property called `secure_api` that, when enabled, returns a 401
(Unauthorized) when an /api endpoint is called without HTTPS. By default,
this is disabled (same as current behavior).

Fixes https://tickets.puppetlabs.com/browse/RAZOR-487