### PR TITLE
Check to see if Samba share is accessible

### DIFF
--- a/tasks/windows.task/second-stage.ps1.erb
+++ b/tasks/windows.task/second-stage.ps1.erb
@@ -21,6 +21,12 @@ write-host "mapping SMB share ${drive_path} for installer access"
 # As far as I can tell, if we don't persist, we don't connect the SMB share,
 # and that means we can't actually run stuff off it.
 new-psdrive -name 'i' -psprovider filesystem -root "$($drive_path)" -persist
+If (!(Test-Path i:))
+{
+        Invoke-WebRequest -Uri "<%= log_url("samba share not accessible ${drive_path}", :error) %>" -UseBasicParsing
+        write-error "samba share not accessible ${drive_path}"
+        exit 1
+}
 start-sleep 10                  # time to settle -- needed on my VM :/
 
 write-host "starting installer ${installer}"


### PR DESCRIPTION
If the Samba share with the winpe.wim is not reachable, or the node is unable to create a network connection to it, it would fail, but the script would still complete "successfully".  This would put the node into a bad state where the new OS was not installed, but Razor had it marked as successfully installed.  This simply tests to ensure the node can reach the samba share, and if it is unsuccessful logs the error with razor and exits the script prior to marking the node as installed.