### PR TITLE
Add Puppet-AIO Broker.

### DIFF
--- a/brokers/puppet-aio.broker/configuration.yaml
+++ b/brokers/puppet-aio.broker/configuration.yaml
@@ -1,0 +1,7 @@
+---
+certname:
+  description: "The locally unique name for this node."
+server:
+  description: "The puppet master server to request configurations from."
+environment:
+  description: "On agent nodes, the environment to request configuration in."

--- a/brokers/puppet-aio.broker/install.erb
+++ b/brokers/puppet-aio.broker/install.erb
@@ -1,0 +1,161 @@
+#!/bin/bash
+<% require 'shellwords' %>
+set -u
+set -e
+
+# Some utility functions.
+fail() { echo >&2 "$@"; exit 1; }
+warn() { echo >&2 "$@"; }
+cmd()  { hash "$1" >&/dev/null; } # portable 'which'
+
+
+# Figure out which package installer is available and, consequently, which OS
+# family we are running on.  Then get `lsb_release` installed on
+# this platform.
+#
+# Thankfully, we don't care which variant we are on because they are uniformly
+# enough structured to make sense.
+if cmd lsb_release; then
+    :                           # nothing to do
+elif cmd apt-get; then
+    # All the distributions I am familiar with inherited this package name
+    # from Debian itself.
+    apt-get -y install lsb-release
+    apt_install
+elif cmd yum; then
+    # We try the second path just in case some distribution comes up with the
+    # brilliant idea that this needs to work before `/usr` can be mounted or
+    # something akin to that.
+    #
+    # This installs a lot of potentially undesirable packages on EL5 systems.
+    # Sorry about that -- take it up with your upstream.  EL6+ improve that.
+    yum -y install /usr/bin/lsb_release || \
+        yum -y install /bin/lsb_release || \
+        fail "neither /usr/bin/lsb_release or /bin/lsb_release found with yum!"
+else
+    fail "neither yum or apt are installed, so I can't figure out what next!"
+fi
+
+
+# Now we have that, we can install our platform specific package to define
+# the repositories.  Thankfully this is also pretty damn simple to get right.
+# In this case we don't skip installation even if the package was already
+# present, since the tool should handle that, and it may gather updates as a
+# consequence of taking the action.
+flavour="$(lsb_release -i | cut -f 2 | tr '[:upper:]' '[:lower:]')"
+case "${flavour}" in
+    centos|redhat*)
+        release="$(lsb_release -r | cut -f2 | cut -d. -f1)"
+        # @todo danielp 2013-09-30: this should be updated to reflect the
+        # portable names once https://jira.puppetlabs.com/browse/RE-359 is
+        # addressed and we have those available.
+        case "${release}" in
+            5) url="https://yum.puppetlabs.com/puppetlabs-release-pc1-el-5.noarch.rpm" ;;
+            6) url="https://yum.puppetlabs.com/puppetlabs-release-pc1-el-6.noarch.rpm" ;;
+            7) url="https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm" ;;
+            *) fail "sorry, don't know how release ${release} works!" ;;
+        esac
+
+        # No need to update package lists for yum, and rpm will fetch the pkg
+        # for us, which is convenient.
+        rpm -q puppetlabs-release || \
+            rpm -ihv "${url}"     || \
+            fail "unable to install the EL repository data file"
+
+        # Install Puppet
+        yum -y install puppet-agent
+        ;;
+
+    fedora)
+        release="$(lsb_release -r | cut -f2 | cut -d. -f1)"
+        case "$release" in
+            20) url="http://yum.puppetlabs.com/puppetlabs-release-pc1-fedora-20.noarch.rpm" ;;
+            21) url="http://yum.puppetlabs.com/puppetlabs-release-pc1-fedora-21.noarch.rpm" ;;
+            22) url="http://yum.puppetlabs.com/puppetlabs-release-pc1-fedora-22.noarch.rpm" ;;
+            *) fail "sorry, don't know how release ${release} works!" ;;
+        esac
+
+        # No need to update package lists for yum, and rpm will fetch the pkg
+        # for us, which is convenient.
+        rpm -q puppetlabs-release || \
+            rpm -ihv "${url}"     || \
+            fail "unable to install the EL repository data file"
+
+        yum -y install puppet-agent
+        ;;
+
+    debian|ubuntu)
+        codename="$(lsb_release -c | cut -f 2 | tr '[:upper:]' '[:lower:]')"
+        package="puppetlabs-release-pc1-${codename}.deb"
+        if cmd curl; then
+            curl -o /tmp/"${package}" http://apt.puppetlabs.com/"${package}" || \
+                fail "unable to download ${package}"
+        elif cmd wget; then
+            wget -O /tmp/"${package}" http://apt.puppetlabs.com/"${package}" || \
+                fail "unable to download ${package}"
+        else
+            fail "sorry, can't find curl or wget to download the package"
+        fi
+
+        # Install the repo data, then fetch newer package lists.
+        dpkg -i /tmp/"${package}" || fail "unable to install ${package}"
+        apt-get -y update
+        apt-get -y install puppet-agent
+        ;;
+
+    *)
+        fail "I don't know what flavour distribution '${flavour}' is, sorry."
+        ;;
+esac
+
+
+<% unless broker.empty? %>
+# Now, configuration.  Much as I love the idea of editing an ini file with
+# basic Unix tools like sed and awk, this seems much less worse, even if it
+# puts a puppet module you might not expect into place on disk.
+/opt/puppetlabs/bin/puppet module install puppetlabs/inifile
+
+# Update the ini file with the resource tool.
+<% broker.each do |setting, value| %>
+/opt/puppetlabs/bin/puppet resource ini_setting ensure=present path=/etc/puppetlabs/puppet/puppet.conf section=main setting=<%= setting.shellescape %> value=<%= value.shellescape %>
+<% end %>
+<% end %>
+
+# For debugging, just in case, dump out the modified confirmation file.
+echo ====================[ /etc/puppetlabs/puppet/puppet.conf ]=========================
+cat /etc/puppetlabs/puppet/puppet.conf
+echo ========================================================================
+
+
+
+# Finally, set Puppet to auto-start, and run the daemon.
+case "${flavour}" in
+    centos|redhat*)
+        chkconfig puppet on
+        service puppet start
+        ;;
+
+    fedora)
+        systemctl enable puppetagent
+        systemctl start puppetagent
+        ;;
+
+    debian|ubuntu)
+        # puppet is automatically configured to run on boot, but...
+        sed -i -e 's/^START=.*$/START=yes/' /etc/default/puppet
+        /etc/init.d/puppet start
+        ;;
+
+    *)
+        fail "I don't know what flavour distribution '${flavour}' is, sorry."
+        ;;
+esac
+
+# Log that the broker is finished.
+if cmd curl; then
+    curl -sL "<%= stage_done_url %>" || fail "curl failed to log broker completion"
+elif cmd wget; then
+    wget -qO- "<%= stage_done_url %>" || fail "wget failed to log broker completion" &> /dev/null
+else
+    warn "neither curl nor wget installed; cannot log completion of broker"
+fi

--- a/spec/brokers/puppet-aio_spec.rb
+++ b/spec/brokers/puppet-aio_spec.rb
@@ -1,0 +1,92 @@
+# -*- encoding: utf-8 -*-
+require 'spec_helper'
+
+describe Razor::BrokerType.find(name: 'puppet-aio') do
+  let :broker do
+    Razor::Data::Broker.new(:name => 'puppet-test', :broker_type => subject)
+  end
+
+  let :node do
+    # I wish there were a better way to fake this, I guess.
+    mac = (1..6).map {'0123456789ABCDEF'.split('').sample(2).join }
+    Razor::Data::Node.new(
+      :hw_info  => ["mac=#{mac.join("-")}"],
+      :dhcp_mac => mac.join(':'),
+      :facts    => {'kernel' => 'simulated', 'osversion' => 'over 9000'},
+      :hostname => "#{Faker::Lorem.word}.#{Faker::Internet.domain_name}",
+      :root_password => Faker::Company.catch_phrase)
+  end
+
+  let :script do broker.install_script_for(node) end
+
+  it "should work without any configuration" do
+    script.should be_an_instance_of String
+    script.should =~ /yum -y install puppet-agent/s
+    script.should =~ /service puppet start/s # don't match . == newline
+    script.should_not =~ /puppet resource ini_setting/
+  end
+
+  it "should not specify the server if not in configuration" do
+    broker.configuration = {}
+    script.should_not =~ /setting=server/
+  end
+
+  it "should specify the server if one is given" do
+    server = "puppet.#{Faker::Internet.domain_name}"
+    broker.configuration = {'server' => server}
+
+    script.should =~ /setting=server value=#{Regexp.escape(server)}/
+  end
+
+  it "should set the certname if given" do
+    certname = "agent.#{Faker::Internet.domain_name}"
+    broker.configuration = {'certname' => certname}
+
+    script.should =~ /setting=certname value=#{Regexp.escape(certname)}/
+  end
+
+  it "should set the environment if given" do
+    environment = "bananafudge"
+    broker.configuration = {'environment' => environment}
+
+    script.should =~ /setting=environment value=#{Regexp.escape(environment)}/
+  end
+
+  it "should set multiple configuration values if given" do
+    server = "puppet.#{Faker::Internet.domain_name}"
+    certname = "agent.#{Faker::Internet.domain_name}"
+    environment = "bananafudge"
+    broker.configuration = {
+      'server'      => server,
+      'certname'    => certname,
+      'environment' => environment
+    }
+
+    script.should =~ /setting=server value=#{Regexp.escape(server)}/
+    script.should =~ /setting=certname value=#{Regexp.escape(certname)}/
+    script.should =~ /setting=environment value=#{Regexp.escape(environment)}/
+  end
+
+  # This is not the most robust check for correctness in the world, but it
+  # does capture "parsing errors", which can help if we somehow bust things up
+  # in the template by dropping Ruby in or something.
+  context "syntax checking with combinations of configuration" do
+    versions = [nil, '2.7.34', '~> 3.1']
+    servers  = [nil, 'puppet', 'puppet.' + Faker::Internet.domain_name,
+      Faker::Internet.ip_v4_address, Faker::Internet.ip_v6_address]
+
+    versions.each do |version|
+      servers.each do |server|
+        it "version #{version.inspect} and server #{server.inspect}" do
+          config = {}
+          version and config['version'] = version
+          server  and config['server']  = server
+          broker.configuration = config
+
+          # turn on '-n' for "don't execute any commands"
+          system('/bin/bash', '-n', '-c', script) or raise "failed syntax check"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds an additional broker that deploys the Puppet AIO package instead of the standard Puppet agent. It's almost virtually identical to the standard Puppet broker; a cleaner approach may be to add an additional flag or variable to the standard Puppet broker to use the AIO package instead.