### PR TITLE
Handle relative directory when running hooks

### DIFF
--- a/lib/razor/data/hook.rb
+++ b/lib/razor/data/hook.rb
@@ -334,10 +334,15 @@ class Razor::Data::Hook < Sequel::Model
       # Run the file from the hook's directory so that relative paths work.
       hook_dir = File.expand_path('..', script)
       stdin, stdout, stderr, wait_thr = Bundler.with_clean_env do
-        extra_path = Razor.config['hook_execution_path']
-        ENV['PATH'] = "#{extra_path}:#{ENV['PATH']}" if extra_path
-        Dir.chdir(hook_dir)
-        Open3.popen3(script.to_s)
+        begin
+          old = Dir.pwd
+          extra_path = Razor.config['hook_execution_path']
+          ENV['PATH'] = "#{extra_path}:#{ENV['PATH']}" if extra_path
+          Dir.chdir(hook_dir)
+          Open3.popen3(script.to_s)
+        ensure
+          Dir.chdir(old)
+        end
       end
       stdin.write(args) if args
       begin

--- a/spec/data/hook_spec.rb
+++ b/spec/data/hook_spec.rb
@@ -490,6 +490,7 @@ cat <<EOF
 }
 EOF
       CONTENTS
+      old_dir = Dir.pwd
       node = Fabricate(:bound_node)
       Razor::Data::Hook.trigger('node-booted', node: node, policy: node.policy)
 
@@ -504,6 +505,7 @@ EOF
       event.severity.should == 'info'
       msg = event.entry['msg']
       msg.should =~ /\/test\.hook$/
+      Dir.pwd.should == old_dir
     end
 
     context "with store_hook_input config" do


### PR DESCRIPTION
Whenever a hook would run, the relative directory would be changed to the
hook's directory. That's normally not an issue, but in for example spec
tests, an accurate relative directory may be relied upon.

The fix is to simply restore the old working directory after the hook
execution completes.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-928