### PR TITLE
Add `update-policy-repo` to update a policy's repo

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # Razor Server Release Notes
 
+## ? - ?
+
+### API changes
+
++ IMPROVEMENT: Added `update-policy-repo` command to facilitate changing
+  the repo associated with a policy without needing to manually update
+  the repo's contents or delete the policy.
+
 ## 1.4.0 - 2016-07-06
 
 ### API changes

--- a/doc/api.md
+++ b/doc/api.md
@@ -386,6 +386,19 @@ policy when you run this command, provisioning errors may occur.
     "task": "other_task"
     }
 
+### Update policy repo
+
+This ensures that a specified policy uses the repo this command specifies.
+If a node is currently provisioning against the
+policy when you run this command, provisioning errors may occur.
+
+    The following shows how to update a policy’s repo to a repo called “other_repo”.
+
+    {
+    "policy": "my_policy",
+    "repo": "other_repo"
+    }
+
 ### Delete policy
 
 Policies can be deleted with the `delete-policy` command.  It accepts the

--- a/doc/api.md
+++ b/doc/api.md
@@ -286,7 +286,7 @@ will return with status code 400.
       "broker": "puppet",
       "hostname": "host${id}.example.com",
       "root_password": "secret",
-      "max_count": "20",
+      "max_count": 20,
       "before"|"after": "other policy",
       "node_metadata": { "key1": "value1", "key2": "value2" },
       "tags": ["existing_tag"]
@@ -369,7 +369,6 @@ existing tag, or create a new one by supplying a name and rule for the
 new tag:
 
     {
-      "name": "a-policy-name",
       "tag" : "a-tag-name",
       "rule": "new-match-expression" #Only for `add-policy-tag`
     }
@@ -383,7 +382,6 @@ policy when you run this command, provisioning errors may occur.
     The following shows how to update a policy’s task to a task called “other_task”.
 
     {
-    "node": "node1",
     "policy": "my_policy",
     "task": "other_task"
     }

--- a/lib/razor/command/update_policy_repo.rb
+++ b/lib/razor/command/update_policy_repo.rb
@@ -1,0 +1,51 @@
+# -*- encoding: utf-8 -*-
+
+class Razor::Command::UpdatePolicyRepo < Razor::Command
+  summary "Update the repo associated to a policy"
+  description <<-EOT
+This ensures that the specified policy uses the specified repo. Note that if a
+node is currently provisioning against this policy, provisioning errors may
+arise.
+  EOT
+
+  example api: <<-EOT
+Update policy's repo to a repo named 'other_repo':
+
+    {"policy": "my_policy", "repo": "other_repo"}
+  EOT
+
+  example cli: <<-EOT
+Update policy's repo to a repo named 'other_repo':
+
+    razor update-policy-repo --policy my_policy --repo other_repo
+
+With positional arguments, this can be shortened:
+
+    razor update-policy-repo my_policy other_repo
+  EOT
+
+  authz '%{policy}'
+
+  attr 'policy', type: String, required: true, references: [Razor::Data::Policy, :name],
+                 position: 0, help: _('The policy that will have its repo updated.')
+
+  attr 'repo', type: String, required: true, position: 1,
+               references: [Razor::Data::Repo, :name],
+               help: _('The repo to be used by the policy.')
+
+  def run(_, data)
+    policy = Razor::Data::Policy[:name => data['policy']]
+    repo = Razor::Data::Repo[:name => data['repo']]
+    repo_name = data['repo']
+    if policy.repo.name != repo_name
+      policy.repo = repo
+      policy.save
+
+      { :result => _("policy %{name} updated to use repo %{repo}") %
+          {name: data['policy'], repo: data['repo']} }
+    else
+      { :result => _("no changes; policy %{name} already uses repo %{repo}") %
+          {name: data['policy'], repo: data['repo']} }
+    end
+  end
+end

--- a/lib/razor/command/update_policy_task.rb
+++ b/lib/razor/command/update_policy_task.rb
@@ -11,11 +11,11 @@ policy, provisioning errors may arise.
   example api: <<-EOT
 Update policy's task to a task named 'other_task':
 
-    {"node": "node1", "policy": "my_policy", "task": "other_task"}
+    {"policy": "my_policy", "task": "other_task"}
 
 Use the task on the policy's repo:
 
-    {"node": "node1", "policy": "my_policy", "no_task": true}
+    {"policy": "my_policy", "no_task": true}
   EOT
 
   example cli: <<-EOT

--- a/lib/razor/messaging/sequel.rb
+++ b/lib/razor/messaging/sequel.rb
@@ -110,15 +110,10 @@ class Razor::Messaging::Sequel < TorqueBox::Messaging::MessageProcessor
       command        = find_command(body['command'])
     end
     if instance.nil?
-      # @todo danielp 2013-07-05: I genuinely don't know the correct way to
-      # handle this.  For the moment we raise an error that will cause the
-      # message to retry later, on the assumption that the object might come
-      # into existence later -- some sort of XA transaction race or failure,
-      # I guess, would be the root cause.
-      #
-      # Is that really the right strategy, though?
-      raise _("Unable to find %{class} with pk %{pk}") %
-        {class: class_constant.name, pk: body['instance'].inspect}
+      # Raise an error that will cause the message to fail. The most likely
+      # cause is that the object has been deleted, but its root cause could also
+      # be some sort of XA transaction race or failure.
+      raise MessageViolatesConsistencyChecks
     else
       # We might as well be tolerant of our inputs, and treat a nil/missing
       # arguments value as "no arguments"

--- a/spec/app/update_policy_repo_spec.rb
+++ b/spec/app/update_policy_repo_spec.rb
@@ -1,0 +1,65 @@
+# -*- encoding: utf-8 -*-
+require_relative '../spec_helper'
+require_relative '../../app'
+
+describe Razor::Command::UpdatePolicyRepo do
+  include Razor::Test::Commands
+
+  let(:app) { Razor::App }
+
+  let(:policy) do
+    Fabricate(:policy)
+  end
+  let(:repo) do
+    Fabricate(:repo)
+  end
+  let(:command_hash) do
+    {
+        'policy' => policy.name,
+        'repo' => repo.name,
+    }
+  end
+
+  before :each do
+    header 'content-type', 'application/json'
+    authorize 'fred', 'dead'
+  end
+
+  def update_policy_repo(data)
+    command 'update-policy-repo', data
+  end
+
+  it_behaves_like "a command"
+
+  it "changes policy's repo" do
+    previous_repo = policy.repo
+    update_policy_repo(command_hash)
+    new_repo = Razor::Data::Policy[name: command_hash['policy']].repo
+    new_repo.should_not == previous_repo
+    new_repo.name.should == repo.name
+    last_response.json['result'].should == "policy #{policy.name} updated to use repo #{repo.name}"
+  end
+
+  it "leaves policy's repo when the same" do
+    previous_repo = policy.repo
+    policy.repo = repo
+    policy.save
+    update_policy_repo(command_hash)
+    new_repo = Razor::Data::Policy[name: command_hash['policy']].repo
+    new_repo.should_not == previous_repo
+    new_repo.name.should == repo.name
+    last_response.json['result'].should == "no changes; policy #{policy.name} already uses repo #{repo.name}"
+  end
+
+  it "should fail if the policy is missing" do
+    command_hash.delete('policy')
+    update_policy_repo(command_hash)
+    last_response.status.should == 422
+  end
+
+  it "should fail if the repo is missing" do
+    command_hash.delete('repo')
+    update_policy_repo(command_hash)
+    last_response.status.should == 422
+  end
+end


### PR DESCRIPTION
Two feasible use cases for needing a command like this are:
- A user notices a mistype of the source for a repo after creating it.
- A user decides that a policy should use a different repo (OS update without
  messing with the policy list)

Updating a policy's repo will provide this functionality with little
interruption to existing installs, if any are occurring. This command should
simply update the reference so that repo file requests can be immediately
redirected to the new repo.

The command will use positional arguments of `policy` then `repo`.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-762