### PR TITLE
(maint) add maintainers file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "file_format": "This MAINTAINERS file format is described at https://github.com/puppetlabs/maintainers",
+  "issues": "https://tickets.puppet.com/browse/RAZOR",
+  "people": [
+    {
+      "github": "steveax",
+      "email": "steve@puppet.com",
+      "name": "Steve Axthelm"
+    },
+    {
+      "github": "smecclellan",
+      "email": "scott.mcclellan@puppet.com",
+      "name": "Scott McClellan"
+    }
+  ]
+}


### PR DESCRIPTION
Puppet is applying a standard maintainers file format to all repos.