### PR TITLE
Removed apt-get commands from os_boot.erb

### DIFF
--- a/tasks/debian.task/os_boot.erb
+++ b/tasks/debian.task/os_boot.erb
@@ -5,11 +5,6 @@ exec >> /var/log/razor.log 2>&1
 <%= render_template("set_hostname") %>
 
 sed -i 's_<%= repo_url("archive.ubuntu.com/ubuntu_g")%>' /etc/apt/sources.list
-apt-get -y update
-[ "$?" -eq 0 ] || curl -s <%= log_url("apt_update_fail", :error) %>
-
-apt-get -y upgrade
-[ "$?" -eq 0 ] || curl -s <%= log_url("apt_upgrade_fail", :error) %>
 
 <%= render_template("store_ip") %>
 

--- a/tasks/ubuntu.task/os_boot.erb
+++ b/tasks/ubuntu.task/os_boot.erb
@@ -8,16 +8,6 @@ exec >> /var/log/razor.log 2>&1
 # APT configuration and system update
 sed -i s$'\001'<%= repo_url %>$'\001'http://gb.archive.ubuntu.com/ubuntu$'\001' /etc/apt/sources.list
 
-apt-get -y update
-[ "$?" -eq 0 ] || curl -s <%= log_url("apt_update_fail", :error) %>
-
-apt-get -y upgrade
-[ "$?" -eq 0 ] || curl -s <%= log_url("apt_upgrade_fail", :error) %>
-
-apt-get -y dist-upgrade
-[ "$?" -eq 0 ] || curl -s <%= log_url("apt_dist_upgrade_fail", :error) %>
-
-
 <%= render_template("store_ip") %>
 
 <%= render_template("os_complete") %>


### PR DESCRIPTION
The os_boot script is run at every boot. This should never be upgrading the os it undermines the administrator.
