### PR TITLE
Escape unsafe characters in kickstart

### DIFF
--- a/tasks/centos.task/kickstart.erb
+++ b/tasks/centos.task/kickstart.erb
@@ -3,15 +3,23 @@
 # see: http://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/6/html/Installation_Guide/s1-kickstart2-options.html
 
 install
+#raw
 url --url=<%= repo_url %>
+#end raw
 cmdline
 lang en_US.UTF-8
 keyboard us
+#raw
 rootpw <%= node.metadata['root_password'] || node.root_password %>
+#end raw
+#raw
 network --hostname <%= node.metadata['hostname'] || node.hostname %>
+#end raw
 firewall --enabled --ssh
 authconfig --enableshadow --passalgo=sha512 --enablefingerprint
+#raw
 timezone --utc <%= node.metadata['timezone'] || 'America/Los_Angeles' %>
+#end raw
 # This skips over the subscription for redhat.
 
 # Avoid having 'rhgb quiet' on the boot line
@@ -34,7 +42,9 @@ reboot
 
 %post --log=/var/log/razor.log
 echo Kickstart post
+#raw
 curl -s -o /root/razor_postinstall.sh <%= file_url("post_install") %>
+#end raw
 
 # Run razor_postinstall.sh on next boot via rc.local
 if [ ! -f /etc/rc.d/rc.local ]; then
@@ -46,6 +56,8 @@ chmod a+x /etc/rc.d/rc.local
 echo bash /root/razor_postinstall.sh >> /etc/rc.d/rc.local
 chmod +x /root/razor_postinstall.sh
 
+#raw
 curl -s <%= stage_done_url("kickstart") %>
+#end raw
 %end
 ############

--- a/tasks/redhat.task/kickstart.erb
+++ b/tasks/redhat.task/kickstart.erb
@@ -3,10 +3,13 @@
 # see: http://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/6/html/Installation_Guide/s1-kickstart2-options.html
 
 install
+#raw
 url --url=<%= repo_url %>
+#end raw
 cmdline
 lang en_US.UTF-8
 keyboard us
+#raw
 rootpw <%= node.metadata['root_password'] || node.root_password %>
 network --hostname <%= node.metadata['hostname'] || node.hostname %>
 firewall --enabled --ssh
@@ -16,6 +19,7 @@ timezone --utc <%= node.metadata['timezone'] || 'America/Los_Angeles' %>
 rhel_username="<%= node.metadata['rhn_username'] %>"
 rhel_password="<%= node.metadata['rhn_password'] %>"
 rhel_activationkey="<%= node.metadata['rhn_activationkey'] %>"
+#end raw
 # If either username or password exist, run the command
 if [ "$rhel_username" != "" -o "$rhel_password" != "" ]; then
     if [ -z "$rhel_activationkey" ] ; then
@@ -47,7 +51,9 @@ reboot
 
 %post --log=/var/log/razor.log
 echo Kickstart post
+#raw
 curl -s -o /root/razor_postinstall.sh <%= file_url("post_install") %>
+#end raw
 
 # Run razor_postinstall.sh on next boot via rc.local
 if [ ! -f /etc/rc.d/rc.local ]; then
@@ -59,6 +65,8 @@ chmod a+x /etc/rc.d/rc.local
 echo bash /root/razor_postinstall.sh >> /etc/rc.d/rc.local
 chmod +x /root/razor_postinstall.sh
 
+#raw
 curl -s <%= stage_done_url("kickstart") %>
+#end raw
 %end
 ############

--- a/tasks/vmware_esxi.task/ks.cfg.erb
+++ b/tasks/vmware_esxi.task/ks.cfg.erb
@@ -29,7 +29,9 @@ wget <%= stage_done_url("kickstart") %>
 
 %firstboot --interpreter=busybox
 # set the hostname correctly before we do anythig else
+#raw
 esxcli system hostname set --fqdn <%= node.metadata['hostname'] || node.hostname %>
+#end raw
 
 # enable HV (Hardware Virtualization to run nested 64bit Guests + Hyper-V VM)
 grep -i 'vhv.allow' /etc/vmware/config || echo 'vhv.allow = 'TRUE'' >> /etc/vmware/config


### PR DESCRIPTION
In cases where interpolation occurs in a kickstart file, special characters
could be rendered which change the meaning of the file or make it invalid. This
wraps such problematic cases in a sanitizing block to prevent such issues from
occurring.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-205
