### PR TITLE
Synchronize time in puppet and puppet-pe brokers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,12 @@
 + IMPROVEMENT: Added `update-policy-broker` command to facilitate
   migrating the broker that a policy uses.
 
+### Other
+
++ IMPROVEMENT: The `puppet` and `puppet-pe` brokers will now attempt to
+  run `ntpdate` against `pool.ntp.org` before registering. The server
+  can be overridden using the new `ntpdate_server` config parameters.
+
 ## 1.4.0 - 2016-07-06
 
 ### API changes

--- a/brokers/puppet-pe.broker/configuration.yaml
+++ b/brokers/puppet-pe.broker/configuration.yaml
@@ -5,3 +5,5 @@ version:
   description: "Override the PE version to install; defaults to `current`."
 windows_agent_download_url:
   description: "The download URL for a Windows PE agent installer; defaults to a URL derived from the `version` config."
+ntpdate_server:
+  description: "The server to use for synchronizing the agent's time"

--- a/brokers/puppet-pe.broker/install.erb
+++ b/brokers/puppet-pe.broker/install.erb
@@ -30,6 +30,20 @@ trap "checkError" exit
 # could have been ignored or something.
 cmd bash || fail "we need bash available to be able to run the installer"
 
+# Synchronize time with ntpdate server before registering with the server.
+ntpdate_server=<% broker[:ntpdate_server] || '' %>
+if [ -z $ntpdate_server ]; then
+    : # skipping ntpdate since `ntpdate_server` is not set
+elif cmd ntpdate; then
+    ntpdate $ntpdate_server
+elif cmd apt-get; then
+    apt-get install ntpdate && ntpdate $ntpdate_server
+elif cmd yum; then
+    yum -y install ntpdate && ntpdate $ntpdate_server
+else
+    warn "unable to synchronize time with ntpdate"
+fi
+
 # ...our nice, generic, delegatable script.
 url="https://<%= (broker[:server] || 'puppet') %>:8140/packages/<%= broker[:version] || 'current' %>/install.bash"
 

--- a/brokers/puppet.broker/configuration.yaml
+++ b/brokers/puppet.broker/configuration.yaml
@@ -5,3 +5,5 @@ server:
   description: "The puppet master server to request configurations from."
 environment:
   description: "On agent nodes, the environment to request configuration in."
+ntpdate_server:
+  description: "The server to use for synchronizing the agent's time"

--- a/brokers/puppet.broker/install.erb
+++ b/brokers/puppet.broker/install.erb
@@ -36,6 +36,19 @@ else
     fail "neither yum or apt are installed, so I can't figure out what next!"
 fi
 
+# Synchronize time with ntpdate server before registering with the server.
+ntpdate_server=<% broker[:ntpdate_server] || '' %>
+if [ -z $ntpdate_server ]; then
+    : # skipping ntpdate since `ntpdate_server` is not set
+elif cmd ntpdate; then
+    ntpdate $ntpdate_server
+elif cmd apt-get; then
+    apt-get install ntpdate && ntpdate $ntpdate_server
+elif cmd yum; then
+    yum -y install ntpdate && ntpdate $ntpdate_server
+else
+    warn "unable to synchronize time with ntpdate"
+fi
 
 # Now we have that, we can install our platform specific package to define
 # the repositories.  Thankfully this is also pretty damn simple to get right.

--- a/spec/brokers/puppet-pe_spec.rb
+++ b/spec/brokers/puppet-pe_spec.rb
@@ -55,17 +55,21 @@ describe Razor::BrokerType.find(name: 'puppet-pe') do
       versions = [nil, '2.7.34', '~> 3.1']
       servers  = [nil, 'puppet', 'puppet.' + Faker::Internet.domain_name,
         Faker::Internet.ip_v4_address, Faker::Internet.ip_v6_address]
+      ntpdates = [nil, 'us.pool.ntp.org']
 
       versions.each do |version|
         servers.each do |server|
-          it "version #{version.inspect} and server #{server.inspect}" do
-            config = {}
-            version and config['version'] = version
-            server  and config['server']  = server
-            broker.configuration = config
+          ntpdates.each do |ntpdate|
+            it "version #{version.inspect} and server #{server.inspect}" do
+              config = {}
+              version and config['version'] = version
+              server  and config['server']  = server
+              ntpdate and config['ntpdate_server'] = ntpdate
+              broker.configuration = config
 
-            # turn on '-n' for "don't execute any commands"
-            system('/bin/bash', '-n', '-c', script) or raise "failed syntax check"
+              # turn on '-n' for "don't execute any commands"
+              system('/bin/bash', '-n', '-c', script) or raise "failed syntax check"
+            end
           end
         end
       end


### PR DESCRIPTION
Without running `ntpdate` before registering with the puppet master, sometimes,
the agent can't retrieve a catalog with an error that says the certificate is
not yet valid.

In most cases, a network will already be configured to use `ntpdate`. A node
may, however, need to set this value before checking in with the puppet master.

To make this as generic as possible, both brokers now include a
new, optional `ntpdate_server` config. Without this config present, no
`ntpdate` command will occur.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-933