### PR TITLE
Add `http_port` argument for bootstrap over HTTPS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
   namespace need to be over HTTPS with SSL, and otherwise will return a 404.
   The actual configuration of this happens in Torquebox's configuration. By
   default, this property is false (no change from current behavior).
++ NEW: If the razor-server is configured to use SSL, any HTTPS calls to
+  /api/microkernel/bootstrap must include the `http_port` argument.
 
 ## 0.16.1 - 2015-01-12
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -676,3 +676,12 @@ culminates in chain loading from the Razor server)
 The URL accepts the parameter `nic_max` which should be set to the maximum
 number of network interfaces that respond to DHCP on any given machine. It
 defaults to 4.
+
+If this request to generate the bootstrap file occurs over HTTPS, the
+`http_port` parameter must be supplied. This is the HTTP (non-SSL/TLS) port
+number that booted nodes will use to communicate with the Razor server.
+
+A full request to render a bootstrap file might look like this, where 8150 is
+the port used for HTTP communication:
+`curl https://user:password@razor-server:8151/api/microkernel/bootstrap?nic_max=4&http_port=8150`
+

--- a/spec/tasks/microkernel/bootstrap_spec.rb
+++ b/spec/tasks/microkernel/bootstrap_spec.rb
@@ -9,6 +9,9 @@ describe "tasks/common/boot_local" do
   before :each do
     Razor.config['auth.enabled'] = false
   end
+  after :each do
+    Razor.config['secure_api'] = false
+  end
 
   subject :boot_local do
     get "/api/microkernel/bootstrap"
@@ -18,5 +21,27 @@ describe "tasks/common/boot_local" do
 
   it "should set the number of tries" do
     boot_local.should =~ /set tries.*0/
+  end
+
+  it "should disallow secure bootstrap requests without http_port argument" do
+    Razor.config['secure_api'] = true
+    get "/api/microkernel/bootstrap", {}, 'HTTPS' => 'on'
+    last_response.status.should == 400
+    last_response.json['error'].should ==
+        'The `http_port` argument must be supplied for bootstrap generation on a secure port'
+  end
+
+  it "should allow secure bootstrap requests with http_port argument" do
+    Razor.config['secure_api'] = true
+    get "/api/microkernel/bootstrap?http_port=8150", {}, 'HTTPS' => 'on'
+    last_response.status.should == 200
+    last_response.body.should =~ /:8150/
+  end
+
+  it "should use the http_port argument for insecure requests" do
+    Razor.config['secure_api'] = false
+    get "/api/microkernel/bootstrap?http_port=8150", {}, 'HTTPS' => 'off'
+    last_response.status.should == 200
+    last_response.body.should =~ /:8150/
   end
 end


### PR DESCRIPTION
Since booted machines cannot by default use the HTTPS port, we need a way to
generate a bootstrap file that points to the correct HTTP port. That port is
managed outside of Razor, so that requires a new argument, `http_port`, to
the bootstrap endpoint that will be used in the generated bootstrap file.

For https://tickets.puppetlabs.com/browse/RAZOR-487