### PR TITLE
Include shebang line in /etc/rc.d/rc.local

### DIFF
--- a/tasks/centos.task/kickstart.erb
+++ b/tasks/centos.task/kickstart.erb
@@ -40,7 +40,7 @@ curl -s -o /root/razor_postinstall.sh <%= file_url("post_install") %>
 if [ ! -f /etc/rc.d/rc.local ]; then
   # On systems using systemd /etc/rc.d/rc.local does not exist at all
   # though systemd is set up to run the file if it exists
-  touch /etc/rc.d/rc.local
+  echo '#!/bin/bash' > /etc/rc.d/rc.local
 fi
 chmod a+x /etc/rc.d/rc.local
 echo bash /root/razor_postinstall.sh >> /etc/rc.d/rc.local

--- a/tasks/redhat.task/kickstart.erb
+++ b/tasks/redhat.task/kickstart.erb
@@ -53,7 +53,7 @@ curl -s -o /root/razor_postinstall.sh <%= file_url("post_install") %>
 if [ ! -f /etc/rc.d/rc.local ]; then
   # On systems using systemd /etc/rc.d/rc.local does not exist at all
   # though systemd is set up to run the file if it exists
-  touch /etc/rc.d/rc.local
+  echo '#!/bin/bash' > /etc/rc.d/rc.local
 fi
 chmod a+x /etc/rc.d/rc.local
 echo bash /root/razor_postinstall.sh >> /etc/rc.d/rc.local


### PR DESCRIPTION
On installs with systemd, the kickstart file will drop the /etc/rc.d/rc.local
file without a shebang line at the start. This causes, in some cases, the
post_install script not to run.

This fixes the simple `touch` command to instead drop a shebang line.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-754