### PR TITLE
(maint) Fix occasional CI test failures

### DIFF
--- a/spec/app/command_browser_spec.rb
+++ b/spec/app/command_browser_spec.rb
@@ -10,6 +10,14 @@ describe "command browser API" do
 
   # We want a command available for testing, unrelated to the default ones.
   let :cmd do Class.new(Razor::Command) end
+  # The `stub_const` call below has a side effect of not deleting the test
+  # Command from the @commands instance variable. This `around` hook reverts
+  # the list when the test is completed.
+  around :each do |example|
+    commands = Razor::Command.instance_variable_get('@commands').dup
+    example.run
+    Razor::Command.instance_variable_set('@commands', commands)
+  end
   before :each do stub_const('Razor::Command::TestBrowsing', cmd) end
 
   def last_response

--- a/spec/help_spec.rb
+++ b/spec/help_spec.rb
@@ -200,6 +200,15 @@ but the rest of the text is
       Class.new(Razor::Command)
     end
 
+    # The `stub_const` call below has a side effect of not deleting the test
+    # Command from the @commands instance variable. This `around` hook reverts
+    # the list when the test is completed.
+    around :each do |example|
+      commands = Razor::Command.instance_variable_get('@commands').dup
+      example.run
+      Razor::Command.instance_variable_set('@commands', commands)
+    end
+
     before :each do
       stub_const('Razor::Command::TestHelpRendering', cmd)
     end


### PR DESCRIPTION
A few spec tests had unintentional side effects, which caused sporadic test
failures. These tests stubbed fake command objects, which were functionally
deleted after the test finished. However, a copy of these command objects was
retained, causing them remain in the list of all command objects. The new API
tests surfaced this issue, which depended on the order in which tests were
executed.

The original list of these commands will be reverted after each test case
that has a side effect, overwriting the version with the fake command objects.