### PR TITLE
Unsigned build winpe

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
   (through e.g. the `protect_new_nodes` config) or bound to a policy.
 + NEW: Added positional arguments to API. These will be included in the help
   for each command.
++ NEW: Added flag "allowunsigned" to allow unsigned drivers to be added to the
+  WinPE image for Windows installations.
 + IMPROVEMENT: Updated and standardized documentation and metadata for existing
   stock tasks. Labels, descriptions, and README.md files inside these stock
   tasks should now be up-to-date.

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@
   tasks should now be up-to-date.
 + IMPROVEMENT: Updated Debian and Ubuntu stock tasks to use Pacific Time rather
   than Central Time and UTC, respectively.
++ IMPROVEMENT: Made the Powershell script that builds Razor's WinPE image more
+  robust in its error handling.
 + IMPROVEMENT: Added documentation for the `update-broker-configuration` command
   to api.md.
 + IMPROVEMENT: Add datatype for `node` argument of `set-node-hw-info` command.


### PR DESCRIPTION
For security purposes, the default requirement for drivers to get added to the
WinPE image is that they be signed by a valid authority. Several third-party
drivers exist, and may need to be added to the WinPE image. This commit
includes a flag, "allowunsigned", which, when specified, allows unsigned
drivers to be added to the image. Without this flag supplied, unsigned
drivers in the `extra-drivers` directory will throw an error.

Also included here are improvements to make the build-razor-winpe.ps1
script more robust.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-761