### PR TITLE
Use preseed/url in Trusty task

### DIFF
--- a/tasks/ubuntu.task/boot_install.erb
+++ b/tasks/ubuntu.task/boot_install.erb
@@ -4,16 +4,6 @@ echo Installation node: <%= node_url  %>
 echo Installation repo: <%= repo_url %>
 sleep 3
 
-# Loading the preseed file is done this way because of a "feature" where
-# the preseed/url kernel argument is augmented if the url's domain does not
-# contain a period. So if the policy's hostname pattern was
-# "node${id}.example.com", the preseed URL would be mutated from
-# "http://razor-server:8080/svc/file/preseed" to
-# "http://razor-server.example.com:8080/svc/file/preseed" This method grabs
-# the preseed file first, then passes it using preseed/file instead of
-# preseed/url. This method appears to only work with Trusty so far, but will
-# stay as the default unless the next version does not support it.
-initrd <%= file_url("preseed") %> preseed.cfg || goto error
 kernel <%= repo_url("/install/netboot/ubuntu-installer/#{task.architecture}/linux") %> <%= render_template("kernel_args").strip %> || goto error
 initrd <%= repo_url("/install/netboot/ubuntu-installer/#{task.architecture}/initrd.gz") %> || goto error
 boot

--- a/tasks/ubuntu.task/kernel_args.erb
+++ b/tasks/ubuntu.task/kernel_args.erb
@@ -1,1 +1,1 @@
-BOOTIF=01-${netX/mac} preseed/file=preseed.cfg debian-installer/locale=en_US netcfg/no_default_route=true netcfg/choose_interface=auto netcfg/get_hostname=<%= node.shortname %> netcfg/get_domain=<%= node.domainname %> priority=critical
+BOOTIF=01-${netX/mac} preseed/url=<%= file_url("preseed") %> debian-installer/locale=en_US netcfg/no_default_route=true netcfg/choose_interface=auto netcfg/get_hostname=<%= node.shortname %> netcfg/get_domain=<%= node.domainname %> priority=critical

--- a/tasks/ubuntu.task/metadata.yaml
+++ b/tasks/ubuntu.task/metadata.yaml
@@ -1,8 +1,7 @@
 ---
 
-os_version: precise
-architecture: amd64
-label: Ubuntu Precice 12.04
+os_version: trusty
+label: Ubuntu Trusty 14.04
 description: Ubuntu Generic Installer
 boot_sequence:
   1: boot_install

--- a/tasks/ubuntu/lucid.task/boot_install.erb
+++ b/tasks/ubuntu/lucid.task/boot_install.erb
@@ -1,9 +1,0 @@
-#!ipxe
-echo Razor <%= task.label %> task boot_call
-echo Installation node: <%= node_url  %>
-echo Installation repo: <%= repo_url %>
-sleep 3
-
-kernel <%= repo_url("/install/netboot/ubuntu-installer/#{task.architecture}/linux") %> <%= render_template("kernel_args").strip %> || goto error
-initrd <%= repo_url("/install/netboot/ubuntu-installer/#{task.architecture}/initrd.gz") %> || goto error
-boot

--- a/tasks/ubuntu/lucid.task/kernel_args.erb
+++ b/tasks/ubuntu/lucid.task/kernel_args.erb
@@ -1,1 +1,0 @@
-BOOTIF=01-${netX/mac} preseed/url=<%= file_url("preseed") %> debian-installer/locale=en_US netcfg/no_default_route=true netcfg/choose_interface=auto netcfg/get_hostname=<%= node.shortname %> netcfg/get_domain=<%= node.domainname %> priority=critical

--- a/tasks/ubuntu/precise.task/boot_install.erb
+++ b/tasks/ubuntu/precise.task/boot_install.erb
@@ -1,9 +1,0 @@
-#!ipxe
-echo Razor <%= task.label %> task boot_call
-echo Installation node: <%= node_url  %>
-echo Installation repo: <%= repo_url %>
-sleep 3
-
-kernel <%= repo_url("/install/netboot/ubuntu-installer/#{task.architecture}/linux") %> <%= render_template("kernel_args").strip %> || goto error
-initrd <%= repo_url("/install/netboot/ubuntu-installer/#{task.architecture}/initrd.gz") %> || goto error
-boot

--- a/tasks/ubuntu/precise.task/kernel_args.erb
+++ b/tasks/ubuntu/precise.task/kernel_args.erb
@@ -1,1 +1,0 @@
-BOOTIF=01-${netX/mac} preseed/url=<%= file_url("preseed") %> debian-installer/locale=en_US netcfg/no_default_route=true netcfg/choose_interface=auto netcfg/get_hostname=<%= node.shortname %> netcfg/get_domain=<%= node.domainname %> priority=critical


### PR DESCRIPTION
The `preseed/file` method of retrieving the preseed file was not working on
all platforms. This switches back to the `preseed/url` method.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-538