### PR TITLE
Changes to the second-stage powershell script

### DIFF
--- a/tasks/windows.task/second-stage.ps1.erb
+++ b/tasks/windows.task/second-stage.ps1.erb
@@ -6,10 +6,10 @@ write-host "Razor second-stage Windows installer script starting"
 # installer.  That will, I guess, have to change some time soon.  Look to see
 # something akin to the way that brokers work implemented.
 $server = '<%= `hostname`.strip %>'
-$share  = 'razor'
 $repo   = '<%= repo_url.split('/').last %>'
-$drive_path = "\\${server}\${share}\${repo}"
-$installer = "${drive_path}\setup.exe"
+$drive_path = "\\${server}\${repo}"
+$drive_letter = "I"
+$installer = "${drive_letter}:\setup.exe"
 
 write-host "fetching the unattended.xml file to feed the installer"
 $unattended_src = '<%= file_url('unattended.xml') %>'
@@ -21,10 +21,10 @@ write-host "mapping SMB share ${drive_path} for installer access"
 # As far as I can tell, if we don't persist, we don't connect the SMB share,
 # and that means we can't actually run stuff off it.
 new-psdrive -name 'i' -psprovider filesystem -root "$($drive_path)" -persist
-If (!(Test-Path i:))
+If (!(Test-Path "$($drive_letter):"))
 {
-        Invoke-WebRequest -Uri "<%= log_url("samba share not accessible ${drive_path}", :error) %>" -UseBasicParsing
-        write-error "samba share not accessible ${drive_path}"
+        Invoke-WebRequest -Uri "<%= log_url("samba share not accessible on $drive_letter", :error) %>" -UseBasicParsing
+        write-error "samba share not accessible on $drive_letter"
         exit 1
 }
 start-sleep 10                  # time to settle -- needed on my VM :/


### PR DESCRIPTION
- Parameterised the drive letter that is used to host the windows install files
- Changed the location that razor will look for the install files in samba.
  - I have changed this because of very inconsistant results when attempting
    to map the drive letter to a folder within a share. It would fail roughly
    7 in 10 times. The change means that you must create a samba share for each
    repository that you will expose over samba the trade off is a more reliable
    install.

This change if accepted will require a change to the documentation on https://github.com/puppetlabs/razor-server/wiki/Installing-windows#create-smb-share. The samba configuration now looks like the following.

[windowssvr2012r2]
  comment   = Windows Server 2012 R2 Install
  # this is, by default, under /var/lib/razor/repo-store/
  path      = /var/lib/razor/repo-store/windowssvr2012r2
  guest ok  = yes
  writable  = no
  browsable = yes

I also found some additional settings that seem to make the connection to the samba share somewhat more reliable these settings are:

[global]
  kernel oplocks = no
  nt acl support = no
  strict locking = no
