### PR TITLE
Find file in directory - Needed for Hooks to work

### DIFF
--- a/lib/razor/data/hook.rb
+++ b/lib/razor/data/hook.rb
@@ -163,7 +163,7 @@ class Razor::Data::Hook < Sequel::Model
   # absolute path. Return nil if there is no such script
   def find_script(cause)
     Razor.config.hook_paths.collect do |path|
-      Pathname.new(path) + "#{hook_type.name}.hook" + cause
+      Pathname.new(path) + "#{hook_type.name}.hook/" + cause
     end.find do |script|
       script.file? and (script.executable? or (!log_append(msg: _("file %{script} is not executable") % {script: script}, severity: 'warn', event: cause) ))
     end


### PR DESCRIPTION
Without the slash it will look for a file called hook_type.hookcause instead of cause in the hook_type.hook directory.