### PR TITLE
Update store_ip shell script to check broadcast interface

### DIFF
--- a/tasks/common/store_ip.erb
+++ b/tasks/common/store_ip.erb
@@ -1,6 +1,6 @@
 <%# -*- shell-script -*- %>
 # Get current IP
-node_ip=$(ip addr show eth0 | awk '/inet / { sub("/[0-9]+$", "", $2); print $2 }')
+node_ip=$(ip addr show | grep -A 2 BROADCAST | grep inet | awk '{ print $2 }' | awk -F'/' '{print $1}')
 echo IP is $node_ip
 
 # Send IP up


### PR DESCRIPTION
This commit updates the store_ip shell script used to get the primary IP address to dynamically determine the primary interface based on what is marked for broadcast by ip. Without this change the script fails to get the IP address for a CentOS 7 host due to a hard coded eth0 value. This has been tested on CentOS and Debian and provides the primary broadcast IP address in both cases.