### PR TITLE
Add `update-policy-broker` command

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 + IMPROVEMENT: Added `update-policy-repo` command to facilitate changing
   the repo associated with a policy without needing to manually update
   the repo's contents or delete the policy.
++ IMPROVEMENT: Added `update-policy-broker` command to facilitate
+  migrating the broker that a policy uses.
 
 ## 1.4.0 - 2016-07-06
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -388,15 +388,28 @@ policy when you run this command, provisioning errors may occur.
 
 ### Update policy repo
 
-This ensures that a specified policy uses the repo this command specifies.
-If a node is currently provisioning against the
-policy when you run this command, provisioning errors may occur.
+This ensures that a specified policy uses the repo this command
+specifies. If a node is currently provisioning against the policy when
+you run this command, provisioning errors may occur.
 
     The following shows how to update a policy’s repo to a repo called “other_repo”.
 
     {
     "policy": "my_policy",
     "repo": "other_repo"
+    }
+
+### Update policy broker
+
+This ensures that a specified policy uses the broker this command
+specifies. If a node is currently in the broker stage of provisioning,
+errors may occur.
+
+    The following shows how to update a policy’s broker to a broker called “other_broker”.
+
+    {
+    "policy": "my_policy",
+    "broker": "other_broker"
     }
 
 ### Delete policy

--- a/lib/razor/command/update_policy_broker.rb
+++ b/lib/razor/command/update_policy_broker.rb
@@ -1,0 +1,51 @@
+# -*- encoding: utf-8 -*-
+
+class Razor::Command::UpdatePolicyBroker < Razor::Command
+  summary "Update the broker associated to a policy"
+  description <<-EOT
+This ensures that the specified policy uses the specified broker. Note that if a
+node is currently provisioning against this policy, provisioning errors may
+arise.
+  EOT
+
+  example api: <<-EOT
+Update policy's broker to a broker named 'other_broker':
+
+    {"policy": "my_policy", "broker": "other_broker"}
+  EOT
+
+  example cli: <<-EOT
+Update policy's broker to a broker named 'other_broker':
+
+    razor update-policy-broker --policy my_policy --broker other_broker
+
+With positional arguments, this can be shortened:
+
+    razor update-policy-broker my_policy other_broker
+  EOT
+
+  authz '%{policy}'
+
+  attr 'policy', type: String, required: true, references: [Razor::Data::Policy, :name],
+                 position: 0, help: _('The policy that will have its broker updated.')
+
+  attr 'broker', type: String, required: true, position: 1,
+               references: [Razor::Data::Broker, :name],
+               help: _('The broker to be used by the policy.')
+
+  def run(_, data)
+    policy = Razor::Data::Policy[:name => data['policy']]
+    broker = Razor::Data::Broker[:name => data['broker']]
+    broker_name = data['broker']
+    if policy.broker.name != broker_name
+      policy.broker = broker
+      policy.save
+
+      { :result => _("policy %{name} updated to use broker %{broker}") %
+          {name: data['policy'], broker: data['broker']} }
+    else
+      { :result => _("no changes; policy %{name} already uses broker %{broker}") %
+          {name: data['policy'], broker: data['broker']} }
+    end
+  end
+end

--- a/spec/app/update_policy_broker_spec.rb
+++ b/spec/app/update_policy_broker_spec.rb
@@ -1,0 +1,65 @@
+# -*- encoding: utf-8 -*-
+require_relative '../spec_helper'
+require_relative '../../app'
+
+describe Razor::Command::UpdatePolicyBroker do
+  include Razor::Test::Commands
+
+  let(:app) { Razor::App }
+
+  let(:policy) do
+    Fabricate(:policy)
+  end
+  let(:broker) do
+    Fabricate(:broker)
+  end
+  let(:command_hash) do
+    {
+        'policy' => policy.name,
+        'broker' => broker.name,
+    }
+  end
+
+  before :each do
+    header 'content-type', 'application/json'
+    authorize 'fred', 'dead'
+  end
+
+  def update_policy_broker(data)
+    command 'update-policy-broker', data
+  end
+
+  it_behaves_like "a command"
+
+  it "changes policy's broker" do
+    previous_broker = policy.broker
+    update_policy_broker(command_hash)
+    new_broker = Razor::Data::Policy[name: command_hash['policy']].broker
+    new_broker.should_not == previous_broker
+    new_broker.name.should == broker.name
+    last_response.json['result'].should == "policy #{policy.name} updated to use broker #{broker.name}"
+  end
+
+  it "leaves policy's broker when the same" do
+    previous_broker = policy.broker
+    policy.broker = broker
+    policy.save
+    update_policy_broker(command_hash)
+    new_broker = Razor::Data::Policy[name: command_hash['policy']].broker
+    new_broker.should_not == previous_broker
+    new_broker.name.should == broker.name
+    last_response.json['result'].should == "no changes; policy #{policy.name} already uses broker #{broker.name}"
+  end
+
+  it "should fail if the policy is missing" do
+    command_hash.delete('policy')
+    update_policy_broker(command_hash)
+    last_response.status.should == 422
+  end
+
+  it "should fail if the broker is missing" do
+    command_hash.delete('broker')
+    update_policy_broker(command_hash)
+    last_response.status.should == 422
+  end
+end


### PR DESCRIPTION
The current method for migrating a policy to use a different broker involves
deleting and recreating the policy. Since we will want to update stock brokers
in the future, we need to supply users a way to change their broker without
deleting policies first. This command will do that.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-935