### PR TITLE
Add `like` and `str` to matcher

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,8 @@
   HTTP and HTTPS communication instead of `RAZOR_PORT`
 + NEW: If the razor-server is configured to use SSL, any HTTPS calls to
   /api/microkernel/bootstrap must include the `http_port` argument.
++ NEW: The `like` matcher function will allow Regex-based string evaluation
+  when matching nodes to tags.
 + BUGFIX: Any metadata that returned an array or hash caused unreliable
   behavior when referenced in tags. This will now return a helpful error.
 + IMPROVEMENT: The task link in `create-policy` is now optional, deferring to

--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,8 @@
   /api/microkernel/bootstrap must include the `http_port` argument.
 + NEW: The `like` matcher function will allow Regex-based string evaluation
   when matching nodes to tags.
++ NEW: The `str` matcher function will convert numbers, strings, and booleans
+  to strings.
 + BUGFIX: Any metadata that returned an array or hash caused unreliable
   behavior when referenced in tags. This will now return a helpful error.
 + IMPROVEMENT: The task link in `create-policy` is now optional, deferring to

--- a/lib/razor/matcher.rb
+++ b/lib/razor/matcher.rb
@@ -22,6 +22,7 @@ require 'json'
 #             If not, an error is raised unless a second argument is given, in
 #             which case it is returned as the default.
 #   num     - converts arg1 to a numeric value if possible; raises if not
+#   str     - converts arg1 to a string value if possible; raises if not
 #   <, <=   - true if arg1 </<= arg2
 #   >, >=   - true if arg1 >/>= arg2
 #   lower   - string result from converting arg1 to lower case
@@ -67,6 +68,7 @@ class Razor::Matcher
         "neq"      => {:expects => [Mixed],           :returns => Boolean },
         "in"       => {:expects => [Mixed],           :returns => Boolean },
         "num"      => {:expects => [Mixed],           :returns => Number  },
+        "str"      => {:expects => [Mixed],           :returns => [String] },
         "gte"      => {:expects => [[Numeric]],       :returns => Boolean },
         "gt"       => {:expects => [[Numeric]],       :returns => Boolean },
         "lte"      => {:expects => [[Numeric]],       :returns => Boolean },
@@ -155,6 +157,10 @@ class Razor::Matcher
       end
 
       raise RuleEvaluationError.new _("can't convert %{raw} to number") % {raw: value.inspect}
+    end
+
+    def str(*args)
+      args[0].to_s
     end
 
     def gte(*args)

--- a/spec/matcher_spec.rb
+++ b/spec/matcher_spec.rb
@@ -190,6 +190,28 @@ describe Razor::Matcher do
       end
     end
 
+    describe "str" do
+      it "should behave for valid integers" do
+        match("=", ["str", 9      ], "9" ).should == true
+        match("=", ["str", "10"   ], "0" ).should == false
+        match("=", ["str", "0xf"  ], "0xf").should == true
+        match("=", ["str", "0b110"], "0b110" ).should == true
+        match("=", ["str", "027"  ], "027").should == true
+      end
+
+      it "should behave for valid floats" do
+        match("=", ["str", 5.4  ], "5.4").should == true
+        match("=", ["str", "2.7"], "2.7").should == true
+        match("=", ["str", "1e5"], "1e5").should == true
+      end
+
+      it "should behave for valid booleans and nil" do
+        match("=", ["str", true ], "true").should == true
+        match("=", ["str", false], "false").should == true
+        match("=", ["str", nil], '').should == true
+      end
+    end
+
     it "gte should behave" do
       match("gte", 3.5, 4).should == false
       match(">=",  4,   4).should == true
@@ -330,7 +352,11 @@ describe Razor::Matcher do
     end
 
     it "should type the return of num as Numeric" do
-      Matcher.new([">", ["num", "7"], 3]). should be_valid
+      Matcher.new([">", ["num", "7"], 3]).should be_valid
+    end
+
+    it "should type the return of num as String" do
+      Matcher.new(["=", ["str", 7], "7"]).should be_valid
     end
 
     it "should validate nested functions" do


### PR DESCRIPTION
This is a refactored version of https://github.com/puppetlabs/razor-server/pull/186, which contains the original commits and feedback. I tweaked the original commits some to add testing and simplify the implementation.

This adds two functions, `like` and `str`, for performing regular expression matching.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-500