### PR TITLE
Add support for bypassing authentication, if request is from localhost.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -82,13 +82,18 @@ and requires full control over the database (eg: add and remove tables):
       org.apache.shiro.SecurityUtils.subject
     end
 
+    # Check if request is from localhost and if bypass for localhost is enabled
+    def local_request?
+      request.ip == '127.0.0.1' and Razor.config['auth.allow_localhost']
+    end
+
     # Assert that the current user has (all of) the specified permissions, and
     # raise an exception if they do not.  We handle that exception generically
     # at the top level.
     #
     # If security is disabled then this simply succeeds.
     def check_permissions!(*which)
-      Razor.config['auth.enabled'] and user.check_permissions(*which)
+      Razor.config['auth.enabled'] and not local_request? and user.check_permissions(*which)
       true
     end
 

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -34,6 +34,8 @@ all:
     # relative path it is relative to the root directory of the
     # Razor installation.
     config: shiro.ini
+    # Allow request to '/api' from localhost even if authentication is enabled.
+    allow_localhost: false
 
   microkernel:
     debug_level: debug

--- a/lib/razor/middleware/auth.rb
+++ b/lib/razor/middleware/auth.rb
@@ -30,6 +30,10 @@ class Razor::Middleware::Auth
     subject.authenticated? or subject.remembered?
   end
 
+  def local?(req)
+    req.ip == '127.0.0.1' and Razor.config['auth.allow_localhost']
+  end
+
   def call(env)
     # Try authentication, regardless of security being enabled or disabled.
     req = Rack::Request.new(env)
@@ -37,7 +41,7 @@ class Razor::Middleware::Auth
 
     # @todo danielp 2013-12-17: at the moment we trust either authenticated
     # or remembered credentials, even though we don't support the later.
-    if enabled? and protected_path?(req) and not authenticated?(subject)
+    if enabled? and protected_path?(req) and not authenticated?(subject) and not local?(req)
       # Auth was required, but we were neither authenticated or remembered.
       [401, {'WWW-Authenticate' => 'Basic realm="Razor"'}, ["Access Denied\n"]]
     else


### PR DESCRIPTION
Puppet modules currently available for configuring razor itself do not support authentication.
This changes add support to enable a bypass option for requests to /api from localhost.

Example puppet module that can be used with this option.

Access from remote to the /api still needs authentication.
Example use case:
External application that communicates with razor.