### PR TITLE
Delete repo directory when repo is deleted

### DIFF
--- a/lib/razor/data/repo.rb
+++ b/lib/razor/data/repo.rb
@@ -34,6 +34,13 @@ module Razor::Data
       end
     end
 
+    def remove_directory(dir)
+      if Dir.exist?(iso_location)
+        FileUtils.chmod_R('+w', dir, force: true)
+        FileUtils.remove_entry_secure(dir)
+      end
+    end
+
     # When we are destroyed, if we have a scratch directory, we need to
     # remove it.
     def after_destroy
@@ -46,7 +53,9 @@ module Razor::Data
 
       # Remove repo directory.
       if Dir.exist?(iso_location)
-        FileUtils.remove_entry_secure(iso_location, true)
+        # Some files in archives are write-only. Change this property so the
+        # delete succeeds.
+        remove_directory(iso_location)
       end
     end
 
@@ -175,6 +184,7 @@ module Razor::Data
     # done, notify ourselves of that so any cleanup required can be performed.
     def unpack_repo(command, path)
       destination = iso_location
+      remove_directory(iso_location)
       destination.mkpath        # in case it didn't already exist
       Archive.extract(path, destination) if path
       self.publish('release_temporary_repo', command)

--- a/spec/data/repo_spec.rb
+++ b/spec/data/repo_spec.rb
@@ -437,6 +437,7 @@ describe Razor::Data::Repo do
         repo = Fabricate.build(:repo)
         repo.unpack_repo(command, tiny_iso)
         unpacked_iso_dir = File::join(repo_dir, repo.name)
+        FileUtils.chmod_R('-w', unpacked_iso_dir, force: true)
         Dir.exist?(unpacked_iso_dir).should be_true
         repo.save
         repo.destroy
@@ -541,6 +542,19 @@ describe Razor::Data::Repo do
         repo.unpack_repo(command, tiny_iso)
 
         root.should exist
+      end
+    end
+
+    it "should work if the repo dir is already present" do
+      Dir.mktmpdir do |root|
+        root = Pathname(root)
+        Razor.config['repo_store_root'] = root
+        repo_dir = Pathname(root) + repo.name
+        repo_dir.mkdir
+        file = repo_dir + 'some-undeletable-file'
+        file.open('w'){|f| f.print 'cant delete this' }
+        FileUtils.chmod('-w', file)
+        repo.unpack_repo(command, tiny_iso)
       end
     end
 


### PR DESCRIPTION
When the user runs `razor delete-repo --name some-repo`, the intent is to
delete the folder if the user supplied an `iso-url` property. That was, in many
cases, not happening because many ISO archives contain files which are
read-only, so the secure delete attempt fails.

The fix for this is to update the contents of the repo directory to allow write
privileges so they can be deleted properly.

This manifested when the user tried to create a new repo with the same name.
The archive extraction would fail from libarchive, and the error was "Can't
unlink already-existing object", likely from the same permissions reason.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-757