### PR TITLE
Get current policy count

### DIFF
--- a/lib/razor/data/node.rb
+++ b/lib/razor/data/node.rb
@@ -1,4 +1,6 @@
 # -*- encoding: utf-8 -*-
+require 'erb'
+
 module Razor::Data
   class DuplicateNodeError < RuntimeError
     attr_reader :hw_info, :nodes
@@ -207,7 +209,7 @@ module Razor::Data
       #    policy or not
       self.installed = nil
       self.root_password = policy.root_password
-      self.hostname = policy.hostname_pattern.gsub(/\$\{\s*id\s*\}/, id.to_s)
+      self.hostname = ERB.new(policy.hostname_pattern).result(binding)
 
       if policy.node_metadata
         modify_metadata('no_replace' => true, 'update' => policy.node_metadata)

--- a/lib/razor/data/node.rb
+++ b/lib/razor/data/node.rb
@@ -209,6 +209,7 @@ module Razor::Data
       #    policy or not
       self.installed = nil
       self.root_password = policy.root_password
+      self.current_policy_count = Node.dataset.filter(:policy_id => self.policy.id).count() + 1
       self.hostname = ERB.new(policy.hostname_pattern).result(binding)
 
       if policy.node_metadata

--- a/lib/razor/data/node.rb
+++ b/lib/razor/data/node.rb
@@ -209,7 +209,7 @@ module Razor::Data
       #    policy or not
       self.installed = nil
       self.root_password = policy.root_password
-      self.current_policy_count = Node.dataset.filter(:policy_id => self.policy.id).count() + 1
+      current_policy_count = Node.dataset.filter(:policy_id => self.policy.id).count() + 1
       self.hostname = ERB.new(policy.hostname_pattern).result(binding)
 
       if policy.node_metadata

--- a/spec/app/create_policy_spec.rb
+++ b/spec/app/create_policy_spec.rb
@@ -28,7 +28,7 @@ describe Razor::Command::CreatePolicy do
         'repo'          => repo.name,
         'task'          => 'some_os',
         'broker'        => broker.name,
-        'hostname'      => "host${id}.example.com",
+        'hostname'      => "host<%= id %>.example.com",
         'root_password' => "geheim",
         'tags'          => [ tag1.name ]
       }

--- a/spec/data/node_spec.rb
+++ b/spec/data/node_spec.rb
@@ -233,9 +233,10 @@ describe Razor::Data::Node do
     end
 
     it "is set from the policy's hostname_pattern when bound" do
-      policy.hostname_pattern = "host${id}.example.org"
+      policy.hostname_pattern = "host<%= id %>.example.org"
       policy.save
       node.bind(policy)
+      puts node.id
       node.hostname.should == "host#{node.id}.example.org"
     end
   end

--- a/spec/fabricators/fabricator.rb
+++ b/spec/fabricators/fabricator.rb
@@ -57,7 +57,7 @@ end
 Fabricator(:policy, :class_name => Razor::Data::Policy) do
   name             { Faker::Commerce.product_name + " #{Fabricate.sequence}" }
   enabled          true
-  hostname_pattern 'host${id}.example.org'
+  hostname_pattern 'host<%= @id %>.example.org'
   root_password    { Faker::Internet.password }
 
   repo
@@ -144,7 +144,6 @@ Fabricator(:bound_node, from: :node) do
   end
 
   after_save do |node, _|
-    node.hostname = node.policy.hostname_pattern.gsub('${id}', node.id.to_s)
     node.save
   end
 end


### PR DESCRIPTION
This is a added feature on top of #316 that will get the current number of nodes attached to this policy so you can use this in your hostname erb template. This is nice in that each policy declares its hostname and I want to use the count to setup app1, and db1, but have them as node1, and node2.