### PR TITLE
Add `update-policy-task` command

### DIFF
--- a/lib/razor/command/update_policy_task.rb
+++ b/lib/razor/command/update_policy_task.rb
@@ -1,0 +1,45 @@
+# -*- encoding: utf-8 -*-
+
+class Razor::Command::UpdatePolicyTask < Razor::Command
+  summary "Update the task associated to a policy"
+  description <<-EOT
+This ensures that the specified policy uses the specified task, setting it
+if necessary. Note that if a node is currently provisioning against this
+policy, errors may arise.
+  EOT
+
+  example api: <<-EOT
+Update policy's task to a task named 'other_task':
+
+    {"node": "node1", "policy": "my_policy", "task": "other_task"}
+  EOT
+
+  example cli: <<-EOT
+Update policy's task to a task named 'other_task':
+
+    razor update-policy-task --policy my_policy --task other_task
+  EOT
+
+  authz '%{policy}'
+
+  attr 'policy', type: String, required: true, references: [Razor::Data::Policy, :name],
+               help: _('The policy that will have its task updated.')
+
+  attr 'task', type: String, required: true,
+              help: _('The task to be used by the policy.')
+
+  def run(request, data)
+    policy = Razor::Data::Policy[:name => data['policy']]
+    task_name = data['task']
+    if policy.task_name != task_name
+      policy.task_name = task_name
+      policy.save
+
+      { :result => _("policy %{name} updated to use task %{task}") %
+          {name: data['policy'], task: data['task']} }
+    else
+      { :result => _("no changes; policy %{name} already uses task %{task}") %
+          {name: data['policy'], task: data['task']} }
+    end
+  end
+end

--- a/spec/app/update_policy_task_spec.rb
+++ b/spec/app/update_policy_task_spec.rb
@@ -1,0 +1,68 @@
+# -*- encoding: utf-8 -*-
+require_relative '../spec_helper'
+require_relative '../../app'
+
+describe Razor::Command::UpdatePolicyTask do
+  include Razor::Test::Commands
+  before 'each' do
+    use_task_fixtures
+  end
+
+  let(:app) { Razor::App }
+
+  let(:policy) do
+    Fabricate(:policy)
+  end
+  let(:task) do
+    Fabricate(:task)
+  end
+  let(:command_hash) do
+    {
+        'policy' => policy.name,
+        'task' => 'some_os',
+    }
+  end
+
+  before :each do
+    header 'content-type', 'application/json'
+    authorize 'fred', 'dead'
+  end
+
+  def update_policy_task(data)
+    command 'update-policy-task', data
+  end
+
+  it_behaves_like "a command"
+
+  it "changes policy's task" do
+    previous_task = policy.task
+    update_policy_task(command_hash)
+    new_task = Razor::Data::Policy[name: command_hash['policy']].task
+    new_task.should_not == previous_task
+    new_task.name.should == 'some_os'
+    last_response.json['result'].should == "policy #{policy.name} updated to use task some_os"
+  end
+
+  it "leaves policy's task when the same" do
+    policy.task_name = 'some_os'
+    policy.save
+    previous_task = policy.task
+    update_policy_task(command_hash)
+    new_task = Razor::Data::Policy[name: command_hash['policy']].task
+    new_task.should_not == previous_task
+    new_task.name.should == 'some_os'
+    last_response.json['result'].should == "no changes; policy #{policy.name} already uses task some_os"
+  end
+
+  it "should fail if the policy is missing" do
+    command_hash.delete('policy')
+    update_policy_task(command_hash)
+    last_response.status.should == 422
+  end
+
+  it "should fail if the task is missing" do
+    command_hash.delete('task')
+    update_policy_task(command_hash)
+    last_response.status.should == 422
+  end
+end


### PR DESCRIPTION
This adds a command, `update-policy-task`, which can be used to set a
policy's associated task after the policy has been created.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-521