### PR TITLE
Allow broker-type with empty configuration.yaml

### DIFF
--- a/lib/razor/broker_type.rb
+++ b/lib/razor/broker_type.rb
@@ -136,7 +136,7 @@ class Razor::BrokerType
   # If there is no configuration data, returns the empty hash.
   def configuration_schema
     @configuration_schema ||= if configuration_path.exist?
-                                YAML.load_file(configuration_path).freeze
+                                (YAML.load_file(configuration_path) || {}).freeze
                               else
                                 {}.freeze
                               end

--- a/spec/broker_type_spec.rb
+++ b/spec/broker_type_spec.rb
@@ -350,6 +350,21 @@ describe Razor::BrokerType do
         }.to raise_error Psych::SyntaxError
       end
     end
+
+    it "should return a blank schema if the file is blank" do
+      broker = {'test' => {'install.erb' => "# no real content here\n",
+                           'configuration.yaml' => nil}}
+      with_brokers_in(path => broker) do
+        Razor::BrokerType.find(name: 'test').configuration_schema.should == {}
+      end
+    end
+    it "should return a blank schema if the file just has a yaml header" do
+      broker = {'test' => {'install.erb' => "# no real content here\n",
+                           'configuration.yaml' => '---'}}
+      with_brokers_in(path => broker) do
+        Razor::BrokerType.find(name: 'test').configuration_schema.should == {}
+      end
+    end
   end
 
   context "install_script" do


### PR DESCRIPTION
When a broker type contains an empty configuration.yaml, an exception is thrown
in the server log when it is instantiated. This fixes that oversight by using a
blank configuration in that case.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-852