### PR TITLE
Fix EL7 broker execution

### DIFF
--- a/tasks/redhat.task/kickstart.erb
+++ b/tasks/redhat.task/kickstart.erb
@@ -39,8 +39,8 @@ if [ ! -f /etc/rc.d/rc.local ]; then
   # On systems using systemd /etc/rc.d/rc.local does not exist at all
   # though systemd is set up to run the file if it exists
   touch /etc/rc.d/rc.local
-  chmod a+x /etc/rc.d/rc.local
 fi
+chmod a+x /etc/rc.d/rc.local
 echo bash /root/razor_postinstall.sh >> /etc/rc.d/rc.local
 chmod +x /root/razor_postinstall.sh
 


### PR DESCRIPTION
The broker was not being executed in EL7 builds since the file was not being
marked as executable. It seems like the /etc/rc.d/rc.local file already
existed in EL7 systems, so the permissions were not being set on the file.

For https://tickets.puppetlabs.com/browse/RAZOR-495