### PR TITLE
facts can now also be a FalseClass and not only a string

### DIFF
--- a/tasks/common/boot_local.erb
+++ b/tasks/common/boot_local.erb
@@ -15,7 +15,7 @@ sleep 3
 <%# kernel image that doesn't include it, or something...                   %>
 <%
   facts = node.facts || {}
-  if !facts["is_virtual"] or facts["is_virtual"] != "false" or
+  if !facts.has_key?('is_virtual') or ((facts["is_virtual"] != "false") and (facts["is_virtual"] != false)) or
       node.metadata['sanboot'] %>
 echo forcing local booting with sanboot 0x80
 sanboot --no-describe --drive 0x80


### PR DESCRIPTION
Newer facter version are returning booleans and not strings. This
made our PXE boot always wanting to do sanboot. With this change
we make sure that still both version work.