### PR TITLE
Hooks configuration "default" should take priority over "required"

### DIFF
--- a/lib/razor/data/hook.rb
+++ b/lib/razor/data/hook.rb
@@ -118,9 +118,9 @@ class Razor::Data::Hook < Sequel::Model
 
       # Required keys that are missing from the supplied configuration.
       schema.each do |key, details|
-        next unless details['required']
         next if configuration.has_key? key
         (configuration[key] = details['default']) and next if details['default']
+        next unless details['required']
         errors.add(:configuration, _("key '%{key}' is required by this hook type, but was not supplied") % {key: key})
       end
     else

--- a/spec/data/hook_spec.rb
+++ b/spec/data/hook_spec.rb
@@ -138,11 +138,14 @@ describe Razor::Data::Hook do
       it "should respect defaults for configuration" do
         configuration = {
             'server'  => {'required' => true, 'description' => 'foo', 'default' => 'abc'},
+            'other'   => {'description' => 'required-absent', 'default' => 'def'},
             'version' => {'required' => false, 'description' => 'bar'}
         }
         set_hook_file('test', 'configuration.yaml' => configuration.to_yaml)
 
-        new_hook.configuration['server'].should == 'abc'
+        hook = new_hook
+        hook.configuration['server'].should == 'abc'
+        hook.configuration['other'].should == 'def'
       end
     end
 


### PR DESCRIPTION
When "required" was absent from a hook's configuration, the "default" argument
took no effect. Better is the reverse case, which is more intuitive: If the
"required" metadatum is omitted, the "default" value will still apply.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-534