### PR TITLE
Add support for erb templates in hostname pattern

### DIFF
--- a/lib/razor/data/node.rb
+++ b/lib/razor/data/node.rb
@@ -1,4 +1,6 @@
 # -*- encoding: utf-8 -*-
+require 'erb'
+
 module Razor::Data
   class DuplicateNodeError < RuntimeError
     attr_reader :hw_info, :nodes
@@ -207,7 +209,9 @@ module Razor::Data
       #    policy or not
       self.installed = nil
       self.root_password = policy.root_password
-      self.hostname = policy.hostname_pattern.gsub(/\$\{\s*id\s*\}/, id.to_s)
+      self.hostname = ERB.new(
+          policy.hostname_pattern.gsub(/\$\{\s*id\s*\}/, id.to_s)
+      ).result(binding)
 
       if policy.node_metadata
         modify_metadata('no_replace' => true, 'update' => policy.node_metadata)

--- a/spec/data/node_spec.rb
+++ b/spec/data/node_spec.rb
@@ -233,7 +233,7 @@ describe Razor::Data::Node do
     end
 
     it "is set from the policy's hostname_pattern when bound" do
-      policy.hostname_pattern = "host${id}.example.org"
+      policy.hostname_pattern = "host<%= id %>.example.org"
       policy.save
       node.bind(policy)
       node.hostname.should == "host#{node.id}.example.org"

--- a/spec/fabricators/fabricator.rb
+++ b/spec/fabricators/fabricator.rb
@@ -57,7 +57,7 @@ end
 Fabricator(:policy, :class_name => Razor::Data::Policy) do
   name             { Faker::Commerce.product_name + " #{Fabricate.sequence}" }
   enabled          true
-  hostname_pattern 'host${id}.example.org'
+  hostname_pattern 'host<%= @id %>.example.org'
   root_password    { Faker::Internet.password }
 
   repo
@@ -144,7 +144,6 @@ Fabricator(:bound_node, from: :node) do
   end
 
   after_save do |node, _|
-    node.hostname = node.policy.hostname_pattern.gsub('${id}', node.id.to_s)
     node.save
   end
 end


### PR DESCRIPTION
Instead of gsub the id this will just use the erb template. Should allow to use facts/metadata when creating host name. Also should allow customizing the id