### PR TITLE
UX for hooks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 
 + NEW: The `update-hook-configuration` command allows changing an existing
   hook's configuration, which should help with hook script creation.
++ NEW: The `run-hook` command allows arbitrary execution of a hook.
 
 ## Next - TBD
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@
 + NEW: The `update-hook-configuration` command allows changing an existing
   hook's configuration, which should help with hook script creation.
 + NEW: The `run-hook` command allows arbitrary execution of a hook.
++ NEW: The `store_hook_input` and `store_hook_output` config settings can
+  toggle storing the input and output for a hook script in the event log. These
+  are disabled by default.
 
 ## Next - TBD
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Razor Server Release Notes
 
+## Next.Next - TBD
+
+### Other
+
++ NEW: The `update-hook-configuration` command allows changing an existing
+  hook's configuration, which should help with hook script creation.
+
 ## Next - TBD
 
 ### Incompatible changes

--- a/app.rb
+++ b/app.rb
@@ -394,7 +394,7 @@ and requires full control over the database (eg: add and remove tables):
                        :template => template)
     end
     @node.save
-    Razor::Data::Hook.run('node-booted', node: @node)
+    Razor::Data::Hook.trigger('node-booted', node: @node)
     render_template(template)
   end
 

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -55,6 +55,11 @@ all:
   # Should newly discovered nodes be marked installed?
   protect_new_nodes: false
 
+  # Should hook input be recorded in the event log for debugging?
+  store_hook_input: false
+  # Should hook output be recorded in the event log for debugging?
+  store_hook_output: false
+
   # How to match nodes to possibly existing nodes in the database. The node
   # sends us the MAC addresses of its network interfaces, serial number,
   # asset tag, and UUID. We consider two nodes to be the same if they agree

--- a/doc/api.md
+++ b/doc/api.md
@@ -420,6 +420,26 @@ The code on the server would be contained in the `hooks/some_hook.hook`
 directory. More information on hooks can be found in the Hooks README 
 (`hooks.md`).
 
+### Update hook configuration
+
+A hook's configuration can be updated using the `update-hook-configuration`
+command. This command can set or clear a single key's value. The following
+arguments would set the configuration value for key `some_key` to `new_value`:
+
+    {
+      "hook": "myhook",
+      "key": "some_key",
+      "value": "new_value"
+    }
+
+The following arguments would clear the configuration value for key `some_key`:
+
+    {
+      "hook": "myhook",
+      "key": "some_key",
+      "clear": true
+    }
+
 ### Delete hook
 
 A single hook can be removed from the database with the `delete-hook`

--- a/doc/api.md
+++ b/doc/api.md
@@ -440,6 +440,21 @@ The following arguments would clear the configuration value for key `some_key`:
       "clear": true
     }
 
+### Run hook
+
+The `run-hook` command triggers a hook to execute. This is helpful when writing
+your own hook scripts in testing their validity. To run the hook which would
+occur when the given node boots, use the following arguments:
+
+    {
+      "name": "myhook",
+      "node": "node1",
+      "event": "node-booted"
+    }
+
+Note that any of the usual event names can be used for the `event` argument.
+See `hooks.md` for a list of these possibilities.
+
 ### Delete hook
 
 A single hook can be removed from the database with the `delete-hook`

--- a/doc/hooks.md
+++ b/doc/hooks.md
@@ -131,6 +131,9 @@ The JSON output of the event script can modify the node metadata:
 
 ### Available events
 
+The exact list of events can be seen from the help for the `run-hook` command,
+but here are the primary events:
+
 * `node-registered`: triggered after a node has been registered, i.e. after
   its facts have been set for the first time by the Microkernel.
 * `node-bound-to-policy`: triggered after a node has been bound to a policy. The

--- a/doc/hooks.md
+++ b/doc/hooks.md
@@ -246,6 +246,52 @@ The input to the hook script will be in JSON, containing a structure like below:
   }
 }
 
+## Input format
+
+The input will contain these keys, where many will disappear if their value is
+null:
+
+- hook
+    - id
+    - name
+    - type (this is the hook type)
+    - configuration
+    - cause (this is the event string, e.g. `node-booted`)
+- node
+    - id
+    - name
+    - hw_info
+    - dhcp_mac
+    - tags (array of hash; use `name` for each)
+    - facts
+    - metadata
+    - state
+        - installed
+        - installed_at
+        - stage
+    - power
+        - desired_power_state
+        - last_known_power_state
+        - last_power_state_update_at
+    - hostname
+    - root_password
+    - ipmi
+        - hostname
+        - username
+    - last_checkin
+- policy (for `node-bound-to-policy` and `node-unbound-from-policy` events only)
+    - id
+    - name
+    - repo (object; use `name`)
+    - task (object; use `name`)
+    - broker (object; use `name`)
+    - enabled
+    - hostname_pattern
+    - root_password
+    - tags => (array of objects; use `name` in each)
+    - nodes
+        - count
+
 ## Sample hook
 
 Here is an example of a basic hook that will count the number of times Razor

--- a/lib/razor/command/register_node.rb
+++ b/lib/razor/command/register_node.rb
@@ -74,7 +74,7 @@ installed, so should not be subject to policy-based reinstallation:
   def run(request, data)
     Razor::Data::Node.lookup(data['hw_info']).set(installed: data['installed']).save.
         tap do |node|
-      Razor::Data::Hook.run('node-registered', node: node)
+      Razor::Data::Hook.trigger('node-registered', node: node)
     end
   end
 end

--- a/lib/razor/command/run_hook.rb
+++ b/lib/razor/command/run_hook.rb
@@ -29,9 +29,7 @@ Run the hook 'counter' for the event 'node-booted' with the provided node.
   attr  'name', type: String, required: true, size: 1..250, references: [Razor::Data::Hook, :name],
                 help: _('The name of the hook to run.')
   attr  'event', type: String, required: true,
-                one_of: ['node-booted', 'node-registered', 'node-bound-to-policy',
-                'node-unbound-from-policy', 'node-deleted', 'node-facts-changed',
-                'node-install-finished'],
+                one_of: Razor::Data::Hook::AVAILABLE_EVENTS,
                 help: _('The name of the hook to run.')
 
   attr  'node', type: String, required: true, references: [Razor::Data::Node, :name],

--- a/lib/razor/command/run_hook.rb
+++ b/lib/razor/command/run_hook.rb
@@ -38,12 +38,14 @@ Run the hook 'counter' for the event 'node-booted' with the provided node.
   attr  'policy', type: String, references: [Razor::Data::Policy, :name],
                 help: _('The name of the policy involved in the hook execution (if any).')
 
+  attr 'debug', type: TrueClass, help: _('Whether to include debug information in the resulting event')
+
   def run(request, data)
     hook = Razor::Data::Hook[:name => data['name']]
     node = Razor::Data::Node[:name => data['node']] if data['node']
     policy = Razor::Data::Policy[:name => data['policy']] if data['policy']
 
-    result = hook.run(data['event'], node: node, policy: policy)
+    result = hook.run(data['event'], node: node, policy: policy, debug: data['debug'])
     result = {result: _("no event handler exists for hook %{name}") % {name: data['name']}} if result.nil?
     result
   end

--- a/lib/razor/command/run_hook.rb
+++ b/lib/razor/command/run_hook.rb
@@ -1,0 +1,52 @@
+# -*- encoding: utf-8 -*-
+
+class Razor::Command::RunHook < Razor::Command
+  summary "Run an existing hook"
+  description <<-EOT
+Run an existing hook for the supplied event with the entities referenced in
+this command. This is useful if you are writing a hook script and want to test
+that it works, or if an existing hook execution failed and you need to re-run
+it. The hook execution will happen synchronously.
+  EOT
+
+  example api: <<-EOT
+Run the hook 'counter' for the event 'node-booted' with the provided node.
+
+    {
+      "hook": "counter",
+      "event": "node-booted",
+      "node": "node1"
+    }
+  EOT
+
+  example cli: <<-EOT
+Run the hook 'counter' for the event 'node-booted' with the provided node.
+
+    razor run-node --hook counter --event node-booted --node node1
+  EOT
+
+  authz '%{name}'
+  attr  'name', type: String, required: true, size: 1..250, references: [Razor::Data::Hook, :name],
+                help: _('The name of the hook to run.')
+  attr  'event', type: String, required: true,
+                one_of: ['node-booted', 'node-registered', 'node-bound-to-policy',
+                'node-unbound-from-policy', 'node-deleted', 'node-facts-changed',
+                'node-install-finished'],
+                help: _('The name of the hook to run.')
+
+  attr  'node', type: String, required: true, references: [Razor::Data::Node, :name],
+                help: _('The name of the node involved in the hook execution.')
+
+  attr  'policy', type: String, references: [Razor::Data::Policy, :name],
+                help: _('The name of the policy involved in the hook execution (if any).')
+
+  def run(request, data)
+    hook = Razor::Data::Hook[:name => data['name']]
+    node = Razor::Data::Node[:name => data['node']] if data['node']
+    policy = Razor::Data::Policy[:name => data['policy']] if data['policy']
+
+    result = hook.run(data['event'], node: node, policy: policy)
+    result = {result: _("no event handler exists for hook %{name}") % {name: data['name']}} if result.nil?
+    result
+  end
+end

--- a/lib/razor/command/update_hook_configuration.rb
+++ b/lib/razor/command/update_hook_configuration.rb
@@ -1,0 +1,72 @@
+# -*- encoding: utf-8 -*-
+
+class Razor::Command::UpdateHookConfiguration < Razor::Command
+  summary "Update one key in a hook's configuration"
+  description <<-EOT
+This allows for updating, adding, and removing a single key of a hook's
+configuration.
+  EOT
+
+  example api: <<-EOT
+Set a single key from a node:
+
+    {"node": "node1", "key": "my_key", "value": "twelve"}
+  EOT
+
+  example cli: <<-EOT
+Set a single key from a node:
+
+    razor update-node-metadata --node node1 \\
+        --key my_key --value twelve
+  EOT
+
+  authz '%{hook}'
+
+  attr 'hook', type: String, required: true, references: [Razor::Data::Hook, :name],
+               help: _('The hook for which to update configuration.')
+
+  attr 'key', required: true, type: String, size: 1..Float::INFINITY,
+              help: _('The key to change in the configuration.')
+
+  attr 'value', help: _('The value for the configuration.')
+
+  attr 'clear', type: TrueClass,
+                     help: _(<<-EOT)
+If true, the key will be either reset back to its default or
+removed from the configuration, depending on whether a default exists.
+EOT
+
+  require_one_of 'value', 'clear'
+
+  # Update/add specific configuration key
+  def run(request, data)
+    hook = Razor::Data::Hook[:name => data['hook']]
+    config = hook.configuration
+    result = if data['value']
+               config[data['key']] = data['value']
+               _("value for key %{name} updated") %
+                   {name: data['key']}
+             elsif data['clear'] and config.has_key?(data['key'])
+               config.delete(data['key'])
+               attr_schema = hook.hook_type.configuration_schema[data['key']]
+               if attr_schema['default']
+                 # The actual setting happens as part of the validation.
+                 _("value for key %{name} reset to default") %
+                     {name: data['key']}
+               else
+                 _("key %{name} removed from configuration") %
+                     {name: data['key']}
+               end
+             else
+               _("no changes; key %{name} already absent") %
+                     {name: data['key']}
+             end
+    hook.configuration = config
+    begin
+      hook.save
+      { :result => result }
+    rescue Sequel::ValidationFailed => _
+      request.error 422, :error => _("cannot clear required configuration key #{data['key']}")
+    end
+  end
+end

--- a/lib/razor/command/update_node_metadata.rb
+++ b/lib/razor/command/update_node_metadata.rb
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 class Razor::Command::UpdateNodeMetadata < Razor::Command
-  summary "Update one key in a nodes metadata"
+  summary "Update one key in a node's metadata"
   description <<-EOT
 This is a shortcut to `modify-node-metadata` that allows for updating or
 adding a single key, in a simpler form than the full

--- a/lib/razor/data/hook.rb
+++ b/lib/razor/data/hook.rb
@@ -209,11 +209,13 @@ class Razor::Data::Hook < Sequel::Model
         args[:policy] = policy_hash(policy)
       end
 
+      appender.update(input: args.to_json) if Razor.config['store_hook_input']
       result, output = exec_script(script, args.to_json)
       appender.update(exit_status: result.exitstatus,
                       severity: result.success? ? 'info' : 'error')
       # If the output is not valid JSON, put the whole message into the 'msg' in the Event
       begin
+        appender.update(output: output) if Razor.config['store_hook_output']
         json = JSON.parse(output)
         appender.update(msg: json['output'], error: json['error'])
         residual = json.keys - ['hook', 'node', 'output', 'error']

--- a/lib/razor/data/hook.rb
+++ b/lib/razor/data/hook.rb
@@ -358,6 +358,8 @@ class Razor::Data::Hook < Sequel::Model
     hook = self
     node = args[:node]
     policy = args[:policy] || (node && node.policy)
+    # NOTE: Any updates to this view should be reflected in the `hooks.md`
+    # file as well.
     {
         hook: {
             id: hook.id,

--- a/lib/razor/data/hook.rb
+++ b/lib/razor/data/hook.rb
@@ -30,6 +30,11 @@
 class Razor::Data::Hook < Sequel::Model
   one_to_many :events
 
+  # If this changes, also update the hooks.md file.
+  AVAILABLE_EVENTS = %w(node-booted node-registered node-bound-to-policy
+                        node-unbound-from-policy node-deleted node-facts-changed
+                        node-install-finished)
+
   plugin :serialization, :json, :configuration
 
   serialize_attributes [
@@ -63,6 +68,7 @@ class Razor::Data::Hook < Sequel::Model
   # This runs the hook in-process. If it should be executed asynchronously, use
   # `trigger`. Returns nil if the hook has no handler for the event.
   def run(event, args = {})
+    raise ArgumentError.new("cannot run hook with event #{event}") unless AVAILABLE_EVENTS.include?(event)
     if script = find_script(event)
       # FIXME: args may contain Data objects; they need to be serialized
       # special

--- a/lib/razor/data/node.rb
+++ b/lib/razor/data/node.rb
@@ -218,8 +218,8 @@ module Razor::Data
     end
 
     def unbind
+      Razor::Data::Hook.trigger('node-unbound-from-policy', node: self, policy: self.policy)
       self.policy = nil
-      Razor::Data::Hook.trigger('node-unbound-from-policy', node: self)
     end
 
     # This is a hack around the fact that the auto_validates plugin does

--- a/lib/razor/data/node.rb
+++ b/lib/razor/data/node.rb
@@ -212,14 +212,14 @@ module Razor::Data
         modify_metadata('no_replace' => true, 'update' => policy.node_metadata)
       end
 
-      Razor::Data::Hook.run('node-bound-to-policy', node: self, policy: policy)
+      Razor::Data::Hook.trigger('node-bound-to-policy', node: self, policy: policy)
 
       self
     end
 
     def unbind
       self.policy = nil
-      Razor::Data::Hook.run('node-unbound-from-policy', node: self)
+      Razor::Data::Hook.trigger('node-unbound-from-policy', node: self)
     end
 
     # This is a hack around the fact that the auto_validates plugin does
@@ -331,7 +331,7 @@ module Razor::Data
       end
       if facts != new_facts
         self.facts = new_facts
-        Razor::Data::Hook.run('node-facts-changed', node: self)
+        Razor::Data::Hook.trigger('node-facts-changed', node: self)
       end
       # @todo lutter 2013-09-09: we'd really like to use the DB's idea of
       # time, i.e. have the update statement do 'last_checkin = now()' but
@@ -431,7 +431,7 @@ module Razor::Data
 
     def destroy
       super
-      Razor::Data::Hook.run('node-deleted', node: self)
+      Razor::Data::Hook.trigger('node-deleted', node: self)
     end
 
     # Use the facts +facts+ to fully register the node; this is a
@@ -481,7 +481,7 @@ module Razor::Data
           kill_node.destroy
         end
         keep_node.save
-        Razor::Data::Hook.run('node-registered', node: keep_node)
+        Razor::Data::Hook.trigger('node-registered', node: keep_node)
         keep_node
       end
     end
@@ -493,7 +493,7 @@ module Razor::Data
       node.boot_count += 1
       if name == "finished" and node.policy
         node.installed = node.policy.name
-        Razor::Data::Hook.run('node-install-finished', node: node)
+        Razor::Data::Hook.trigger('node-install-finished', node: node)
       end
       node.save
     end

--- a/spec/app/run_hook_spec.rb
+++ b/spec/app/run_hook_spec.rb
@@ -1,0 +1,76 @@
+# -*- encoding: utf-8 -*-
+require_relative '../spec_helper'
+require_relative '../../app'
+
+describe Razor::Command::RunHook do
+  include Razor::Test::Commands
+
+  use_hook_fixtures
+
+  let(:app) { Razor::App }
+  let(:hook) { Fabricate(:counter_hook)}
+  let(:node) { Fabricate(:node)}
+  let(:command_hash) do
+    {
+        "name" => hook.name,
+        "event" => 'node-booted',
+        "node" => node.name
+    }
+  end
+  before :each do
+    authorize 'fred', 'dead'
+  end
+
+  def run_hook(hash = command_hash)
+    command 'run-hook', hash
+  end
+
+  it_behaves_like "a command"
+
+  before :each do
+    header 'content-type', 'application/json'
+  end
+
+  it "should return the resulting event" do
+    hook.configuration[command_hash['event']].should == 0
+    run_hook
+    last_response.status.should == 202
+    last_response.json['spec'].should =~ /events/
+    event_name = last_response.json['name']
+    event = Razor::Data::Event[id: event_name]
+    event.node_id.should == node.id
+    event.hook_id.should == hook.id
+    event.entry['cause'].should == command_hash['event']
+    event.entry['exit_status'].should == 0
+    event.entry['actions'].should == <<-EOT.strip
+updating hook configuration: {\"update\"=>{\"#{command_hash['event']}\"=>1}} and updating node metadata: {\"update\"=>{\"last_hook_execution\"=>\"#{command_hash['event']}\"}}
+    EOT
+    hook.reload.configuration[command_hash['event']].should == 1
+    node.reload.metadata['last_hook_execution'].should == command_hash['event']
+  end
+
+  it "should say if the hook does not handle the event" do
+    command_hash['event'] = 'node-unbound-from-policy' # Not included in fixture
+    run_hook
+    last_response.status.should == 202
+    last_response.json['result'].should == "no event handler exists for hook #{command_hash['name']}"
+  end
+
+  it "should allow a policy" do
+    command_hash['event'] = 'node-bound-to-policy'
+    policy = Fabricate(:policy)
+    command_hash['policy'] = policy.name
+    run_hook
+    last_response.status.should == 202
+    event_name = last_response.json['name']
+    event = Razor::Data::Event[id: event_name]
+    event.policy_id.should == policy.id
+  end
+
+  it "should require that the event is a real event" do
+    command_hash['event'] = 'not-an-event'
+    run_hook
+    last_response.status.should == 422
+    last_response.json['error'].should == 'event must refer to one of node-booted, node-registered, node-bound-to-policy, node-unbound-from-policy, node-deleted, node-facts-changed, node-install-finished'
+  end
+end

--- a/spec/app/run_hook_spec.rb
+++ b/spec/app/run_hook_spec.rb
@@ -73,4 +73,23 @@ updating hook configuration: {\"update\"=>{\"#{command_hash['event']}\"=>1}} and
     last_response.status.should == 422
     last_response.json['error'].should == 'event must refer to one of node-booted, node-registered, node-bound-to-policy, node-unbound-from-policy, node-deleted, node-facts-changed, node-install-finished'
   end
+
+  it "should respect debug mode" do
+    command_hash['debug'] = true
+    run_hook
+    last_response.status.should == 202
+    event_name = last_response.json['name']
+    event = Razor::Data::Event[id: event_name]
+    event.entry['input'].should_not be_nil
+    event.entry['output'].should_not be_nil
+  end
+
+  it "should default debug mode to off" do
+    run_hook
+    last_response.status.should == 202
+    event_name = last_response.json['name']
+    event = Razor::Data::Event[id: event_name]
+    event.entry['input'].should be_nil
+    event.entry['output'].should be_nil
+  end
 end

--- a/spec/app/update_hook_configuration_spec.rb
+++ b/spec/app/update_hook_configuration_spec.rb
@@ -1,0 +1,101 @@
+# -*- encoding: utf-8 -*-
+require_relative '../spec_helper'
+require_relative '../../app'
+
+describe Razor::Command::UpdateHookConfiguration do
+  include Razor::Test::Commands
+
+  use_hook_fixtures
+
+  let(:app) { Razor::App }
+
+  let(:hook) do
+    Fabricate(:hook_with_configuration)
+  end
+  let(:command_hash) do
+    {
+        'hook' => hook.name,
+        'key' => 'optional-key',
+        'value' => 'new',
+    }
+  end
+
+  before :each do
+    header 'content-type', 'application/json'
+    authorize 'fred', 'dead'
+  end
+
+  def update_config(data)
+    command 'update-hook-configuration', data
+  end
+
+  it_behaves_like "a command"
+
+  context 'update' do
+    [123, '123', ['abc'], {'a' => 123}].each do |new|
+      it 'should update a single existing key' do
+        command_hash['value'] = new
+        update_config(command_hash)
+        last_response.status.should == 202
+        last_response.json['result'].should == 'value for key optional-key updated'
+        hook.reload
+        hook.configuration[command_hash['key']].should == new
+      end
+    end
+  end
+
+  context 'clear' do
+    it 'should clear a single existing key' do
+      command_hash['clear'] = true
+      command_hash.delete('value')
+      command_hash['key'] = 'optional-key'
+      update_config(command_hash)
+      last_response.status.should == 202
+      last_response.json['result'].should == 'key optional-key removed from configuration'
+      hook.reload
+      hook.configuration.should_not include command_hash['key']
+    end
+    it 'should reset key with default back to its default' do
+      command_hash['clear'] = true
+      command_hash.delete('value')
+      command_hash['key'] = 'key-with-default'
+      update_config(command_hash)
+      last_response.status.should == 202
+      last_response.json['result'].should == 'value for key key-with-default reset to default'
+      hook.reload
+      hook.configuration[command_hash['key']].should == 1
+    end
+    it 'should reset an explicitly optional key with default back to its default' do
+      command_hash['clear'] = true
+      command_hash.delete('value')
+      command_hash['key'] = 'optional-key-with-default'
+      update_config(command_hash)
+      last_response.status.should == 202
+      last_response.json['result'].should == 'value for key optional-key-with-default reset to default'
+      hook.reload
+      hook.configuration[command_hash['key']].should == 1
+    end
+
+    it 'should fail to clear a required key' do
+      command_hash['clear'] = true
+      command_hash.delete('value')
+      command_hash['key'] = 'required-key'
+      update_config(command_hash)
+      hook.reload
+      last_response.json['error'].should == 'cannot clear required configuration key required-key'
+      last_response.status.should == 422
+      hook.configuration.should include command_hash['key']
+    end
+
+    it 'should allow nonexistent keys' do
+      command_hash['clear'] = true
+      command_hash.delete('value')
+      command_hash['key'] = 'non-existent'
+      update_config(command_hash)
+      last_response.status.should == 202
+      last_response.json['result'].should == 'no changes; key non-existent already absent'
+      hook.reload
+      hook.configuration.should_not include command_hash['non-existent']
+    end
+  end
+end

--- a/spec/data/hook_spec.rb
+++ b/spec/data/hook_spec.rb
@@ -166,7 +166,7 @@ describe Razor::Data::Hook do
 
   describe "handle" do
     it "should correctly handle an event with no applicable hooks" do
-      Razor::Data::Hook.run('abc', node: Fabricate(:node))
+      Razor::Data::Hook.trigger('abc', node: Fabricate(:node))
     end
     it "should correctly handle an event with two applicable hooks" do
       first = Razor::Data::Hook.new(:name => 'first', :hook_type => hook_type).save
@@ -196,7 +196,7 @@ cat <<EOF
 EOF
 exit 0
       CONTENTS
-      Razor::Data::Hook.run('abc', node: node)
+      Razor::Data::Hook.trigger('abc', node: node)
       queue.count_messages.should == 2
       2.times { run_message(queue.receive) }
       events = Razor::Data::Event.all
@@ -217,7 +217,7 @@ exit 0
       Razor::Data::Hook.new(:name => 'test', :hook_type => hook_type).save
 
       set_hook_file('test', 'abc' => "exit 1") { |file| file.chmod(0644)}
-      Razor::Data::Hook.run('abc', node: Fabricate(:node))
+      Razor::Data::Hook.trigger('abc', node: Fabricate(:node))
       events = Razor::Data::Event.all
       events.size.should == 1
       events.first.entry['msg'].should =~ /abc is not executable/
@@ -245,7 +245,7 @@ cat <<EOF
 EOF
 exit #{exitcode}
         CONTENTS
-        Razor::Data::Hook.run('abc', node: node)
+        Razor::Data::Hook.trigger('abc', node: node)
         queue.count_messages.should == 1
         run_message(queue.receive)
         event = Razor::Data::Event.find(hook_id: hook.id)
@@ -272,7 +272,7 @@ cat <<EOF
 EOF
 exit 0
       CONTENTS
-      Razor::Data::Hook.run('abc', node: node)
+      Razor::Data::Hook.trigger('abc', node: node)
       queue.count_messages.should == 1
       run_message(queue.receive)
       event = Razor::Data::Event.find(hook_id: hook.id)
@@ -306,7 +306,7 @@ EOF
       CONTENTS
       policy = Fabricate(:policy_with_tag)
       node = Fabricate(:bound_node, policy: policy, tags: policy.tags)
-      Razor::Data::Hook.run('abc', node: node)
+      Razor::Data::Hook.trigger('abc', node: node)
 
       # There will also be a 'Node' message on the queue.
       messages = queue.count_messages.times.map {queue.receive}
@@ -356,7 +356,7 @@ cat <<EOF
 EOF
       CONTENTS
       node = Fabricate(:bound_node)
-      Razor::Data::Hook.run('abc', node: node)
+      Razor::Data::Hook.trigger('abc', node: node)
 
       # There will also be a 'Node' message on the queue.
       messages = queue.count_messages.times.map {queue.receive}
@@ -406,7 +406,7 @@ cat <<EOF
 EOF
       CONTENTS
       node = Fabricate(:bound_node)
-      Razor::Data::Hook.run('abc', node: node, policy: node.policy)
+      Razor::Data::Hook.trigger('abc', node: node, policy: node.policy)
 
       # There will also be a 'Node' message on the queue.
       messages = queue.count_messages.times.map {queue.receive}
@@ -463,7 +463,7 @@ EOF
 exit #{exit}
         CONTENTS
         hook.configuration['counter'].should == 0
-        Razor::Data::Hook.run('abc')
+        Razor::Data::Hook.trigger('abc')
         queue.count_messages.should == 1
         run_message(queue.receive)
         hook.reload
@@ -500,7 +500,7 @@ exit #{exit}
         CONTENTS
         node.metadata = {'existing' => 'value', 'to-remove' => 'other-value'}
         node.save
-        Razor::Data::Hook.run('abc', node: node)
+        Razor::Data::Hook.trigger('abc', node: node)
         # There will also be a 'Node' message on the queue.
         messages = queue.count_messages.times.map {queue.receive}
         event = messages.select {|message| message['class'] == 'Razor::Data::Hook'}.first
@@ -532,7 +532,7 @@ EOF
       CONTENTS
       node.metadata = {'existing' => 'value'}
       node.save
-      Razor::Data::Hook.run('abc', node: node)
+      Razor::Data::Hook.trigger('abc', node: node)
       # There will also be a 'Node' message on the queue.
       messages = queue.count_messages.times.map {queue.receive}
       event = messages.select {|message| message['class'] == 'Razor::Data::Hook'}.first
@@ -552,7 +552,7 @@ standard output
 EOF
 exit 0
       CONTENTS
-      Razor::Data::Hook.run('abc', node: node)
+      Razor::Data::Hook.trigger('abc', node: node)
       queue.count_messages.should == 1
       run_message(queue.receive)
 
@@ -586,7 +586,7 @@ cat <<EOF
 }
 EOF
       CONTENTS
-      Razor::Data::Hook.run('abc')
+      Razor::Data::Hook.trigger('abc')
       queue.count_messages.should == 1
       run_message(queue.receive)
 
@@ -615,7 +615,7 @@ EOF
       CONTENTS
       node.metadata = {'existing' => 'value'}
       node.save
-      Razor::Data::Hook.run('abc', node: node)
+      Razor::Data::Hook.trigger('abc', node: node)
       # There will also be a 'Node' message on the queue.
       messages = queue.count_messages.times.map {queue.receive}
       event = messages.select {|message| message['class'] == 'Razor::Data::Hook'}.first
@@ -639,7 +639,7 @@ cat <<EOF
 }
 EOF
       CONTENTS
-      Razor::Data::Hook.run('abc', node: node)
+      Razor::Data::Hook.trigger('abc', node: node)
       queue.count_messages.should == 1
       run_message(queue.receive)
       Razor::Data::Event.first.entry['error'].should == 'unexpected key in hook\'s output: other-key'
@@ -661,7 +661,7 @@ cat <<EOF
 }
 EOF
       CONTENTS
-      Razor::Data::Hook.run('abc', node: node)
+      Razor::Data::Hook.trigger('abc', node: node)
       queue.count_messages.should == 1
       run_message(queue.receive)
       Razor::Data::Event.first.entry['error'].should == 'unexpected key in hook\'s output for node update: other-key'
@@ -683,7 +683,7 @@ cat <<EOF
 }
 EOF
       CONTENTS
-      Razor::Data::Hook.run('abc', node: node)
+      Razor::Data::Hook.trigger('abc', node: node)
       queue.count_messages.should == 1
       run_message(queue.receive)
       Razor::Data::Event.first.entry['error'].should == 'unexpected key in hook\'s output for hook update: other-key'
@@ -704,7 +704,7 @@ cat <<EOF
 }
 EOF
       CONTENTS
-      Razor::Data::Hook.run('abc', node: node)
+      Razor::Data::Hook.trigger('abc', node: node)
       queue.count_messages.should == 1
       run_message(queue.receive)
       Razor::Data::Event.first.entry['error'].should == 'hook output for hook configuration should be an object but was a string'
@@ -725,7 +725,7 @@ cat <<EOF
 }
 EOF
       CONTENTS
-      Razor::Data::Hook.run('abc', node: node)
+      Razor::Data::Hook.trigger('abc', node: node)
       queue.count_messages.should == 1
       run_message(queue.receive)
       Razor::Data::Event.first.entry['error'].should == 'hook output for hook configuration should be an object but was a string'
@@ -750,7 +750,7 @@ cat <<EOF
 }
 EOF
       CONTENTS
-      Razor::Data::Hook.run('abc', node: node)
+      Razor::Data::Hook.trigger('abc', node: node)
       queue.count_messages.should == 1
       run_message(queue.receive)
       Razor::Data::Event.first.entry['error'].should == "undefined operation on hook: do-thing; should be 'update' or 'remove'"

--- a/spec/fabricators/fabricator.rb
+++ b/spec/fabricators/fabricator.rb
@@ -163,6 +163,18 @@ Fabricator(:hook, :class_name => Razor::Data::Hook) do
   end
 end
 
+Fabricator(:hook_with_configuration, :from => :hook) do
+  hook_type do
+    path = Pathname(__FILE__).dirname + '..' + 'fixtures' + 'hooks' + 'with_configuration.hook'
+    Razor::HookType.new(path)
+  end
+  configuration do
+    {'key-with-default' => 'original',
+     'required-key' => 'other-original',
+     'optional-key' => 'a value'}
+  end
+end
+
 Fabricator(:event, :class_name => Razor::Data::Event) do
   entry do
     {msg: Faker::Commerce.product_name}

--- a/spec/fabricators/fabricator.rb
+++ b/spec/fabricators/fabricator.rb
@@ -175,6 +175,13 @@ Fabricator(:hook_with_configuration, :from => :hook) do
   end
 end
 
+Fabricator(:counter_hook, :from => :hook) do
+  hook_type do
+    path = Pathname(__FILE__).dirname + '..' + 'fixtures' + 'hooks' + 'counter.hook'
+    Razor::HookType.new(path)
+  end
+end
+
 Fabricator(:event, :class_name => Razor::Data::Event) do
   entry do
     {msg: Faker::Commerce.product_name}

--- a/spec/fixtures/hooks/counter.hook/configuration.yaml
+++ b/spec/fixtures/hooks/counter.hook/configuration.yaml
@@ -1,0 +1,28 @@
+---
+node-booted:
+  description: "The number of times a node has booted"
+  default: 0
+
+node-bound-to-policy:
+  description: "The number of times a node has bound to a policy"
+  default: 0
+
+node-deleted:
+  description: "The number of times a node has been deleted"
+  default: 0
+
+node-facts-changed:
+  description: "The number of times a node's facts have changed"
+  default: 0
+
+node-install-finished:
+  description: "The number of times a node's install has finished"
+  default: 0
+
+node-registered:
+  description: "The number of times a node has been registered"
+  default: 0
+
+node-unbound-from-policy:
+  description: "The number of times a node has unbound from a policy"
+  default: 0

--- a/spec/fixtures/hooks/counter.hook/node-booted
+++ b/spec/fixtures/hooks/counter.hook/node-booted
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+set -e
+
+json=$(< /dev/stdin)
+
+value=1
+
+cat <<EOF
+{
+  "hook": {
+    "configuration": {
+      "update": {
+        "node-booted": $value
+      }
+    }
+  },
+  "node": {
+    "metadata": {
+      "update": {
+        "last_hook_execution": "node-booted"
+      }
+    }
+  }
+}
+EOF

--- a/spec/fixtures/hooks/counter.hook/node-bound-to-policy
+++ b/spec/fixtures/hooks/counter.hook/node-bound-to-policy
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+set -e
+
+json=$(< /dev/stdin)
+
+value=1
+
+cat <<EOF
+{
+  "hook": {
+    "configuration": {
+      "update": {
+        "node-bound-to-policy": $value
+      }
+    }
+  },
+  "node": {
+    "metadata": {
+      "update": {
+        "last_hook_execution": "node-bound-to-policy"
+      }
+    }
+  }
+}
+EOF

--- a/spec/fixtures/hooks/counter.hook/node-deleted
+++ b/spec/fixtures/hooks/counter.hook/node-deleted
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+set -e
+
+json=$(< /dev/stdin)
+
+value=1
+
+cat <<EOF
+{
+  "hook": {
+    "configuration": {
+      "update": {
+        "node-deleted": $value
+      }
+    }
+  },
+  "node": {
+    "metadata": {
+      "update": {
+        "last_hook_execution": "node-deleted"
+      }
+    }
+  }
+}
+EOF

--- a/spec/fixtures/hooks/counter.hook/node-facts-changed
+++ b/spec/fixtures/hooks/counter.hook/node-facts-changed
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+set -e
+
+json=$(< /dev/stdin)
+
+value=1
+
+cat <<EOF
+{
+  "hook": {
+    "configuration": {
+      "update": {
+        "node-facts-changed": $value
+      }
+    }
+  },
+  "node": {
+    "metadata": {
+      "update": {
+        "last_hook_execution": "node-facts-changed"
+      }
+    }
+  }
+}
+EOF

--- a/spec/fixtures/hooks/counter.hook/node-install-finished
+++ b/spec/fixtures/hooks/counter.hook/node-install-finished
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+set -e
+
+json=$(< /dev/stdin)
+
+value=1
+
+cat <<EOF
+{
+  "hook": {
+    "configuration": {
+      "update": {
+        "node-install-finished": $value
+      }
+    }
+  },
+  "node": {
+    "metadata": {
+      "update": {
+        "last_hook_execution": "node-install-finished"
+      }
+    }
+  }
+}
+EOF

--- a/spec/fixtures/hooks/counter.hook/node-registered
+++ b/spec/fixtures/hooks/counter.hook/node-registered
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+set -e
+
+json=$(< /dev/stdin)
+
+value=1
+
+cat <<EOF
+{
+  "hook": {
+    "configuration": {
+      "update": {
+        "node-registered": $value
+      }
+    }
+  },
+  "node": {
+    "metadata": {
+      "update": {
+        "last_hook_execution": "node-registered"
+      }
+    }
+  }
+}
+EOF

--- a/spec/fixtures/hooks/with_configuration.hook/configuration.yaml
+++ b/spec/fixtures/hooks/with_configuration.hook/configuration.yaml
@@ -1,6 +1,13 @@
 ---
-some-key:
-  description: "Some variable."
+key-with-default:
+  description: "Some variable with a default."
   default: 1
-some-other-key:
-  description: "Some other variable."
+required-key:
+  description: "Some required variable."
+  required: true
+optional-key:
+  description: "Some optional variable."
+optional-key-with-default:
+  description: "Some optional variable with a default."
+  required: false
+  default: 1

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -180,15 +180,11 @@ module Razor::Test
         params = Hash[params.map{|(k,v)| [k.to_s,v]}]
         # Do the aliasing and conforming before checking the returned params.
         modified_params = cmd.conform!(cmd.apply_aliases!(params))
+        # Overwrite with special nested hash values.
         modified_params = deep_merge(modified_params, opts[:expect]) if opts[:expect]
         last_response.command.params.should == stringify_keys(modified_params)
         last_response.command.status.should == status
       end
-    end
-
-    def deep_merge(original, new)
-      merger = proc { |key,v1,v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2 }
-      new.merge(original, &merger)
     end
 
     def stringify_keys(hash)
@@ -200,6 +196,16 @@ module Razor::Test
         end
         memo
       end
+    end
+
+    private
+    # This method melds all values from `new` into `original` using the same
+    # structure. `new` must be a hash or nested hash, otherwise will be ignored.
+    # If there exists a value for `new`, it will clobber the corresponding value
+    # in `original` unless both are hashes, in which case the items are merged.
+    def deep_merge(original, new)
+      merger = proc { |key,v1,v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2 }
+      new.merge(original, &merger)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -82,6 +82,7 @@ FIXTURES_PATH = File::expand_path("fixtures", File::dirname(__FILE__))
 INST_PATH = File::join(FIXTURES_PATH, "tasks")
 
 BROKER_FIXTURE_PATH = File.join(FIXTURES_PATH, 'brokers')
+HOOK_FIXTURE_PATH = File.join(FIXTURES_PATH, 'hooks')
 
 def use_task_fixtures
   Razor.config["task_path"] = INST_PATH
@@ -89,6 +90,10 @@ end
 
 def use_broker_fixtures
   Razor.config["broker_path"] = BROKER_FIXTURE_PATH
+end
+
+def use_hook_fixtures
+  Razor.config["hook_path"] = HOOK_FIXTURE_PATH
 end
 
 # Make sure our migration is current, or fail hard.
@@ -175,9 +180,15 @@ module Razor::Test
         params = Hash[params.map{|(k,v)| [k.to_s,v]}]
         # Do the aliasing and conforming before checking the returned params.
         modified_params = cmd.conform!(cmd.apply_aliases!(params))
+        modified_params = deep_merge(modified_params, opts[:expect]) if opts[:expect]
         last_response.command.params.should == stringify_keys(modified_params)
         last_response.command.status.should == status
       end
+    end
+
+    def deep_merge(original, new)
+      merger = proc { |key,v1,v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2 }
+      new.merge(original, &merger)
     end
 
     def stringify_keys(hash)


### PR DESCRIPTION
This adds three features which will help users write hooks:
- `run-hook` to arbitrarily execute a hook
- `update-hook-configuration` to change a hook's configuration
- `store_hook_input` and `store_hook_output` for recording debugging information in the event log.

For https://tickets.puppetlabs.com/browse/RAZOR-388