### PR TITLE
Add Fedora 23 task

### DIFF
--- a/tasks/fedora.task/README.md
+++ b/tasks/fedora.task/README.md
@@ -1,0 +1,13 @@
+# Task notes for Fedora 23
+
+## Node Metadata
+
+- 'timezone' (optional) - This is the string corresponding to the timezone for
+  the node.
+  - Default: America/Los_Angeles
+- 'root_password' (optional) - This is an override for the root_password that
+  exists on the node when it binds to a policy. If this is provided, it will be
+  used for the node's root password.
+- 'hostname' (optional) - This is an override for the hostname that exists
+  on the node when it binds to a policy. If this is provided, it will be used
+  for the node's hostname.

--- a/tasks/fedora.task/kickstart.erb
+++ b/tasks/fedora.task/kickstart.erb
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Kickstart for RHEL/CentOS 6
+# see: http://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/6/html/Installation_Guide/s1-kickstart2-options.html
+
+install
+url --url=<%= repo_url %>
+cmdline
+lang en_US.UTF-8
+keyboard us
+rootpw <%= node.metadata['root_password'] || node.root_password %>
+network --hostname <%= node.metadata['hostname'] || node.hostname %>
+firewall --enabled --ssh
+authconfig --enableshadow --passalgo=sha512 --enablefingerprint
+timezone --utc <%= node.metadata['timezone'] || 'America/Los_Angeles' %>
+# Avoid having 'rhgb quiet' on the boot line
+bootloader --location=mbr --append="crashkernel=auto"
+# The following is the partition information you requested
+# Note that any partitions you deleted are not expressed
+# here so unless you clear all partitions first, this is
+# not guaranteed to work
+zerombr
+clearpart --all --initlabel
+autopart
+# reboot automatically
+reboot
+
+# following is MINIMAL https://partner-bugzilla.redhat.com/show_bug.cgi?id=593309
+%packages
+@core
+
+%end
+
+%post --log=/var/log/razor.log
+echo Kickstart post
+curl -s -o /root/razor_postinstall.sh <%= file_url("post_install") %>
+
+# Run razor_postinstall.sh on next boot via rc.local
+if [ ! -f /etc/rc.d/rc.local ]; then
+  # On systems using systemd /etc/rc.d/rc.local does not exist at all
+  # though systemd is set up to run the file if it exists
+  echo '#!/bin/bash' >> /etc/rc.d/rc.local
+fi
+chmod a+x /etc/rc.d/rc.local
+echo bash /root/razor_postinstall.sh >> /etc/rc.d/rc.local
+chmod +x /root/razor_postinstall.sh
+
+curl -s <%= stage_done_url("kickstart") %>
+%end
+############

--- a/tasks/fedora.task/metadata.yaml
+++ b/tasks/fedora.task/metadata.yaml
@@ -1,0 +1,9 @@
+---
+
+os_version: 23
+label: Fedora 23
+description: Fedora Generic installer
+base: redhat
+boot_sequence:
+  1: boot_install
+  default: boot_local

--- a/tasks/fedora/23.task/README.md
+++ b/tasks/fedora/23.task/README.md
@@ -1,0 +1,13 @@
+# Task notes for Fedora 23
+
+## Node Metadata
+
+- 'timezone' (optional) - This is the string corresponding to the timezone for
+  the node.
+  - Default: America/Los_Angeles
+- 'root_password' (optional) - This is an override for the root_password that
+  exists on the node when it binds to a policy. If this is provided, it will be
+  used for the node's root password.
+- 'hostname' (optional) - This is an override for the hostname that exists
+  on the node when it binds to a policy. If this is provided, it will be used
+  for the node's hostname.

--- a/tasks/fedora/23.task/metadata.yaml
+++ b/tasks/fedora/23.task/metadata.yaml
@@ -1,0 +1,8 @@
+---
+
+os_version: 23
+label: Fedora 23
+description: Fedora 23 installer
+boot_sequence:
+  1: boot_install
+  default: boot_local


### PR DESCRIPTION
This adds a task for Fedora 23. Fedora releases happen quickly, so this might
only be relevant for a year, but these same steps should be valid for future
releases as well.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-755