### PR TITLE
Reinstall node with same policy

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 ### Other
 
 + NEW: Task added for Windows 2008 R2. Details are on the [Wiki](https://github.com/puppetlabs/razor-server/wiki/Installing-windows).
++ NEW: `reinstall-node` now accepts a `same_policy` argument, which indicates
+  that the node should skip over the microkernel and policy-binding stage,
+  and just proceed with a reinstall of the current policy.
 
 ## 1.0.1 - 2015-06-11
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -485,10 +485,19 @@ This command removes a node's association with any policy and clears its
 `installed` flag; once the node reboots, it will boot back into the
 Microkernel and go through discovery, tag matching and possibly be bound to
 another policy. This command does not change its metadata or facts. Specify
-which node to unbind by sending the node's name in the body of the request
+which node to unbind by sending the node's name in the body of the request:
 
     {
       "name": "node17"
+    }
+
+The `same_policy` flag can be used to skip the microkernel boot and policy
+binding stage, installing the same task/repo/policy again. This is most helpful
+when developing a custom task.
+
+    {
+      "name": "node17",
+      "same_policy: true
     }
 
 ### Set node IPMI credentials

--- a/lib/razor/command/reinstall_node.rb
+++ b/lib/razor/command/reinstall_node.rb
@@ -7,18 +7,29 @@ Remove a node's association with any policy and clears its `installed` flag;
 once the node reboots, it will boot back into the Microkernel and go through
 discovery, tag matching and possibly be bound to another policy. This command
 does not change its metadata or facts.
+
+To skip the Microkernel boot and policy-binding step, use the `same-policy`
+attribute to simply clear the install flag.
   EOT
 
   example api: <<-EOT
 Make 'node17' available for reinstallation:
 
-    {"name": "node17"}
+    { "name": "node17" }
+
+Reinstall 'node17' using its same policy:
+
+    { "name": "node17", "same_policy": true }
   EOT
 
   example cli: <<-EOT
 Make 'node17' available for reinstallation:
 
     razor reinstall-node --name node17
+
+Reinstall 'node17' using its same policy:
+
+    razor reinstall-node --name node17 --same-policy
   EOT
 
 
@@ -26,13 +37,16 @@ Make 'node17' available for reinstallation:
   attr  'name', type: String, required: true, references: Razor::Data::Node,
                 help: _('The name of the node to flag for reinstallation.')
 
+  attr  'same_policy', type: :bool, help: _('Keep the same policy for the node.')
+
   def run(request, data)
+    data['same_policy'] ||= false
     actions = []
 
     node = Razor::Data::Node[:name => data['name']]
     log = { :event => :reinstall }
 
-    if node.policy
+    if node.policy and not data['same_policy']
       log[:policy_name] = node.policy.name
       node.unbind
       actions << _("node unbound from %{policy}") % {policy: log[:policy_name]}
@@ -42,6 +56,7 @@ Make 'node17' available for reinstallation:
       log[:installed] = node.installed
       node.installed = nil
       node.installed_at = nil
+      node.boot_count = 1
       actions << _("installed flag cleared")
     end
 

--- a/lib/razor/data/task.rb
+++ b/lib/razor/data/task.rb
@@ -8,8 +8,20 @@ module Razor::Data
   # Note that we duck type this with Razor::Task so that they can be used
   # interchangeably for template lookup etc.
   class Task < Sequel::Model
-    plugin :serialization, :json, :boot_seq
     plugin :serialization, :json, :templates
+    # Standard json serialization doesn't work here.
+    # JSON serializes integers as strings, undo that
+    serialize_attributes [
+                         ->(b){ b.to_json },               # serialize
+                         ->(b){
+                           if b.is_a?(String)
+                             b = JSON.parse(b)
+                             b.keys.select { |k| k.is_a?(String) and k =~ /^[0-9]+$/ }.
+                                 each { |k| b[k.to_i] = b.delete(k) }
+                           end
+                           b
+                         } # deserialize
+                         ], :boot_seq
 
     one_to_many :events, :key => :task_name, :primary_key => :name
 

--- a/spec/data/task_spec.rb
+++ b/spec/data/task_spec.rb
@@ -10,10 +10,6 @@ describe Razor::Data::Task do
     end
   end
 
-  before(:each) do
-    use_task_fixtures
-  end
-
   subject(:task) do
     Razor::Data::Task.create(
       :name => 'test',
@@ -124,6 +120,9 @@ describe Razor::Data::Task do
   end
 
   describe "find_template" do
+    before(:each) do
+      use_task_fixtures
+    end
     it "raises TemplateNotFoundError for nonexistent template" do
       expect {
         task.find_template('no such template').should_not be_nil
@@ -150,6 +149,7 @@ describe Razor::Data::Task do
 
   describe "boot_template" do
     it "uses the boot template with the right seq" do
+      task.reload
       node = Razor::Data::Node.new(:hw_info => ["mac=deadbeef"],
                                    :boot_count => 0)
       ["boot_install", "boot_again", "boot_local", "boot_local"].each do |t|

--- a/spec/fabricators/fabricator.rb
+++ b/spec/fabricators/fabricator.rb
@@ -46,7 +46,7 @@ Fabricator(:task, :class_name => Razor::Data::Task) do
   os            { Faker::Commerce.product_name }
   os_version    { random_version }
   description   { Faker::Lorem.sentence }
-  boot_seq      {{'default' => 'boot_local'}}
+  boot_seq      {{1 => 'boot_first', 'default' => 'boot_local'}}
 end
 
 Fabricator(:tag, :class_name => Razor::Data::Tag) do


### PR DESCRIPTION
Two related changes here:

- BUGFIX: Fixing deserialization of database task's boot sequence
- NEW: Allow reinstall-node with same policy

The former caused problems in the testing of the latter, so has been included in the same pull request.