### PR TITLE
(RAZOR-499) Support Structured Metadata

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -537,6 +537,16 @@ however, clear can only be done on its own (it doesnt make sense to
 update some details and then clear everything).  An error will also be
 returned if an attempt is made to update and remove the same key.
 
+Note that metadata values can also be structured data specified as native
+JSON or as a valid JSON string.  E.g:
+
+    {
+        "node": "node1",
+        "update": {
+            "key1": [ "list", "of", "values" ],
+        }
+    }
+
 ### Update node metadata
 
 The `update-node-metadata` command is a shortcut to `modify-node-metadata`
@@ -548,6 +558,15 @@ request with a simple data structure that looks like.
         "key"       : "my_key",
         "value"     : "my_val",
         "no_replace": true       #Optional. Will not replace existing keys
+    }
+
+Note that metadata values can also be structured data specified as native
+JSON or as a valid JSON string.  E.g:
+
+    {
+        "node"      : "mode1",
+        "key"       : "my_key",
+        "value"     : "[ "list", "of", "values" ]",
     }
 
 ### Remove Node Metadata

--- a/lib/razor/command/modify_node_metadata.rb
+++ b/lib/razor/command/modify_node_metadata.rb
@@ -7,6 +7,8 @@ Node metadata can be added, changed, or removed with this command; it contains
 a limited editing language to make changes to the existing metadata in an
 atomic fashion.
 
+Values to keys in update operations can be structured data such as arrays and hashes.
+
 It can also clear all metadata from a node, although that operation is
 exclusive to all other editing operations, and cannot be performed atomically
 with them.
@@ -20,7 +22,7 @@ modify an existing value already present on a node:
         "node": "node1",
         "update": {
             "key1": "value1",
-            "key2": "value2"
+            "key2": [ "val1", "val2", "val3" ]
         }
         "remove": ["key3", "key4"],
         "no-replace": true
@@ -36,7 +38,7 @@ Editing node metadata, by adding and removing some keys, but refusing to
 modify an existing value already present on a node:
 
     razor modify-node-metadata --node node1 --update key1=value1 \\
-        --update key2=value2 --remove key3 --remove key4 --noreplace
+        --update key2='[ "val1", "val2", "val3" ]' --remove key3 --remove key4 --noreplace
 
 Removing all node metadata:
 

--- a/lib/razor/data/node.rb
+++ b/lib/razor/data/node.rb
@@ -291,8 +291,17 @@ module Razor::Data
       if data['update']
         data['update'].is_a? Hash or raise ArgumentError, _('update must be a hash')
         replace = (not [true, 'true'].include?(data['no_replace']))
+
         data['update'].each do |k,v|
-          new_metadata[k] = v if replace or not new_metadata[k]
+          if replace or not new_metadata[k]
+            begin
+              # If the value is valid json, parse it and store as structured
+              new_metadata[k] = JSON::parse(v)
+            rescue
+              # Otherwise just store the data as is.
+              new_metadata[k] = v
+            end
+          end
         end
       end
       if data['remove']

--- a/spec/app/modify_node_metadata_spec.rb
+++ b/spec/app/modify_node_metadata_spec.rb
@@ -142,6 +142,24 @@ describe Razor::Command::ModifyNodeMetadata do
       node_metadata['k2'].should == 'v2'
       node_metadata['k3'].should == 'v3'
     end
+
+    it "should store valid json values as structured data" do
+      id = node.id
+      data = { 'node' => "node#{id}", 'update' => { 'k1' => '{"innerkey1": "innerval1"}'} }
+      modify_metadata(data)
+      last_response.status.should == 202
+      node_metadata = Node[:id => id].metadata
+      node_metadata['k1'].should == { "innerkey1" => "innerval1" }
+    end
+
+    it "should store structured values as structured data" do
+      id = node.id
+      data = { 'node' => "node#{id}", 'update' => { 'k1' => {"innerkey1" => "innerval1"} } }
+      modify_metadata(data)
+      last_response.status.should == 202
+      node_metadata = Node[:id => id].metadata
+      node_metadata['k1'].should == { "innerkey1" => "innerval1" }
+    end
   end
 
   describe "when removing metadata from a node" do


### PR DESCRIPTION
This allows for structured data to be stored as values to metadata similar to structured facts.

The values can be specified as native json where raw json is being sent to the api, or as a single quoted string on the command line.