### PR TITLE
(RAZOR-779) match (but do not bind) when protect_new_nodes is true

### DIFF
--- a/spec/app/provisioning_spec.rb
+++ b/spec/app/provisioning_spec.rb
@@ -288,7 +288,7 @@ describe "provisioning API" do
       last_response.status.should == 404
     end
   end
-  
+
   describe "storing node metadata" do
     before(:each) do
       @node = Fabricate(:node)
@@ -512,8 +512,6 @@ describe "provisioning API" do
         node.registered?.should be_true
         node.installed.should == installed
         node.policy.should be_nil
-        # Checkin will not try to evaluate tags on installed nodes
-        node.tags.should be_empty
       end
     end
   end


### PR DESCRIPTION
Prior to this commit, when protect_new_nodes was set to true, nodes
would not be matched or bound. This commit changes the behavior so
that new nodes will always be matched, even if they are not bound
due to protect_new_nodes being set to true.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-779