### PR TITLE
Serialize policy's tags for output to hook

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,8 @@
   metadata.
 + IMPROVEMENT: The hooks.md file has been revamped, now including a full
   example.
++ BUGFIX: Tags on policies are now being serialized properly when passed to the
+  hook as input.
 
 ## 0.16.1 - 2015-01-12
 

--- a/lib/razor/data/hook.rb
+++ b/lib/razor/data/hook.rb
@@ -390,7 +390,7 @@ class Razor::Data::Hook < Sequel::Model
                :enabled => policy.enabled,
                :hostname_pattern => policy.hostname_pattern,
                :root_password => policy.root_password,
-               :tags => policy.tags,
+               :tags => policy.tags.map { |t| view_object_reference(t) },
                :nodes => {:count => policy.nodes.count},
     } : nil
   end

--- a/spec/data/hook_spec.rb
+++ b/spec/data/hook_spec.rb
@@ -303,7 +303,8 @@ cat <<EOF
 }
 EOF
       CONTENTS
-      node = Fabricate(:bound_node)
+      policy = Fabricate(:policy_with_tag)
+      node = Fabricate(:bound_node, policy: policy, tags: policy.tags)
       Razor::Data::Hook.run('abc', node: node)
 
       # There will also be a 'Node' message on the queue.
@@ -327,11 +328,12 @@ EOF
       input['policy']['broker'].should == node.policy.broker.name
       input['policy']['enabled'].should == node.policy.enabled
       input['policy']['hostname_pattern'].should == node.policy.hostname_pattern
-      input['policy']['tags'].should == node.policy.tags
+      input['policy']['tags'].count.should == node.policy.tags.count
       input['policy']['nodes']['count'].should == node.policy.nodes.count
       input['node']['name'].should == node.name
       input['node']['facts'].count.should == node.facts.count
       input['node']['metadata'].count.should == node.metadata.count
+      input['node']['tags'].count.should == node.tags.count
     end
 
     it "should contain recent metadata if node or hook has changed" do


### PR DESCRIPTION
A policy's associated tags were not being serialized to the hook, leading to
errors right before the script was being executed. This serializes the tags
as an array of tag names, as expected.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-533