### PR TITLE
Fix razor-server service on EL7

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 ### Other
 
++ BUGFIX: The EL7 packages will now start the razor-server service properly.
 + BUGFIX: Tasks created through the `create-task` command will now find
   the correct boot stage, rather than feeding the `default` stage at each boot.
 + NEW: Task added for Windows 2008 R2. Details are on the [Wiki](https://github.com/puppetlabs/razor-server/wiki/Installing-windows).

--- a/ext/redhat/razor-server.env
+++ b/ext/redhat/razor-server.env
@@ -8,3 +8,4 @@ JBOSS_MODULES_SYSTEM_PKGS=org.jboss.byteman
 LAUNCH_JBOSS_IN_BACKGROUND=true
 LANG=en_US.UTF-8
 JAVA_OPTS="-Xms128m -Xmx1024m -XX:MaxPermSize=256m -Djava.net.preferIPv4Stack=true"
+HTTP_PORT=8080


### PR DESCRIPTION
Systemd's .service file was referencing the absent HTTP_PORT variable. This
resulted in an empty string being passed to the service for its http.port
argument. Since an empty string can't be translated to an integer, this error
resulted:

JBAS014688: Wrong type for port. Expected [EXPRESSION, INT] but was STRING

The fix is simply supplying this environment variable, which works here in
the .env file.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-629