### PR TITLE
RAZOR-513: Make MAC handling consistant

### DIFF
--- a/lib/razor/data/node.rb
+++ b/lib/razor/data/node.rb
@@ -362,7 +362,7 @@ module Razor::Data
         # independent of the order in which the BIOS enumerates NICs. We
         # also don't care about case
         k = "mac" if k =~ /net[0-9]+/
-        [k.downcase, v.strip.downcase]
+        [k.downcase, v.strip.downcase.gsub(":", "-")]
       end.select do |k, _|
         Razor::Config::HW_INFO_KEYS.include?(k) || k.start_with?('fact_')
       end.sort do |a, b|


### PR DESCRIPTION
Fix Razor::Data::Node.canonicalize_hw_info so that it subs :'s for -'s in macs presented in both 'mac' and net\d+ keys in hw_info.  I.e. 

hw_info = {
  'mac'   => ['00:01:02:03:04:05]',  #Currently subs
  'net\d' => '00:01:02:03:04:05',    #Does not sub
}