### PR TITLE
Fix r_just no implicit conversion error in hostname.hook

### DIFF
--- a/hooks/hostname.hook/node-bound-to-policy
+++ b/hooks/hostname.hook/node-bound-to-policy
@@ -22,7 +22,7 @@ else
   # This could just as easily call an external system to retrieve the node's
   # hostname.
   new_hostname = config['hostname_pattern'].
-                 gsub('${count}', policy_counter.to_s.rjust(config['padding'], '0')).
+                 gsub('${count}', policy_counter.to_s.rjust(config['padding'].to_i, '0')).
                  gsub('${policy}', input['policy']['name'])
   output = {
       'node' => {


### PR DESCRIPTION
`r_just` has no implicit conversion from string (`config['padding']`) into integer, manually using `.to_i` to fix it.