### PR TITLE
Make the Chef broker handle multiple run-list items

### DIFF
--- a/brokers/chef.broker/install.erb
+++ b/brokers/chef.broker/install.erb
@@ -65,7 +65,7 @@ EOP
 (
 cat <<'EOFFIRSTRUN'
 {
-	"run_list": ["<%= broker.run_list %>"],
+	"run_list": <%= broker.run_list.split(/\s*,\s*/) %>,
 	"razor_metadata":  {
 <%
 unless node.metadata.empty?


### PR DESCRIPTION
The Chef broker would fail if more than one item was provided in the run list. This fix parses multiple items correctly and inserts them into the Chef first-run.json file.