### PR TITLE
Add /api/collections/config collection

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -568,7 +568,7 @@ and requires full control over the database (eg: add and remove tables):
   # hand-coded list, but ... it will do, for now.
   COLLECTIONS = [:brokers, :repos, :tags, :policies,
                  [:nodes, {'start' => {"type" => "number"}, 'limit' => {"type" => "number"}}], :tasks, :commands,
-                 [:events, {'start' => {"type" => "number"}, 'limit' => {"type" => "number"}}], :hooks]
+                 [:events, {'start' => {"type" => "number"}, 'limit' => {"type" => "number"}}], :hooks, :config]
 
   #
   # The main entry point for the public/management API
@@ -778,6 +778,22 @@ and requires full control over the database (eg: add and remove tables):
     {
       "spec" => spec_url("collections", "nodes", "log"),
       "items" => node.log(limit: params[:limit], start: params[:start])
+    }.to_json
+  end
+
+  get '/api/collections/config' do
+    blacklist = Razor.config['api_config_blacklist'] || []
+    items = Razor.config.flat_values.reject do |k, _|
+      blacklist.include? k
+    end
+    {
+        "spec" => spec_url("collections", "config"),
+        "items" => items.map do |k,v|
+          {
+            "name" => k,
+            "value" => v
+          }
+        end,
     }.to_json
   end
 

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -137,3 +137,10 @@ all:
     #match_on:
     #  - unique_fact
     #  - /other_facts_.*/
+
+  # These should correspond to config properties that should be hidden from the
+  # /api/collections/config endpoint. By default, this endpoint will reveal all
+  # config in this file.
+  api_config_blacklist:
+    - database_url
+    - facts.blacklist

--- a/lib/razor/config.rb
+++ b/lib/razor/config.rb
@@ -19,6 +19,9 @@ module Razor
     # The possible keys we allow in hw_info,
     HW_INFO_KEYS = [ 'mac', 'serial', 'asset', 'uuid']
 
+    attr_reader :values
+    attr_reader :flat_values
+
     def initialize(env, fname = nil, defaults_file = nil)
       @values = {}
       # Load defaults first.
@@ -57,6 +60,23 @@ module Razor
       end
       @values.merge!(yaml["all"] || {})
       @values.merge!(yaml[Razor.env] || {})
+    end
+
+    def flat_values
+      @flat_values ||= flatten_hash(@values)
+    end
+
+    # Converts e.g. {'a' => {'b' => 1}} to {'a.b' => 1}
+    def flatten_hash(hash)
+      hash.each_with_object({}) do |(k, v), h|
+        if v.is_a? Hash
+          flatten_hash(v).map do |h_k, h_v|
+            h["#{k}.#{h_k}"] = h_v
+          end
+        else
+          h[k] = v
+        end
+      end
     end
 
     def root

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -159,6 +159,25 @@ describe Razor::Config do
     end
   end
 
+  describe "flat_values" do
+    it "builds a valid tree" do
+      config = make_config({'1' => {'2' => ['value']}, 'a' => 'other-value'})
+      config.flat_values.should == {'1.2' => ['value'], 'a' => 'other-value'}
+    end
+    it "works for empty configs" do
+      make_config({}).flat_values.should == {}
+    end
+    it "works for any depth" do
+      depth = Random.new.rand(100) + 2
+      config = {'a' => nil}
+      expected = {"#{(['a'] * (depth + 1)).join('.')}" => nil}
+      depth.times do
+        config['a'] = config.dup
+      end
+      make_config(config).flat_values.should == expected
+    end
+  end
+
   shared_examples "expanding paths" do |setting|
     let :setting_name    do setting + '_path' end
     let :setting_default do File.join(Razor.root, setting + 's') end

--- a/tasks/microkernel.task/boot.erb
+++ b/tasks/microkernel.task/boot.erb
@@ -1,7 +1,7 @@
 #!ipxe
 initrd <%= repo_url("/initrd0.img") %> || goto error
 
-kernel <%= repo_url("/vmlinuz0") %> rootflags=loop initrd=initrd0.img root=live:/microkernel.iso rootfstype=auto ro rd.live.image quiet acpi=force rd.luks=0 rd.md=0 rd.dm=0 <%= microkernel_kernel_args %> || goto error
+kernel <%= repo_url("/vmlinuz0") %> rootflags=loop initrd=initrd0.img root=live:/microkernel.iso rootfstype=auto ro rd.live.image <%= db = config['microkernel.debug_level']; db = '' unless ['quiet', 'debug'].include?(db); db %> acpi=force rd.luks=0 rd.md=0 rd.dm=0 <%= microkernel_kernel_args %> || goto error
 boot || goto error
 
 :error


### PR DESCRIPTION
If the user wanted to see which config settings Razor was using, there was
previously no simple way to find out. This commit adds a collection,
`config`, which simply returns the config settings that are in effect.

The collection returns "items", an array which has an object for each
config. The object has key "name" and value "value".

Fixes https://tickets.puppetlabs.com/browse/RAZOR-531