### PR TITLE
Removed the OS upgrade commands

### DIFF
--- a/tasks/ubuntu.task/os_boot.erb
+++ b/tasks/ubuntu.task/os_boot.erb
@@ -8,16 +8,6 @@ exec >> /var/log/razor.log 2>&1
 # APT configuration and system update
 sed -i s$'\001'<%= repo_url %>$'\001'http://gb.archive.ubuntu.com/ubuntu$'\001' /etc/apt/sources.list
 
-apt-get -y update
-[ "$?" -eq 0 ] || curl -s <%= log_url("apt_update_fail", :error) %>
-
-apt-get -y upgrade
-[ "$?" -eq 0 ] || curl -s <%= log_url("apt_upgrade_fail", :error) %>
-
-apt-get -y dist-upgrade
-[ "$?" -eq 0 ] || curl -s <%= log_url("apt_dist_upgrade_fail", :error) %>
-
-
 <%= render_template("store_ip") %>
 
 <%= render_template("os_complete") %>


### PR DESCRIPTION
Removed apt-get commands from os_boot.erb

The os_boot.erb script is run at every boot and must not be doing any kind of upgrade. This is dangerous and undermines the administrator.