### PR TITLE
Standardize API argument names from '-' to '_'

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -105,12 +105,12 @@ There are three flavors of repositories: ones where Razor unpacks ISO's for
 you and serves their contents, ones that are somewhere else (For example,
 on a mirror you maintain), and ones where a stub directory is created and
 the contents can be entered manually. The first form is created by creating a
-repo with the `iso-url` property; the server will download and unpack the
+repo with the `iso_url` property; the server will download and unpack the
 ISO image into its file system:
 
     {
       "name": "fedora19",
-      "iso-url": "file:///tmp/Fedora-19-x86_64-DVD.iso"
+      "iso_url": "file:///tmp/Fedora-19-x86_64-DVD.iso"
       "task": "puppet"
     }
 
@@ -191,10 +191,10 @@ To create a broker, clients post the following to the `create-broker` URL:
          "server": "puppet.example.org",
          "environment": "production"
       },
-      "broker-type": "puppet"
+      "broker_type": "puppet"
     }
 
-The `broker-type` must correspond to a broker that is present on the
+The `broker_type` must correspond to a broker that is present on the
 `broker_path` set in `config.yaml`.
 
 The permissible settings for the `configuration` hash depend on the broker
@@ -320,7 +320,7 @@ accept the same body, consisting of the name of the policy in question:
       "name": "a policy"
     }
 
-### Modify the max-count for a policy
+### Modify the max_count for a policy
 
 The command `modify-policy-max-count` makes it possible to manipulate how
 many nodes can be bound to a specific policy at the most. The body of the
@@ -328,7 +328,7 @@ request should be of the form:
 
     {
       "name": "a policy"
-      "max-count": new-count
+      "max_count": new-count
     }
 
 The `new-count` can be an integer, which must be larger than the number of
@@ -365,13 +365,13 @@ reboot.
 ### Create hook
 
 A hook can be created with the `create-hook` command.  It accepts the name
-of a single hook, plus the `hook-type` which references existing code
+of a single hook, plus the `hook_type` which references existing code
 on the Razor server's `hooks` directory, and an optional starting
-configuration corresponding to that hook-type:
+configuration corresponding to that hook_type:
 
     {
       "name": "myhook",
-      "hook-type": "some_hook",
+      "hook_type": "some_hook",
       "configuration": {"foo": 7, "bar": "rhubarb"}
     }
 
@@ -430,9 +430,9 @@ The structure of a request is:
 
     {
       "name": "node17",
-      "ipmi-hostname": "bmc17.example.com",
-      "ipmi-username": null,
-      "ipmi-password": "sekretskwirrl"
+      "ipmi_hostname": "bmc17.example.com",
+      "ipmi_username": null,
+      "ipmi_password": "sekretskwirrl"
     }
 
 The various IPMI fields can be null (representing no value, or the NULL

--- a/doc/hooks.md
+++ b/doc/hooks.md
@@ -26,7 +26,7 @@ directory and optional event scripts within that directory:
 
 The `create-hook` command is used to create a hook object from a hook type:
 
-    > razor create-hook --name myhook --hook-type some_hook \
+    > razor create-hook --name myhook --hook_type some_hook \
         --configuration foo=7 --configuration bar=rhubarb
 
 The hook object created by this command will track changes to the hook's
@@ -286,7 +286,7 @@ the configuration on the hook object:
 That completes the hook type. Next, we'll create the hook object which will
 store the configuration via:
 
-    razor create-hook --name counter --hook-type counter
+    razor create-hook --name counter --hook_type counter
 
 Since the configuration is absent from this creation call, the default value
 of 0 in `configuration.yaml` is used. Alternatively, this could be set using

--- a/lib/razor/command/create_broker.rb
+++ b/lib/razor/command/create_broker.rb
@@ -16,7 +16,7 @@ Creating a simple Puppet broker:
          "server":      "puppet.example.org",
          "environment": "production"
       },
-      "broker-type": "puppet"
+      "broker_type": "puppet"
     }
   EOT
 
@@ -35,7 +35,7 @@ Creating a simple Puppet broker:
     which broker the node will be handed off via after installation.
   HELP
 
-  attr 'broker-type', required: true, type: String, references: [Razor::BrokerType, :name],
+  attr 'broker_type', required: true, type: String, references: [Razor::BrokerType, :name],
                       help: _(<<-HELP)
     The broker type from which this broker is created.  The available
     broker types on your server are:
@@ -44,7 +44,7 @@ Creating a simple Puppet broker:
 
   object 'configuration', help: _(<<-HELP) do
     The configuration for the broker.  The acceptable values here are
-    determined by the `broker-type` selected.  In general this has
+    determined by the `broker_type` selected.  In general this has
     settings like which server to contact, and other configuration
     related to handing on the newly installed system to the final
     configuration management system.
@@ -55,8 +55,7 @@ Creating a simple Puppet broker:
   end
 
   def run(request, data)
-    type = data.delete("broker-type")
-    data["broker_type"] = Razor::BrokerType.find(name: type)
+    data["broker_type"] = Razor::BrokerType.find(name: data.delete("broker_type"))
 
     Razor::Data::Broker.import(data).first
   end
@@ -64,7 +63,8 @@ Creating a simple Puppet broker:
   def self.conform!(data)
     data.tap do |_|
       # Allow "c" as a shorthand.
-      add_hash_alias(data, 'configuration', 'c')
+      add_hash_alias(data, 'c', 'configuration')
+      add_alias(data, 'broker-type', 'broker_type')
     end
   end
 end

--- a/lib/razor/command/create_broker.rb
+++ b/lib/razor/command/create_broker.rb
@@ -42,7 +42,7 @@ Creating a simple Puppet broker:
 #{Razor::BrokerType.all.map{|n| "    - #{n}" }.join("\n")}
   HELP
 
-  object 'configuration', help: _(<<-HELP) do
+  object 'configuration', alias: 'c', help: _(<<-HELP) do
     The configuration for the broker.  The acceptable values here are
     determined by the `broker_type` selected.  In general this has
     settings like which server to contact, and other configuration
@@ -58,14 +58,6 @@ Creating a simple Puppet broker:
     data["broker_type"] = Razor::BrokerType.find(name: data.delete("broker_type"))
 
     Razor::Data::Broker.import(data).first
-  end
-
-  def self.conform!(data)
-    data.tap do |_|
-      # Allow "c" as a shorthand.
-      add_hash_alias(data, 'c', 'configuration')
-      add_alias(data, 'broker-type', 'broker_type')
-    end
   end
 end
 

--- a/lib/razor/command/create_hook.rb
+++ b/lib/razor/command/create_hook.rb
@@ -34,7 +34,7 @@ Create a simple hook:
 #{Razor::HookType.all.map{|n| "    - #{n}" }.join("\n")}
   HELP
 
-  object 'configuration', help: _(<<-HELP) do
+  object 'configuration', alias: 'c', help: _(<<-HELP) do
     The configuration for the hook.  The acceptable values here are
     determined by the `hook_type` selected.  In general this has
     settings like a node counter or other settings which may change
@@ -49,14 +49,6 @@ Create a simple hook:
     data["hook_type"] = Razor::HookType.find(name: data.delete("hook_type"))
 
     Razor::Data::Hook.import(data).first
-  end
-
-  def self.conform!(data)
-    data.tap do |_|
-      # Allow "c" as a shorthand.
-      add_hash_alias(data, 'c', 'configuration')
-      add_alias(data, 'hook-type', 'hook_type')
-    end
   end
 end
 

--- a/lib/razor/command/create_hook.rb
+++ b/lib/razor/command/create_hook.rb
@@ -11,7 +11,7 @@ Create a simple hook:
 
     {
       "name": "myhook",
-      "hook-type": "some_hook",
+      "hook_type": "some_hook",
       "configuration": {"foo": 7, "bar": "rhubarb"}
     }
   EOT
@@ -27,7 +27,7 @@ Create a simple hook:
   attr  'name', type: String, required: true, size: 1..Float::INFINITY,
                 help: _('The name of the tag.')
 
-  attr 'hook-type', required: true, type: String, references: [Razor::HookType, :name],
+  attr 'hook_type', required: true, type: String, references: [Razor::HookType, :name],
        help: _(<<-HELP)
     The hook type from which this hook is created.  The available
     hook types on your server are:
@@ -36,7 +36,7 @@ Create a simple hook:
 
   object 'configuration', help: _(<<-HELP) do
     The configuration for the hook.  The acceptable values here are
-    determined by the `hook-type` selected.  In general this has
+    determined by the `hook_type` selected.  In general this has
     settings like a node counter or other settings which may change
     over time as the hook gets executed.
 
@@ -46,8 +46,7 @@ Create a simple hook:
   end
 
   def run(request, data)
-    type = data.delete("hook-type")
-    data["hook_type"] = Razor::HookType.find(name: type)
+    data["hook_type"] = Razor::HookType.find(name: data.delete("hook_type"))
 
     Razor::Data::Hook.import(data).first
   end
@@ -55,7 +54,8 @@ Create a simple hook:
   def self.conform!(data)
     data.tap do |_|
       # Allow "c" as a shorthand.
-      add_hash_alias(data, 'configuration', 'c')
+      add_hash_alias(data, 'c', 'configuration')
+      add_alias(data, 'hook-type', 'hook_type')
     end
   end
 end

--- a/lib/razor/command/create_policy.rb
+++ b/lib/razor/command/create_policy.rb
@@ -77,7 +77,7 @@ A sample policy installing CentOS 6.4:
     The name of the policy to create this policy after in the policy list.
   HELP
 
-  array 'tags', help: _(<<-HELP) do
+  array 'tags', alias: 'tag', help: _(<<-HELP) do
     The names of tags that are used for matching nodes to this policy.
 
     When a node has all these tags matched on it, it will be a candidate
@@ -133,10 +133,6 @@ A sample policy installing CentOS 6.4:
 
     data["enabled"] = true if data["enabled"].nil?
 
-    data["max_count"] = data.delete("max_count") if data.has_key?("max_count")
-    data["root_password"] = data.delete("root_password") if data.has_key?("root_password")
-    data["node_metadata"] = data.delete("node_metadata") if data.has_key?("node_metadata")
-
     # Create the policy
     policy, is_new = Razor::Data::Policy.import(data)
 
@@ -154,10 +150,8 @@ A sample policy installing CentOS 6.4:
       data['before'] = data['before']['name'] if data['before'].is_a?(Hash) and data['before'].keys == ['name']
       data['after'] = data['after']['name'] if data['after'].is_a?(Hash) and data['after'].keys == ['name']
 
-      data['tag'] = Array[data['tag']] unless [NilClass, Array, Hash].include?(data['tag'].class)
       data['tags'] = Array[data['tags']] unless [NilClass, Array, Hash].include?(data['tags'].class)
-      add_array_alias(data, 'tag', 'tags')
-      
+
       # Removed feature: Cannot create tags in create-policy
       if data['tags'].is_a?(Array) && data['tags'].any? {|tag_pair| tag_pair.is_a?(Hash) and tag_pair.keys == ['name', 'rule'] }
         raise Razor::ValidationFailure, _('this command can no longer create tags; see `razor help create-tag`')
@@ -169,10 +163,6 @@ A sample policy installing CentOS 6.4:
       data['repo'] = data['repo']['name'] if data['repo'].is_a?(Hash) and data['repo'].keys == ['name']
       data['broker'] = data['broker']['name'] if data['broker'].is_a?(Hash) and data['broker'].keys == ['name']
       data['task'] = data['task']['name'] if data['task'].is_a?(Hash) and data['task'].keys == ['name']
-
-      add_alias(data, 'root-password', 'root_password')
-      add_alias(data, 'node-metadata', 'node_metadata')
-      add_alias(data, 'max-count', 'max_count')
     end
   end
 end

--- a/lib/razor/command/create_policy.rb
+++ b/lib/razor/command/create_policy.rb
@@ -23,11 +23,11 @@ A sample policy installing CentOS 6.4:
       "broker":        "noop",
       "enabled":       true,
       "hostname":      "host${id}.example.com",
-      "root-password": "secret",
-      "max-count":     20,
+      "root_password": "secret",
+      "max_count":     20,
       "before":        "other policy",
       "tags":          ["small"],
-      "node-metadata": {"key": "value"}
+      "node_metadata": {"key": "value"}
     }
   EOT
 
@@ -56,7 +56,7 @@ A sample policy installing CentOS 6.4:
     - id -- the internal node ID number
   HELP
 
-  attr 'root-password', required: true, type: String, size: 1..Float::INFINITY, help: _(<<-HELP)
+  attr 'root_password', required: true, type: String, size: 1..Float::INFINITY, help: _(<<-HELP)
     The root password for newly installed systems.  This is passed directly
     to the individual task, rather than "understood" by the server, so the
     valid values are dependent on the individual task capabilities.
@@ -64,7 +64,7 @@ A sample policy installing CentOS 6.4:
 
   attr 'enabled', type: :bool, help: _('Is this policy enabled when first created?')
 
-  attr 'max-count', type: Integer, help: _(<<-HELP)
+  attr 'max_count', type: Integer, help: _(<<-HELP)
     The maximum number of nodes that can bind to this policy.
     If omitted, the policy is 'unlimited', and no maximum is applied.
   HELP
@@ -105,7 +105,7 @@ A sample policy installing CentOS 6.4:
     match the selected repo, as it references files contained within that repository.
   HELP
 
-  attr 'node-metadata', type: Hash, help: _(<<-HELP)
+  attr 'node_metadata', type: Hash, help: _(<<-HELP)
     Allows a policy to apply metadata to a node when it binds. This is NON
     AUTHORITATIVE in that it will not replace existing metadata on the node
     with the same keys it will only add keys that are missing.
@@ -133,9 +133,9 @@ A sample policy installing CentOS 6.4:
 
     data["enabled"] = true if data["enabled"].nil?
 
-    data["max_count"] = data.delete("max-count") if data.has_key?("max-count")
-    data["root_password"] = data.delete("root-password") if data.has_key?("root-password")
-    data["node_metadata"] = data.delete("node-metadata") if data.has_key?("node-metadata")
+    data["max_count"] = data.delete("max_count") if data.has_key?("max_count")
+    data["root_password"] = data.delete("root_password") if data.has_key?("root_password")
+    data["node_metadata"] = data.delete("node_metadata") if data.has_key?("node_metadata")
 
     # Create the policy
     policy, is_new = Razor::Data::Policy.import(data)
@@ -156,7 +156,7 @@ A sample policy installing CentOS 6.4:
 
       data['tag'] = Array[data['tag']] unless [NilClass, Array, Hash].include?(data['tag'].class)
       data['tags'] = Array[data['tags']] unless [NilClass, Array, Hash].include?(data['tags'].class)
-      add_array_alias(data, 'tags', 'tag')
+      add_array_alias(data, 'tag', 'tags')
       
       # Removed feature: Cannot create tags in create-policy
       if data['tags'].is_a?(Array) && data['tags'].any? {|tag_pair| tag_pair.is_a?(Hash) and tag_pair.keys == ['name', 'rule'] }
@@ -169,9 +169,10 @@ A sample policy installing CentOS 6.4:
       data['repo'] = data['repo']['name'] if data['repo'].is_a?(Hash) and data['repo'].keys == ['name']
       data['broker'] = data['broker']['name'] if data['broker'].is_a?(Hash) and data['broker'].keys == ['name']
       data['task'] = data['task']['name'] if data['task'].is_a?(Hash) and data['task'].keys == ['name']
-      data['root-password'] = data.delete('root_password') if data['root_password']
-      data['max-count'] = data.delete('max_count') if data['max_count']
-      data['node-metadata'] = data.delete('node_metadata') if data['node_metadata']
+
+      add_alias(data, 'root-password', 'root_password')
+      add_alias(data, 'node-metadata', 'node_metadata')
+      add_alias(data, 'max-count', 'max_count')
     end
   end
 end

--- a/lib/razor/command/create_repo.rb
+++ b/lib/razor/command/create_repo.rb
@@ -106,7 +106,6 @@ downloaded onto the Razor server:
 
   def self.conform!(data)
     data.tap do |_|
-      add_alias(data, 'iso-url', 'iso_url')
       data['task'] = data['task']['name'] if data['task'].is_a?(Hash) and data['task'].keys == ['name']
     end
   end

--- a/lib/razor/command/create_repo.rb
+++ b/lib/razor/command/create_repo.rb
@@ -12,7 +12,7 @@ by the razor-server in the background:
 
     {
       "name":    "fedora19",
-      "iso-url": "http://example.com/Fedora-19-x86_64-DVD.iso"
+      "iso_url": "http://example.com/Fedora-19-x86_64-DVD.iso"
       "task":    "fedora"
     }
 
@@ -20,7 +20,7 @@ You can also unpack an ISO image from a file *on the server*; this does not
 upload the file from the client:
     {
       "name":    "fedora19",
-      "iso-url": "file:///tmp/Fedora-19-x86_64-DVD.iso"
+      "iso_url": "file:///tmp/Fedora-19-x86_64-DVD.iso"
       "task":    "fedora"
     }
 
@@ -63,10 +63,10 @@ downloaded onto the Razor server:
   attr  'name', type: String, required: true, size: 1..250,
                 help: _('The name of the repository.')
 
-  attr 'url', type: URI, exclude: ['iso-url', 'no-content'], size: 1..1000,
+  attr 'url', type: URI, exclude: ['iso_url', 'no_content'], size: 1..1000,
               help: _('The URL of the remote repository to use.')
 
-  attr 'iso-url', type: URI, exclude: ['url', 'no-content'], size: 1..1000, help: _(<<-HELP)
+  attr 'iso_url', type: URI, exclude: ['url', 'no_content'], size: 1..1000, help: _(<<-HELP)
     The URL of the ISO image to download and unpack to create the
     repository.  This can be an HTTP or HTTPS URL, or it can be a
     file URL.
@@ -77,7 +77,7 @@ downloaded onto the Razor server:
     command.
   HELP
 
-  attr 'no-content', type: TrueClass, exclude: ['iso-url', 'url'], help: _(<<-HELP)
+  attr 'no_content', type: TrueClass, exclude: ['iso_url', 'url'], help: _(<<-HELP)
     For cases where extraction will be done manually, this argument
     creates a stub directory in the repo store where the extracted
     contents can be placed.
@@ -86,27 +86,27 @@ downloaded onto the Razor server:
   attr 'task', type: String, required: true, help: _(<<-HELP)
     The name of the task associated with this repository.  This is used to
     install nodes that match a policy using this repository; generally it
-    should match the OS that the URL or ISO-URL attributes point to.
+    should match the OS that the URL or ISO_URL attributes point to.
   HELP
 
-  require_one_of 'url', 'iso-url', 'no-content'
+  require_one_of 'url', 'iso_url', 'no_content'
 
   def run(request, data)
     # Create our shiny new repo.  This will implicitly, thanks to saving
     # changes, trigger our loading saga to begin.  (Which takes place in the
     # same transactional context, ensuring we don't send a message to our
     # background workers without also committing this data to our database.)
-    data["iso_url"] = data.delete("iso-url")
     data["task_name"] = data.delete("task")
 
-    # Remove this; it just helped bypass `url` and `iso-url`.
-    data.delete('no-content')
+    # Remove this; it just helped bypass `url` and `iso_url`.
+    data.delete('no_content')
 
     Razor::Data::Repo.import(data, @command).first
   end
 
   def self.conform!(data)
     data.tap do |_|
+      add_alias(data, 'iso-url', 'iso_url')
       data['task'] = data['task']['name'] if data['task'].is_a?(Hash) and data['task'].keys == ['name']
     end
   end

--- a/lib/razor/command/create_task.rb
+++ b/lib/razor/command/create_task.rb
@@ -21,7 +21,7 @@ Define the RedHat task included with Razor using this command:
       "name":        "redhat6",
       "os":          "Red Hat Enterprise Linux",
       "description": "A basic installer for RHEL6",
-      "boot-seq": {
+      "boot_seq": {
         "1":       "boot_install",
         "default": "boot_local"
       }
@@ -39,7 +39,7 @@ Define the RedHat task included with Razor using this command:
 
     razor create-task --name redhat-new --os "Red Hat Enterprise Linux" \\
         --description "A basic installer for RHEL6" \\
-        --boot-seq 1=boot_install --boot-seq default=boot_local \\
+        --boot-seq 1=boot_install --boot_seq default=boot_local \\
         --templates "boot_install=#\!ipxe\\necho Razor <%= task.label %> task boot_call\\necho Installation node: <%= node_url  %>\\necho Installation repo: <%= repo_url %>\\n\\nsleep 3\\nkernel <%= repo_url(\"/isolinux/vmlinuz\") %> <%= render_template(\"kernel_args\").strip %> || goto error\\ninitrd <%= repo_url(\"/isolinux/initrd.img\") %> || goto error\\nboot\\n:error\\nprompt --key s --timeout 60 ERROR, hit 's' for the iPXE shell; reboot in 60 seconds && shell || reboot\\n" \\
         --templates kernel_args="ks=<%= file_url(\"kickstart\") %> network ksdevice=bootif BOOTIF=01-${netX/mac}" \\
         --templates kickstart="#\!/bin/bash\\n# Kickstart for RHEL/CentOS 6\\n# see: http://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/6/html/Installation_Guide/s1-kickstart2-options.html\\n\\ninstall\\nurl --url=<%= repo_url %>\\ncmdline\\nlang en_US.UTF-8\\nkeyboard us\\nrootpw <%= node.root_password %>\\nnetwork --hostname <%= node.hostname %>\\nfirewall --enabled --ssh\\nauthconfig --enableshadow --passalgo=sha512 --enablefingerprint\\ntimezone --utc America/Los_Angeles\\n# Avoid having 'rhgb quiet' on the boot line\\nbootloader --location=mbr --append=\"crashkernel=auto\"\\n# The following is the partition information you requested\\n# Note that any partitions you deleted are not expressed\\n# here so unless you clear all partitions first, this is\\n# not guaranteed to work\\nzerombr\\nclearpart --all --initlabel\\nautopart\\n# reboot automatically\\nreboot\\n\\n# following is MINIMAL https://partner-bugzilla.redhat.com/show_bug.cgi?id=593309\\n%packages --nobase\\n@core\\n\\n%end\\n\\n%post --log=/var/log/razor.log\\necho Kickstart post\\ncurl -s -o /root/razor_postinstall.sh <%= file_url(\"post_install\") %>\\n\\n# Run razor_postinstall.sh on next boot via rc.local\\nif [ ! -f /etc/rc.d/rc.local ]; then\\n  # On systems using systemd /etc/rc.d/rc.local does not exist at all\\n  # though systemd is set up to run the file if it exists\\n  touch /etc/rc.d/rc.local\\n  chmod a+x /etc/rc.d/rc.local\\nfi\\necho bash /root/razor_postinstall.sh >> /etc/rc.d/rc.local\\nchmod +x /root/razor_postinstall.sh\\n\\ncurl -s <%= stage_done_url(\"kickstart\") %>\\n%end\\n############\\n" \\

--- a/lib/razor/command/modify_node_metadata.rb
+++ b/lib/razor/command/modify_node_metadata.rb
@@ -77,7 +77,6 @@ Removing all node metadata:
 
   def self.conform!(data)
     data.tap do |_|
-      add_alias(data, 'no-replace', 'no_replace')
       data['clear'] = true if data['clear'] == 'true'
       data['clear'] = false if data['clear'] == 'false'
       data['no_replace'] = true if data['no_replace'] == 'true'

--- a/lib/razor/command/modify_node_metadata.rb
+++ b/lib/razor/command/modify_node_metadata.rb
@@ -23,7 +23,7 @@ modify an existing value already present on a node:
             "key2": "value2"
         }
         "remove": ["key3", "key4"],
-        "no-replace": true
+        "no_replace": true
     }
 
 Removing all node metadata:
@@ -36,7 +36,7 @@ Editing node metadata, by adding and removing some keys, but refusing to
 modify an existing value already present on a node:
 
     razor modify-node-metadata --node node1 --update key1=value1 \\
-        --update key2=value2 --remove key3 --remove key4 --noreplace
+        --update key2=value2 --remove key3 --remove key4 --no-replace
 
 Removing all node metadata:
 
@@ -55,7 +55,7 @@ Removing all node metadata:
     either 'update' or 'remove'.
   HELP
 
-  attr 'no-replace', type: :bool, help: _(<<-HELP)
+  attr 'no_replace', type: :bool, help: _(<<-HELP)
     If true, the `update` operation will cause this command to fail if the
     metadata key is already present on the node.  No effect on `remove` or
     clear.
@@ -71,19 +71,17 @@ Removing all node metadata:
         request.error 422, :error => _('cannot update and remove the same key')
     end
 
-    data['no_replace'] = data['no-replace']
-
     node = Razor::Data::Node[:name => data.delete('node')]
     node.modify_metadata(data)
   end
 
   def self.conform!(data)
     data.tap do |_|
-      data['no-replace'] = data.delete('no_replace') if data.has_key?('no_replace')
+      add_alias(data, 'no-replace', 'no_replace')
       data['clear'] = true if data['clear'] == 'true'
       data['clear'] = false if data['clear'] == 'false'
-      data['no-replace'] = true if data['no-replace'] == 'true'
-      data['no-replace'] = false if data['no-replace'] == 'false'
+      data['no_replace'] = true if data['no_replace'] == 'true'
+      data['no_replace'] = false if data['no_replace'] == 'false'
     end
   end
 end

--- a/lib/razor/command/modify_policy_max_count.rb
+++ b/lib/razor/command/modify_policy_max_count.rb
@@ -65,10 +65,4 @@ Set a policy to a maximum of 15 nodes:
     policy.set(max_count: max_count).save
     { :result => _("Changed max_count for policy %{name} to %{count}") % {name: policy.name, count: bound} }
   end
-
-  def self.conform!(data)
-    data.tap do |_|
-      add_alias(data, 'max-count', 'max_count')
-    end
-  end
 end

--- a/lib/razor/command/modify_policy_max_count.rb
+++ b/lib/razor/command/modify_policy_max_count.rb
@@ -11,11 +11,11 @@ greater than the number of nodes currently bound to the policy; it may also be
   example api: <<-EOT
 Set a policy to match an unlimited number of nodes:
 
-    {"name": "example", "max-count": null}
+    {"name": "example", "max_count": null}
 
 Set a policy to a maximum of 15 nodes:
 
-    {"name": "example", "max-count": 15}
+    {"name": "example", "max_count": 15}
   EOT
 
   example cli: <<-EOT
@@ -33,7 +33,7 @@ Set a policy to a maximum of 15 nodes:
   attr 'name', type: String, required: true, references: Razor::Data::Policy,
                help: _('The name of the policy to modify.')
 
-  attr 'max-count', required: true, help: _(<<-HELP)
+  attr 'max_count', required: true, help: _(<<-HELP)
     The new maximum number of nodes bound by this policy.  This can be
     "null", in which case the policy becomes unlimited, or an integer
     greater than or equal to one.
@@ -45,7 +45,7 @@ Set a policy to a maximum of 15 nodes:
   def run(request, data)
     policy = Razor::Data::Policy[:name => data['name']]
 
-    max_count_s = data['max-count']
+    max_count_s = data['max_count']
 
     if max_count_s.nil?
       max_count = nil
@@ -53,16 +53,22 @@ Set a policy to a maximum of 15 nodes:
     else
       max_count = max_count_s.to_i
       max_count.to_s == max_count_s.to_s or
-        request.error 422, :error => _("New max-count '%{raw}' is not a valid integer") % {raw: max_count_s}
+        request.error 422, :error => _("New max_count '%{raw}' is not a valid integer") % {raw: max_count_s}
       bound = max_count_s
       node_count = policy.nodes.count
       node_count <= max_count or
         request.error 400, :error => n_(
-        "There is currently %{node_count} node bound to this policy. Cannot lower max-count to %{max_count}",
-        "There are currently %{node_count} nodes bound to this policy. Cannot lower max-count to %{max_count}",
+        "There is currently %{node_count} node bound to this policy. Cannot lower max_count to %{max_count}",
+        "There are currently %{node_count} nodes bound to this policy. Cannot lower max_count to %{max_count}",
         node_count) % {node_count: node_count, max_count: max_count}
     end
     policy.set(max_count: max_count).save
-    { :result => _("Changed max-count for policy %{name} to %{count}") % {name: policy.name, count: bound} }
+    { :result => _("Changed max_count for policy %{name} to %{count}") % {name: policy.name, count: bound} }
+  end
+
+  def self.conform!(data)
+    data.tap do |_|
+      add_alias(data, 'max-count', 'max_count')
+    end
   end
 end

--- a/lib/razor/command/set_node_hw_info.rb
+++ b/lib/razor/command/set_node_hw_info.rb
@@ -62,21 +62,15 @@ Update `node172` with new hardware information:
   end
 
   def run(request, data)
-    if (data['hw-info'].keys & Razor.config['match_nodes_on']).empty?
-      msg = _('hw-info must contain at least one of the match keys: %{keys}') %
+    if (data['hw_info'].keys & Razor.config['match_nodes_on']).empty?
+      msg = _('hw_info must contain at least one of the match keys: %{keys}') %
         {keys: Razor.config['match_nodes_on'].join(', ')}
       raise Razor::ValidationFailure.new(msg)
     else
       Razor::Data::Node[name: data['node']].tap do |node|
-        node.hw_hash = data['hw-info']
+        node.hw_hash = data['hw_info']
         node.save
       end
     end
-  end
-
-  def self.conform!(data)
-    data.tap { |_|
-      data['hw-info'] = data.delete('hw_info') if data.has_key?('hw_info')
-    }
   end
 end

--- a/lib/razor/command/set_node_hw_info.rb
+++ b/lib/razor/command/set_node_hw_info.rb
@@ -21,7 +21,7 @@ Update `node172` with new hardware information:
 
     {
       "node": "node172",
-      "hw-info": {
+      "hw_info": {
         "net0":   "78:31:c1:be:c8:00",
         "net1":   "72:00:01:f2:13:f0",
         "net2":   "72:00:01:f2:13:f1",
@@ -49,7 +49,7 @@ Update `node172` with new hardware information:
     The node for which to modify hardware information.
   HELP
 
-  object 'hw-info', required: true, size: 1..Float::INFINITY, help: _(<<-HELP) do
+  object 'hw_info', required: true, size: 1..Float::INFINITY, help: _(<<-HELP) do
     The new hardware information for the node.
   HELP
     extra_attrs /^net[0-9]+$/, type: String, help: _(<<-HELP)

--- a/lib/razor/command/set_node_ipmi_credentials.rb
+++ b/lib/razor/command/set_node_ipmi_credentials.rb
@@ -21,9 +21,9 @@ Set IPMI credentials for node 'node17':
 
     {
       "name":          "node17",
-      "ipmi-hostname": "bmc17.example.com",
-      "ipmi-username": null,
-      "ipmi-password": "sekretskwirrl"
+      "ipmi_hostname": "bmc17.example.com",
+      "ipmi_username": null,
+      "ipmi_password": "sekretskwirrl"
     }
   EOT
 
@@ -40,13 +40,13 @@ Set IPMI credentials for node 'node17':
   attr  'name', type: String, required: true, references: Razor::Data::Node,
                 help: _('The node on which to set IPMI credentials.')
 
-  attr 'ipmi-hostname', type: String, size: 1..255,
+  attr 'ipmi_hostname', type: String, size: 1..255,
                         help: _('The IPMI hostname or IP address of the BMC of this host.')
 
-  attr 'ipmi-username', type: String, also: 'ipmi-hostname', size: 1..32,
+  attr 'ipmi_username', type: String, also: 'ipmi_hostname', size: 1..32,
                         help: _('The IPMI LANPLUS username, if any, for this BMC.')
 
-  attr 'ipmi-password', type: String, also: 'ipmi-hostname', size: 1..20,
+  attr 'ipmi_password', type: String, also: 'ipmi_hostname', size: 1..20,
                         help: _('The IPMI LANPLUS password, if any, for this BMC.')
 
   def run(request, data)
@@ -58,10 +58,18 @@ Set IPMI credentials for node 'node17':
     # change that (because, say, we fix the -/_ thing globally, make sure
     # you restrict this to changing the specific attributes only.
     node.update(
-      :ipmi_hostname => data['ipmi-hostname'],
-      :ipmi_username => data['ipmi-username'],
-      :ipmi_password => data['ipmi-password'])
+      :ipmi_hostname => data['ipmi_hostname'],
+      :ipmi_username => data['ipmi_username'],
+      :ipmi_password => data['ipmi_password'])
 
     { :result => _('updated IPMI details') }
+  end
+
+  def self.conform!(data)
+    data.tap do |_|
+      add_alias(data, 'ipmi-hostname', 'ipmi_hostname')
+      add_alias(data, 'ipmi-username', 'ipmi_username')
+      add_alias(data, 'ipmi-password', 'ipmi_password')
+    end
   end
 end

--- a/lib/razor/command/set_node_ipmi_credentials.rb
+++ b/lib/razor/command/set_node_ipmi_credentials.rb
@@ -64,12 +64,4 @@ Set IPMI credentials for node 'node17':
 
     { :result => _('updated IPMI details') }
   end
-
-  def self.conform!(data)
-    data.tap do |_|
-      add_alias(data, 'ipmi-hostname', 'ipmi_hostname')
-      add_alias(data, 'ipmi-username', 'ipmi_username')
-      add_alias(data, 'ipmi-password', 'ipmi_password')
-    end
-  end
 end

--- a/lib/razor/command/update_node_metadata.rb
+++ b/lib/razor/command/update_node_metadata.rb
@@ -32,25 +32,25 @@ Set a single key from a node:
   attr 'value', required: true,
                 help: _('The value for the metadata.')
 
-  attr 'no-replace', type: :bool,
+  attr 'no_replace', type: :bool,
                      help: _('If true, it is an error to try to change an existing key')
 
   # Update/add specific metadata key (works with GET)
   def run(request, data)
     node = Razor::Data::Node[:name => data['node']]
     operation = { 'update' => { data['key'] => data['value'] } }
-    operation['no_replace'] = data['no-replace']
+    operation['no_replace'] = data['no_replace']
 
     node.modify_metadata(operation)
   end
   
   def self.conform!(data)
     data.tap do |_|
-      data['no-replace'] = data.delete('no_replace') if data.has_key?('no_replace')
+      add_alias(data, 'no-replace', 'no_replace')
       data['all'] = true if data['all'] == 'true'
       data['all'] = false if data['all'] == 'false'
-      data['no-replace'] = true if data['no-replace'] == 'true'
-      data['no-replace'] = false if data['no-replace'] == 'false'
+      data['no_replace'] = true if data['no_replace'] == 'true'
+      data['no_replace'] = false if data['no_replace'] == 'false'
     end
   end
 end

--- a/lib/razor/command/update_node_metadata.rb
+++ b/lib/razor/command/update_node_metadata.rb
@@ -46,7 +46,6 @@ Set a single key from a node:
   
   def self.conform!(data)
     data.tap do |_|
-      add_alias(data, 'no-replace', 'no_replace')
       data['all'] = true if data['all'] == 'true'
       data['all'] = false if data['all'] == 'false'
       data['no_replace'] = true if data['no_replace'] == 'true'

--- a/lib/razor/view.rb
+++ b/lib/razor/view.rb
@@ -97,7 +97,7 @@ module Razor
 
       view_object_hash(broker).merge(
         :configuration   => broker.configuration,
-        :"broker-type"   => broker.broker_type,
+        :broker_type   => broker.broker_type,
         :policies        => { :id => view_object_url(broker) + "/policies",
                               :count => broker.policies.count,
                               :name => "policies" })
@@ -201,7 +201,7 @@ module Razor
       view_object_hash(hook).merge(
       {
         :name          => hook.name,
-        :"hook-type"   => hook.hook_type,
+        :hook_type   => hook.hook_type,
         :configuration => hook.configuration,
         :log           => { :id => view_object_url(hook) + "/log",
                             :name => "log",

--- a/locales/razor-server.pot
+++ b/locales/razor-server.pot
@@ -6,10 +6,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Razor Server 0.16.0-3-g05fd9bd\n"
+"Project-Id-Version: Razor Server 0.16.1-10-gcc48604\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-12 13:00-0600\n"
-"PO-Revision-Date: 2015-01-12 13:00-0600\n"
+"POT-Creation-Date: 2015-03-03 13:17-0600\n"
+"PO-Revision-Date: 2015-03-03 13:17-0600\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -34,79 +34,83 @@ msgstr ""
 msgid "only application/json content is available"
 msgstr ""
 
-#: ../app.rb:99
+#: ../app.rb:69
+msgid "API requests must be over SSL (secure_api config property is enabled)"
+msgstr ""
+
+#: ../app.rb:103
 msgid "only application/json is accepted here"
 msgstr ""
 
-#: ../app.rb:102
+#: ../app.rb:106
 msgid "unable to parse JSON"
 msgstr ""
 
-#: ../app.rb:139
+#: ../app.rb:143
 msgid "store_metadata_url must include update and/or remove keys"
 msgstr ""
 
-#: ../app.rb:432
+#: ../app.rb:436
 msgid "node %{node} not bound to a policy yet"
 msgstr ""
 
-#: ../app.rb:439
+#: ../app.rb:446
 msgid "install template %{name}.erb does not exist"
 msgstr ""
 
-#: ../app.rb:492
+#: ../app.rb:499
 msgid "File %{path} not found"
 msgstr ""
 
-#: ../app.rb:507
+#: ../app.rb:514
 msgid "No extension file configured"
 msgstr ""
 
-#: ../app.rb:576 ../app.rb:582 ../app.rb:588
+#: ../app.rb:583 ../app.rb:589 ../app.rb:595
 msgid "no tag matched id=%{name}"
 msgstr ""
 
-#: ../app.rb:598 ../app.rb:604
+#: ../app.rb:605 ../app.rb:611
 msgid "no broker matched id=%{name}"
 msgstr ""
 
-#: ../app.rb:614 ../app.rb:620
+#: ../app.rb:621 ../app.rb:627
 msgid "no policy matched id=%{name}"
 msgstr ""
 
-#: ../app.rb:632
+#: ../app.rb:639
 msgid "Task %{name} does not exist"
 msgstr ""
 
-#: ../app.rb:644
+#: ../app.rb:651
 msgid "no repo matched name=%{name}"
 msgstr ""
 
-#: ../app.rb:658 ../app.rb:660
+#: ../app.rb:665 ../app.rb:667
 msgid "no such command"
 msgstr ""
 
-#: ../app.rb:674
+#: ../app.rb:681
 msgid "id must be a number but was %{id}"
 msgstr ""
 
-#: ../app.rb:677
+#: ../app.rb:684
 msgid "no event matched id=%{id}"
 msgstr ""
 
-#: ../app.rb:690 ../app.rb:697
+#: ../app.rb:697 ../app.rb:704
 msgid "no hook matched name=%{name}"
 msgstr ""
 
-#: ../app.rb:710
+#: ../app.rb:717
 msgid "no node matched name=%{name}"
 msgstr ""
 
-#: ../app.rb:720
+#: ../app.rb:727
 msgid "no node matched hw_id=%{hw_id}"
 msgstr ""
 
-#: ../app.rb:735
+#: ../app.rb:742
 msgid "The nic_max parameter must be an integer not starting with 0"
 msgstr ""
 
@@ -122,11 +126,11 @@ msgstr ""
 msgid "could not find install template '%{name}' for broker '%{broker_name}'"
 msgstr ""
 
-#: ../lib/razor/broker_type.rb:154
+#: ../lib/razor/broker_type.rb:155
 msgid "%{name} has install template %{file}, but it is unreadable"
 msgstr ""
 
-#: ../lib/razor/broker_type.rb:156
+#: ../lib/razor/broker_type.rb:157
 msgid "%{name} has no install script template"
 msgstr ""
 
@@ -141,7 +145,7 @@ msgid ""
 "Body is: '%{body}'\n"
 msgstr ""
 
-#: ../lib/razor/command.rb:102
+#: ../lib/razor/command.rb:120
 msgid "internal error: command %{name} has no execution code!"
 msgstr ""
 
@@ -185,7 +189,7 @@ msgstr ""
 #: ../lib/razor/command/create_broker.rb:45
 msgid ""
 "    The configuration for the broker.  The acceptable values here are\n"
-"    determined by the `broker-type` selected.  In general this has\n"
+"    determined by the `broker_type` selected.  In general this has\n"
 "    settings like which server to contact, and other configuration\n"
 "    related to handing on the newly installed system to the final\n"
 "    configuration management system.\n"
@@ -207,7 +211,7 @@ msgstr ""
 #: ../lib/razor/command/create_hook.rb:37
 msgid ""
 "    The configuration for the hook.  The acceptable values here are\n"
-"    determined by the `hook-type` selected.  In general this has\n"
+"    determined by the `hook_type` selected.  In general this has\n"
 "    settings like a node counter or other settings which may change\n"
 "    over time as the hook gets executed.\n"
 "\n"
@@ -329,7 +333,7 @@ msgstr ""
 msgid ""
 "    The name of the task associated with this repository.  This is used to\n"
 "    install nodes that match a policy using this repository; generally it\n"
-"    should match the OS that the URL or ISO-URL attributes point to.\n"
+"    should match the OS that the URL or ISO_URL attributes point to.\n"
 msgstr ""
 
 #: ../lib/razor/command/create_tag.rb:29
@@ -530,17 +534,17 @@ msgid ""
 msgstr ""
 
 #: ../lib/razor/command/modify_policy_max_count.rb:56
-msgid "New max-count '%{raw}' is not a valid integer"
+msgid "New max_count '%{raw}' is not a valid integer"
 msgstr ""
 
 #: ../lib/razor/command/modify_policy_max_count.rb:60
-msgid "There is currently %{node_count} node bound to this policy. Cannot lower max-count to %{max_count}"
-msgid_plural "There are currently %{node_count} nodes bound to this policy. Cannot lower max-count to %{max_count}"
+msgid "There is currently %{node_count} node bound to this policy. Cannot lower max_count to %{max_count}"
+msgid_plural "There are currently %{node_count} nodes bound to this policy. Cannot lower max_count to %{max_count}"
 msgstr[0] ""
 msgstr[1] ""
 
 #: ../lib/razor/command/modify_policy_max_count.rb:66
-msgid "Changed max-count for policy %{name} to %{count}"
+msgid "Changed max_count for policy %{name} to %{count}"
 msgstr ""
 
 #: ../lib/razor/command/move_policy.rb:32

--- a/spec/app/api_spec.rb
+++ b/spec/app/api_spec.rb
@@ -1158,6 +1158,12 @@ describe "command and query API" do
         last_response.body.should =~ /^[^#]*dhcp\s+net#{i}/m
       end
     end
+
+    it "accepts a http_port parameter" do
+      get "/api/microkernel/bootstrap?http_port=8150"
+      last_response.status.should == 200
+      last_response.body.should =~ /:8150/
+    end
   end
 
   context "/api/collections/events" do

--- a/spec/app/api_spec.rb
+++ b/spec/app/api_spec.rb
@@ -407,7 +407,7 @@ describe "command and query API" do
       '$schema'  => 'http://json-schema.org/draft-04/schema#',
       'title'    => "Broker Collection JSON Schema",
       'type'     => 'object',
-      'required' => %w[spec id name configuration broker-type],
+      'required' => %w[spec id name configuration broker_type],
       'properties' => {
         'spec' => {
           '$schema'  => 'http://json-schema.org/draft-04/schema#',
@@ -424,7 +424,7 @@ describe "command and query API" do
           'type'     => 'string',
           'pattern'  => '^[a-zA-Z0-9 ]+$'
         },
-        'broker-type' => {
+        'broker_type' => {
           '$schema'  => 'http://json-schema.org/draft-04/schema#',
           'type'     => 'string',
           'pattern'  => '^[a-zA-Z0-9 ]+$'
@@ -989,7 +989,7 @@ describe "command and query API" do
         '$schema'  => 'http://json-schema.org/draft-04/schema#',
         'title'    => "Hook Collection JSON Schema",
         'type'     => 'object',
-        'required' => %w[spec id name hook-type],
+        'required' => %w[spec id name hook_type],
         'properties' => {
             'spec' => {
                 '$schema'  => 'http://json-schema.org/draft-04/schema#',
@@ -1006,7 +1006,7 @@ describe "command and query API" do
                 'type'     => 'string',
                 'pattern'  => '^[^\n]+$'
             },
-            'hook-type' => {
+            'hook_type' => {
                 '$schema'  => 'http://json-schema.org/draft-04/schema#',
                 'type'     => 'string',
                 'pattern'  => '^[a-zA-Z0-9 ]+$'

--- a/spec/app/create_broker_spec.rb
+++ b/spec/app/create_broker_spec.rb
@@ -23,7 +23,7 @@ describe Razor::Command::CreateBroker do
 
     let :command_hash do
       { 'name'        => Faker::Commerce.product_name,
-        'broker-type' => 'test'
+        'broker_type' => 'test'
       }
     end
 
@@ -48,11 +48,11 @@ describe Razor::Command::CreateBroker do
     end
 
     it "should fail if the named broker does not actually exist" do
-      create_broker command_hash.merge 'broker-type' => 'no-such-broker-for-me'
+      create_broker command_hash.merge 'broker_type' => 'no-such-broker-for-me'
 
       last_response.status.should == 404
       last_response.json['error'].should ==
-        "broker-type must be the name of an existing broker type, but is 'no-such-broker-for-me'"
+        "broker_type must be the name of an existing broker type, but is 'no-such-broker-for-me'"
     end
 
     it "should fail cleanly if 'configuration' is a string" do
@@ -90,7 +90,7 @@ describe Razor::Command::CreateBroker do
     end
 
     it "should validate valid configuration" do
-      command_hash['broker-type'] = 'with_configuration'
+      command_hash['broker_type'] = 'with_configuration'
       command_hash['configuration'] = {'some-key' => 'valid-value'}
       command = create_broker command_hash
 
@@ -99,7 +99,7 @@ describe Razor::Command::CreateBroker do
     end
 
     it "should validate invalid configuration" do
-      command_hash['broker-type'] = 'with_configuration'
+      command_hash['broker_type'] = 'with_configuration'
       command_hash['configuration'] = {'not-valid-key' => 'not-valid-value'}
       command = create_broker command_hash
 
@@ -108,7 +108,7 @@ describe Razor::Command::CreateBroker do
     end
 
     it "should validate valid configuration abbreviation" do
-      command_hash['broker-type'] = 'with_configuration'
+      command_hash['broker_type'] = 'with_configuration'
       command_hash['c'] = {'some-key' => 'valid-value'}
       command = create_broker command_hash
 
@@ -117,7 +117,7 @@ describe Razor::Command::CreateBroker do
     end
 
     it "should validate invalid configuration abbreviation" do
-      command_hash['broker-type'] = 'with_configuration'
+      command_hash['broker_type'] = 'with_configuration'
       command_hash['c'] = {'not-valid-key' => 'not-valid-value'}
       command = create_broker command_hash
 
@@ -126,7 +126,7 @@ describe Razor::Command::CreateBroker do
     end
 
     it "should validate mixed shorthand and longhand configuration" do
-      command_hash['broker-type'] = 'with_configuration'
+      command_hash['broker_type'] = 'with_configuration'
       command_hash['c'] = {'some-key' => 'valid-value'}
       command_hash['configuration'] = {'some-other-key' => 'other-valid-value'}
       command = create_broker command_hash

--- a/spec/app/create_hook_spec.rb
+++ b/spec/app/create_hook_spec.rb
@@ -23,7 +23,7 @@ describe Razor::Command::CreateHook do
 
     let :command_hash do
       { 'name'        => Faker::Commerce.product_name,
-        'hook-type' => 'test'
+        'hook_type' => 'test'
       }
     end
 
@@ -48,11 +48,11 @@ describe Razor::Command::CreateHook do
     end
 
     it "should fail if the named hook does not actually exist" do
-      create_hook command_hash.merge 'hook-type' => 'no-such-hook-for-me'
+      create_hook command_hash.merge 'hook_type' => 'no-such-hook-for-me'
 
       last_response.status.should == 404
       last_response.json['error'].should ==
-          "hook-type must be the name of an existing hook type, but is 'no-such-hook-for-me'"
+          "hook_type must be the name of an existing hook type, but is 'no-such-hook-for-me'"
     end
 
     it "should fail cleanly if 'configuration' is a string" do
@@ -97,7 +97,7 @@ describe Razor::Command::CreateHook do
     end
 
     it "should validate valid configuration" do
-      command_hash['hook-type'] = 'with_configuration'
+      command_hash['hook_type'] = 'with_configuration'
       command_hash['configuration'] = {'some-key' => 'valid-value'}
       command = create_hook command_hash
 
@@ -106,7 +106,7 @@ describe Razor::Command::CreateHook do
     end
 
     it "should validate invalid configuration" do
-      command_hash['hook-type'] = 'with_configuration'
+      command_hash['hook_type'] = 'with_configuration'
       command_hash['configuration'] = {'not-valid-key' => 'not-valid-value'}
       command = create_hook command_hash
 
@@ -115,7 +115,7 @@ describe Razor::Command::CreateHook do
     end
 
     it "should validate valid configuration abbreviation" do
-      command_hash['hook-type'] = 'with_configuration'
+      command_hash['hook_type'] = 'with_configuration'
       command_hash['c'] = {'some-key' => 'valid-value'}
       command = create_hook command_hash
 
@@ -124,7 +124,7 @@ describe Razor::Command::CreateHook do
     end
 
     it "should validate invalid configuration abbreviation" do
-      command_hash['hook-type'] = 'with_configuration'
+      command_hash['hook_type'] = 'with_configuration'
       command_hash['c'] = {'not-valid-key' => 'not-valid-value'}
       command = create_hook command_hash
 
@@ -133,7 +133,7 @@ describe Razor::Command::CreateHook do
     end
 
     it "should validate mixed shorthand and longhand configuration" do
-      command_hash['hook-type'] = 'with_configuration'
+      command_hash['hook_type'] = 'with_configuration'
       command_hash['c'] = {'some-key' => 'valid-value'}
       command_hash['configuration'] = {'some-other-key' => 'other-valid-value'}
       command = create_hook command_hash

--- a/spec/app/create_policy_spec.rb
+++ b/spec/app/create_policy_spec.rb
@@ -29,7 +29,7 @@ describe Razor::Command::CreatePolicy do
         'task'          => 'some_os',
         'broker'        => broker.name,
         'hostname'      => "host${id}.example.com",
-        'root-password' => "geheim",
+        'root_password' => "geheim",
         'tags'          => [ tag1.name ]
       }
     end
@@ -85,7 +85,7 @@ describe Razor::Command::CreatePolicy do
     end
 
     it "should fail if the root password is missing" do
-      command_hash.delete('root-password')
+      command_hash.delete('root_password')
       create_policy
       last_response.status.should == 422
     end
@@ -105,7 +105,7 @@ describe Razor::Command::CreatePolicy do
     end
 
     it "should conform root password's legacy syntax" do
-      command_hash['root_password'] = command_hash.delete('root-password')
+      command_hash['root_password'] = command_hash.delete('root_password')
       create_policy
       last_response.status.should == 202
     end
@@ -131,7 +131,7 @@ describe Razor::Command::CreatePolicy do
     end
 
     it "should allow creating a policy with max count" do
-      command_hash['max-count'] = 10
+      command_hash['max_count'] = 10
 
       create_policy
 
@@ -140,7 +140,7 @@ describe Razor::Command::CreatePolicy do
 
     it "should allow creating a policy with node_metadata" do
       metadata = { "key1" => "value1", "key2" => "value2" }
-      command_hash['node-metadata'] = metadata
+      command_hash['node_metadata'] = metadata
       create_policy
       Razor::Data::Policy[:name => command_hash['name']].node_metadata.should == metadata
     end
@@ -151,10 +151,10 @@ describe Razor::Command::CreatePolicy do
       last_response.json['error'].should == 'repo should be a string, but was actually a object'
     end
 
-    it "should fail with the wrong datatype for max-count" do
-      command_hash['max-count'] = { }
+    it "should fail with the wrong datatype for max_count" do
+      command_hash['max_count'] = { }
       create_policy
-      last_response.json['error'].should =~ /max-count should be a number, but was actually a object/
+      last_response.json['error'].should =~ /max_count should be a number, but was actually a object/
     end
 
 

--- a/spec/app/create_policy_spec.rb
+++ b/spec/app/create_policy_spec.rb
@@ -172,18 +172,19 @@ describe Razor::Command::CreatePolicy do
       ([tag1, tag2] & Razor::Data::Policy[:name => command_hash['name']].tags).should == [tag1, tag2]
     end
 
-    it "should conform tag string into tags" do
+    it "should not conform tag string into tags" do
       tag2 = Fabricate('tag')
       command_hash['tag'] = tag2.name
       create_policy
-      last_response.status.should == 202
-      ([tag1, tag2] & Razor::Data::Policy[:name => command_hash['name']].tags).should == [tag1, tag2]
+      last_response.json['error'].should == 'cannot supply both tags and tag'
+      last_response.status.should == 422
     end
 
     it "should fail with the wrong datatype for tag" do
       command_hash['tag'] = 123
+      command_hash.delete('tags')
       create_policy
-      last_response.json['error'].should == "tags[1] should be a string, but was actually a number"
+      last_response.json['error'].should == "tags[0] should be a string, but was actually a number"
       last_response.status.should == 422
     end
 

--- a/spec/app/create_repo_spec.rb
+++ b/spec/app/create_repo_spec.rb
@@ -9,7 +9,7 @@ describe Razor::Command::CreateRepo do
   let(:command_hash) do
     {
         "name" => "magicos",
-        "iso-url" => "file:///dev/null",
+        "iso_url" => "file:///dev/null",
         "task"    => "some_os",
     }
   end
@@ -57,7 +57,7 @@ describe Razor::Command::CreateRepo do
     it "should fail if an extra key is given, if otherwise good" do
       post '/api/commands/create-repo', {
         "name"      => "magicos",
-        "iso-url"   => "file:///dev/null",
+        "iso_url"   => "file:///dev/null",
         "banana"    => "> orange",
         "task"      => "some_os",
       }.to_json
@@ -68,7 +68,7 @@ describe Razor::Command::CreateRepo do
     it "should return the 202, and the URL of the repo" do
       command 'create-repo', {
         "name" => "magicos",
-        "iso-url" => "file:///dev/null",
+        "iso_url" => "file:///dev/null",
         "task"    => "some_os",
       }, :status => :pending
 
@@ -85,7 +85,7 @@ describe Razor::Command::CreateRepo do
       it "should return 202 if the repo is identical" do
         data = {
           'name'    => repo.name,
-          'iso-url' => repo.iso_url,
+          'iso_url' => repo.iso_url,
           'task'    => repo.task.name
         }
 
@@ -113,7 +113,7 @@ describe Razor::Command::CreateRepo do
     it "should create an repo record in the database" do
       command 'create-repo', {
         "name" => "magicos",
-        "iso-url" => "file:///dev/null",
+        "iso_url" => "file:///dev/null",
         "task"    => "some_os",
       }, :status => :pending
 
@@ -123,7 +123,7 @@ describe Razor::Command::CreateRepo do
     it "should conform to allow task-name long form" do
       command 'create-repo', {
           "name" => "magicos",
-          "iso-url" => "file:///dev/null",
+          "iso_url" => "file:///dev/null",
           "task"    => {'name' => 'some_os'},
       }, :status => :pending
 

--- a/spec/app/ipmi_spec.rb
+++ b/spec/app/ipmi_spec.rb
@@ -27,18 +27,18 @@ describe Razor::Command::SetNodeIPMICredentials do
     node.ipmi_password.should be_nil
 
     update = {
-      'ipmi-hostname' => Faker::Internet.ip_v4_address,
-      'ipmi-username' => Faker::Internet.user_name,
-      'ipmi-password' => Faker::Internet.password[0..19]
+      'ipmi_hostname' => Faker::Internet.ip_v4_address,
+      'ipmi_username' => Faker::Internet.user_name,
+      'ipmi_password' => Faker::Internet.password[0..19]
     }
 
     command 'set-node-ipmi-credentials', {:name => node.name}.merge(update)
     last_response.status.should == 202
     node.reload                 # refresh from the database, plz
 
-    node.ipmi_hostname.should == update['ipmi-hostname']
-    node.ipmi_username.should == update['ipmi-username']
-    node.ipmi_password.should == update['ipmi-password']
+    node.ipmi_hostname.should == update['ipmi_hostname']
+    node.ipmi_username.should == update['ipmi_username']
+    node.ipmi_password.should == update['ipmi_password']
   end
 end
 

--- a/spec/app/modify_node_metadata_spec.rb
+++ b/spec/app/modify_node_metadata_spec.rb
@@ -12,7 +12,7 @@ describe Razor::Command::ModifyNodeMetadata do
     {
         "node" => node.name,
         'update' => { 'k1' => 'v2', 'k2' => 'v2'},
-        'no-replace' => true
+        'no_replace' => true
     }
   end
 
@@ -70,11 +70,11 @@ describe Razor::Command::ModifyNodeMetadata do
     last_response.json["error"].should =~ /clear should be a boolean, but was actually a string/
   end
 
-  it "should complain if no-replace is not boolean true or string 'true'" do
-    data = { 'node' => "node#{node.id}", 'update' => { 'k1' => 'v1'}, 'no-replace' => 'something' }
+  it "should complain if no_replace is not boolean true or string 'true'" do
+    data = { 'node' => "node#{node.id}", 'update' => { 'k1' => 'v1'}, 'no_replace' => 'something' }
     modify_metadata(data)
     last_response.status.should == 422
-    last_response.json["error"].should =~ /no-replace should be a boolean, but was actually a string/
+    last_response.json["error"].should =~ /no_replace should be a boolean, but was actually a string/
   end
 
   it "should reject blank attributes" do
@@ -106,11 +106,11 @@ describe Razor::Command::ModifyNodeMetadata do
       node_metadata['k1'].should == 'v2'
     end
 
-    it "should NOT update the value of an existing tag if no-replace is set" do
+    it "should NOT update the value of an existing tag if no_replace is set" do
       id = node.id
       data = { 'node' => "node#{id}", 'update' => { 'k1' => 'v1'} }
       modify_metadata(data)
-      data = { 'node' => "node#{id}", 'update' => { 'k1' => 'v2', 'k2' => 'v2'}, 'no-replace' => true }
+      data = { 'node' => "node#{id}", 'update' => { 'k1' => 'v2', 'k2' => 'v2'}, 'no_replace' => true }
       modify_metadata(data)
       last_response.status.should == 202
       node_metadata = Node[:id => id].metadata

--- a/spec/app/modify_policy_max_count_spec.rb
+++ b/spec/app/modify_policy_max_count_spec.rb
@@ -8,11 +8,11 @@ describe Razor::Command::ModifyPolicyMaxCount do
   let(:app) { Razor::App }
 
   let(:policy) { Fabricate(:policy) }
-  let(:command_hash) { { "name" => policy.name, "max-count" => 1 } }
+  let(:command_hash) { { "name" => policy.name, "max_count" => 1 } }
 
   def set_max_count(count=nil)
     command 'modify-policy-max-count',
-         { "name" => policy.name, "max-count" => count }
+         { "name" => policy.name, "max_count" => count }
   end
 
   context "/api/commands/modify-policy-max-count" do
@@ -23,18 +23,18 @@ describe Razor::Command::ModifyPolicyMaxCount do
 
     it_behaves_like "a command"
 
-    it "should accept a string for max-count" do
+    it "should accept a string for max_count" do
       set_max_count("2")
       last_response.status.should == 202
     end
 
-    it "should reject a non-integer string for max-count" do
+    it "should reject a non-integer string for max_count" do
       set_max_count("a")
       last_response.status.should == 422
       last_response.json['error'].should =~ /'a' is not a valid integer/
     end
 
-    it "should allow increasing the max-count" do
+    it "should allow increasing the max_count" do
       policy.max_count = 1
       policy.save
 
@@ -45,7 +45,7 @@ describe Razor::Command::ModifyPolicyMaxCount do
       policy.max_count.should == 2
     end
 
-    it "should allow lifting the max-count alltogether" do
+    it "should allow lifting the max_count altogether" do
       set_max_count(nil)
       last_response.status.should == 202
 
@@ -53,7 +53,7 @@ describe Razor::Command::ModifyPolicyMaxCount do
       policy.max_count.should be_nil
     end
 
-    it "should fail when trying to lower the max-count below the number of currently bound nodes" do
+    it "should fail when trying to lower the max_count below the number of currently bound nodes" do
       policy.max_count = 2
       policy.save
       2.times do

--- a/spec/app/set_node_hw_info_spec.rb
+++ b/spec/app/set_node_hw_info_spec.rb
@@ -10,7 +10,7 @@ describe Razor::Command::SetNodeHWInfo do
   let :command_hash do
     {
         'node' => node.name,
-        'hw-info' => node_hw_hash_to_hw_info(node.hw_hash)
+        'hw_info' => node_hw_hash_to_hw_info(node.hw_hash)
     }
   end
 
@@ -51,7 +51,7 @@ describe Razor::Command::SetNodeHWInfo do
     command_hash['hw-info'] = {serial: '1234'}
     set_node_hw_info
     last_response.json['error'].
-      should == "hw-info must contain at least one of the match keys: mac"
+      should == "hw_info must contain at least one of the match keys: mac"
      last_response.status.should == 422
   end
 
@@ -66,7 +66,7 @@ describe Razor::Command::SetNodeHWInfo do
     before = node.hw_hash
     before.should_not == {'serial' => '1234'}
 
-    command_hash['hw-info'] = {serial: '1234'}
+    command_hash['hw_info'] = {serial: '1234'}
     set_node_hw_info
     last_response.status.should == 202
 
@@ -74,8 +74,8 @@ describe Razor::Command::SetNodeHWInfo do
     Razor::Data::Node[id: node.id].should_not == before
   end
 
-  it "should conform the old 'hw_info' syntax" do
-    command_hash['hw_info'] = command_hash.delete('hw-info')
+  it "should conform the old 'hw-info' syntax" do
+    command_hash['hw-info'] = command_hash.delete('hw_info')
     set_node_hw_info
     last_response.status.should == 202
   end

--- a/spec/app/update_node_metadata_spec.rb
+++ b/spec/app/update_node_metadata_spec.rb
@@ -15,7 +15,7 @@ describe Razor::Command::UpdateNodeMetadata do
         'node' => node.name,
         'value' => 'v1',
         'key' => 'k1',
-        'no-replace' => 'true'
+        'no_replace' => 'true'
     }
   end
 
@@ -30,18 +30,18 @@ describe Razor::Command::UpdateNodeMetadata do
 
   it_behaves_like "a command"
 
-  it "should require no-replace to equal true" do
-    data = { 'node' => "node#{node.id}", 'key' => 'k1', 'value' => 'v1', 'no-replace' => 'not true' }
+  it "should require no_replace to equal true" do
+    data = { 'node' => "node#{node.id}", 'key' => 'k1', 'value' => 'v1', 'no_replace' => 'not true' }
     update_metadata(data)
     last_response.status.should == 422
-    last_response.json["error"].should =~ /no-replace should be a boolean, but was actually a string/
+    last_response.json["error"].should =~ /no_replace should be a boolean, but was actually a string/
   end
 
   it "should conform no_replace" do
     data = { 'node' => "node#{node.id}", 'key' => 'k1', 'value' => 'v1', 'no_replace' => 'not true' }
     update_metadata(data)
     last_response.status.should == 422
-    last_response.json["error"].should =~ /no-replace should be a boolean, but was actually a string/
+    last_response.json["error"].should =~ /no_replace should be a boolean, but was actually a string/
   end
 
   #Defer to the modify-node-metadata tests for the verification of the

--- a/spec/data/command_spec.rb
+++ b/spec/data/command_spec.rb
@@ -110,72 +110,67 @@ describe Razor::Data::Command do
     end
   end
 
-  describe 'add_alias' do
+  describe 'run_alias' do
     it 'assumes a string alias by default' do
       data = {'abc' => '123'}
-      Razor::Command.add_alias(data, 'abc', 'def')
+      Razor::Command.run_alias(data, 'abc', 'def')
       data['def'].should == '123'
       data.keys.should_not include 'abc'
     end
     it 'keeps the original data intact' do
       data = {'def' => '123'}
-      Razor::Command.add_alias(data, 'abc', 'def')
+      Razor::Command.run_alias(data, 'abc', 'def')
       data['def'].should == '123'
       data.keys.should_not include 'abc'
     end
     it 'does nothing if neither the alias nor the attribute is supplied' do
       data = {}
-      Razor::Command.add_alias(data, 'abc', 'def')
+      Razor::Command.run_alias(data, 'abc', 'def')
       data.keys.should == []
     end
     # This may not be ideal behavior, but this test is needed in case desired
     # behavior changes in the future.
     it 'fails if both are supplied' do
       data = {'def' => '123', 'abc' => '456'}
-      expect {Razor::Command.add_alias(data, 'abc', 'def')}.
+      expect {Razor::Command.run_alias(data, 'abc', 'def')}.
          to raise_error(Razor::ValidationFailure, "cannot supply both def and abc")
     end
-  end
-
-  describe 'add_hash_alias' do
     it 'merges two hashes' do
       data = {'abc' => {'123' => '456'}, 'def' => {'789' => '012'}}
-      Razor::Command.add_hash_alias(data, 'abc', 'def')
+      Razor::Command.run_alias(data, 'abc', 'def')
       data['def'].should == {'123' => '456', '789' => '012'}
       data.keys.should_not include 'abc'
     end
-    it 'performs aliasing' do
+    it 'performs aliasing on a hash' do
       data = {'abc' => {'123' => '456'}}
-      Razor::Command.add_hash_alias(data, 'abc', 'def')
+      Razor::Command.run_alias(data, 'abc', 'def')
       data['def'].should == {'123' => '456'}
       data.keys.should_not include 'abc'
     end
-    it 'keeps the original data intact' do
+    it 'keeps the original data intact on a hash' do
       data = {'def' => {'123' => '456'}}
-      Razor::Command.add_hash_alias(data, 'abc', 'def')
+      Razor::Command.run_alias(data, 'abc', 'def')
       data['def'].should == {'123' => '456'}
+      data.keys.should_not include 'abc'
+    end
+    it 'merges two arrays' do
+      data = {'abc' => ['123'], 'def' => ['456']}
+      Razor::Command.run_alias(data, 'abc', 'def')
+      data['def'].should == ['456', '123']
+      data.keys.should_not include 'abc'
+    end
+    it 'performs aliasing on an array' do
+      data = {'abc' => ['123']}
+      Razor::Command.run_alias(data, 'abc', 'def')
+      data['def'].should == ['123']
+      data.keys.should_not include 'abc'
+    end
+    it 'keeps the original data intact on an array' do
+      data = {'def' => ['123']}
+      Razor::Command.run_alias(data, 'abc', 'def')
+      data['def'].should == ['123']
       data.keys.should_not include 'abc'
     end
   end
 
-  describe 'add_array_alias' do
-    it 'merges two hashes' do
-      data = {'abc' => ['123'], 'def' => ['456']}
-      Razor::Command.add_array_alias(data, 'abc', 'def')
-      data['def'].should == ['456', '123']
-      data.keys.should_not include 'abc'
-    end
-    it 'performs aliasing' do
-      data = {'abc' => ['123']}
-      Razor::Command.add_array_alias(data, 'abc', 'def')
-      data['def'].should == ['123']
-      data.keys.should_not include 'abc'
-    end
-    it 'keeps the original data intact' do
-      data = {'def' => ['123']}
-      Razor::Command.add_array_alias(data, 'abc', 'def')
-      data['def'].should == ['123']
-      data.keys.should_not include 'abc'
-    end
-  end
 end

--- a/spec/data/command_spec.rb
+++ b/spec/data/command_spec.rb
@@ -109,4 +109,73 @@ describe Razor::Data::Command do
       cmd.status.should == 'pending'
     end
   end
+
+  describe 'add_alias' do
+    it 'assumes a string alias by default' do
+      data = {'abc' => '123'}
+      Razor::Command.add_alias(data, 'abc', 'def')
+      data['def'].should == '123'
+      data.keys.should_not include 'abc'
+    end
+    it 'keeps the original data intact' do
+      data = {'def' => '123'}
+      Razor::Command.add_alias(data, 'abc', 'def')
+      data['def'].should == '123'
+      data.keys.should_not include 'abc'
+    end
+    it 'does nothing if neither the alias nor the attribute is supplied' do
+      data = {}
+      Razor::Command.add_alias(data, 'abc', 'def')
+      data.keys.should == []
+    end
+    # This may not be ideal behavior, but this test is needed in case desired
+    # behavior changes in the future.
+    it 'fails if both are supplied' do
+      data = {'def' => '123', 'abc' => '456'}
+      expect {Razor::Command.add_alias(data, 'abc', 'def')}.
+         to raise_error(Razor::ValidationFailure, "cannot supply both def and abc")
+    end
+  end
+
+  describe 'add_hash_alias' do
+    it 'merges two hashes' do
+      data = {'abc' => {'123' => '456'}, 'def' => {'789' => '012'}}
+      Razor::Command.add_hash_alias(data, 'abc', 'def')
+      data['def'].should == {'123' => '456', '789' => '012'}
+      data.keys.should_not include 'abc'
+    end
+    it 'performs aliasing' do
+      data = {'abc' => {'123' => '456'}}
+      Razor::Command.add_hash_alias(data, 'abc', 'def')
+      data['def'].should == {'123' => '456'}
+      data.keys.should_not include 'abc'
+    end
+    it 'keeps the original data intact' do
+      data = {'def' => {'123' => '456'}}
+      Razor::Command.add_hash_alias(data, 'abc', 'def')
+      data['def'].should == {'123' => '456'}
+      data.keys.should_not include 'abc'
+    end
+  end
+
+  describe 'add_array_alias' do
+    it 'merges two hashes' do
+      data = {'abc' => ['123'], 'def' => ['456']}
+      Razor::Command.add_array_alias(data, 'abc', 'def')
+      data['def'].should == ['456', '123']
+      data.keys.should_not include 'abc'
+    end
+    it 'performs aliasing' do
+      data = {'abc' => ['123']}
+      Razor::Command.add_array_alias(data, 'abc', 'def')
+      data['def'].should == ['123']
+      data.keys.should_not include 'abc'
+    end
+    it 'keeps the original data intact' do
+      data = {'def' => ['123']}
+      Razor::Command.add_array_alias(data, 'abc', 'def')
+      data['def'].should == ['123']
+      data.keys.should_not include 'abc'
+    end
+  end
 end

--- a/spec/data/repo_spec.rb
+++ b/spec/data/repo_spec.rb
@@ -297,7 +297,7 @@ describe Razor::Data::Repo do
         ).on(queue)
       end
 
-      it "should publish 'unpack_repo' with nil path if no url or iso-url" do
+      it "should publish 'unpack_repo' with nil path if no url or iso_url" do
         repo.iso_url = nil
         repo.url = nil
         expect {

--- a/spec/shared_examples/for_commands.rb
+++ b/spec/shared_examples/for_commands.rb
@@ -36,7 +36,7 @@ shared_examples "a command" do | attributes = {}|
           command command_name, without_attribute, :status => status
           last_response.json['error'].should satisfy,
                "should be required, but was: #{last_response.json['error'] or '[success]'}" do |value|
-            required_attribute_string = exclude_key.to_s.gsub('_', '-')
+            required_attribute_string = exclude_key.to_s
             required = (value == "#{required_attribute_string} is a required attribute, but it is not present")
             require_one_of = (value =~ /requires one out of the.+#{required_attribute_string}.+attributes to be supplied/)
             programmatic = (always_require.map(&:to_s).include?(exclude_key) and not value.nil?)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -173,7 +173,9 @@ module Razor::Test
         last_response.command.command.should == name.to_s
         cmd = Razor::Command.find(name: name)
         params = Hash[params.map{|(k,v)| [k.to_s,v]}]
-        last_response.command.params.should == stringify_keys(cmd.conform!(params))
+        # Do the aliasing and conforming before checking the returned params.
+        modified_params = cmd.conform!(cmd.apply_aliases!(params))
+        last_response.command.params.should == stringify_keys(modified_params)
         last_response.command.status.should == status
       end
     end

--- a/spec/tasks/microkernel/bootstrap_spec.rb
+++ b/spec/tasks/microkernel/bootstrap_spec.rb
@@ -44,4 +44,14 @@ describe "tasks/common/boot_local" do
     last_response.status.should == 200
     last_response.body.should =~ /:8150/
   end
+
+  it "should allow both the http_port argument and the nic_max argument" do
+    Razor.config['secure_api'] = false
+    get "/api/microkernel/bootstrap?http_port=8150&nic_max=4", {}, 'HTTPS' => 'off'
+    last_response.status.should == 200
+    last_response.body.should =~ /:8150/
+    4.times.each do |i|
+      last_response.body.should =~ /^[^#]*dhcp\s+net#{i}/m
+    end
+  end
 end

--- a/spec/validation/hash_attribute_spec.rb
+++ b/spec/validation/hash_attribute_spec.rb
@@ -400,4 +400,30 @@ describe Razor::Validation::HashAttribute do
         should =~ %r~#{Regexp.escape(child.help.gsub(/^/, '  ').rstrip)}~
     end
   end
+
+  context "alias" do
+    let(:schema) do
+      Razor::Validation::HashSchema.new('test').tap do |schema|
+        schema.attr('attr', help: 'foo')
+      end
+    end
+
+    subject(:attr) { schema.attribute('attr') }
+
+    [true, false, 1, 1.1, :string, [1, 2]].each do |input|
+      it "should fail unless the alias is a string or array of strings (#{input.inspect})" do
+        expect { attr.alias(input) }.
+            to raise_error(ArgumentError, /alias must be a string or array of strings \(got .+\)/)
+      end
+    end
+
+    ['abc', ['abc', 'def']].each do |input|
+      it "should work with alias #{input}" do
+        expect do
+          attr.alias(input)
+          attr.finalize(schema)
+        end.not_to raise_error
+      end
+    end
+  end
 end

--- a/spec/validation/hash_schema_spec.rb
+++ b/spec/validation/hash_schema_spec.rb
@@ -235,5 +235,33 @@ describe Razor::Validation::HashSchema do
           to raise_error(/extra attributes a, b, c were present in the command, but are not allowed/)
       end
     end
+
+    context "aliases" do
+      before :each do
+        Razor.config['auth.enabled'] = false
+        schema.authz 'none'
+      end
+      it "should apply an alias" do
+        schema.attr('a', alias: 'b', required: true, help: 'foo')
+        schema.finalize
+        schema.validate!({'b' => 2}, nil)
+      end
+      it "should ignore alias if not matched" do
+        schema.attr('a', alias: 'b', required: true, help: 'foo')
+        schema.finalize
+        schema.validate!({'a' => 2}, nil)
+      end
+      it "should throw an error if both are supplied" do
+        schema.attr('a', alias: 'b', required: true, help: 'foo')
+        schema.finalize
+        expect { schema.validate!({'a' => 1, 'b' => 2}, nil) }.
+          to raise_error(/cannot supply both a and b/)
+      end
+      it "should automatically apply aliases for underscores" do
+        schema.attr('a_b_c', required: true, help: 'foo')
+        schema.finalize
+        schema.validate!({'a-b-c' => 2}, nil)
+      end
+    end
   end
 end

--- a/tasks/coreos.task/README.md
+++ b/tasks/coreos.task/README.md
@@ -3,9 +3,9 @@
 ## Definition
 
 Allowing for full clusters of CoreOS to be deployed, automatically
-configuring the setup with heavy use of Razor's node-metadata function to
+configuring the setup with heavy use of Razor's node_metadata function to
 enable features like etcd configuration, fleet metadata, formatting of
-drives and automatic addition of SSH keys. Since the node-metadata is
+drives and automatic addition of SSH keys. Since the node_metadata is
 applied on all nodes, their value can easily be updated with different
 settings on a per-node basis if wanted.
 
@@ -40,7 +40,7 @@ Create tags for whatever you have in your DC that you'd like to use for CoreOS.
 }
 ```
 
-Create a policy and make sure you exchange the following node-metadata with
+Create a policy and make sure you exchange the following node_metadata with
 your own:
 
  - persistent-drive
@@ -58,7 +58,7 @@ your own:
   "hostname": "host.lab.purevirtual.eu",
   "root_password": "secret",
   "max_count": 10,
-  "node-metadata": {
+  "node_metadata": {
 	  "persistent-drive": "sda",
 	  "fleet-metadata": "region=us-east",
 	  "discovery-token": "7577ba844d87b990e2d79717852fb4d4",


### PR DESCRIPTION
In order to standardize the API more, we will use underscores in argument names
rather than dashes. The previous dashes will still be accepted as input, but
the returned values and documentation should be exclusively underscores.

Additionally, if both the dash and underscore arguments are supplied, an
error will be thrown.

For https://tickets.puppetlabs.com/browse/RAZOR-481