### PR TITLE
Add `win_language` metadata used by Windows installers

### DIFF
--- a/tasks/windows.task/unattended.xml.erb
+++ b/tasks/windows.task/unattended.xml.erb
@@ -44,14 +44,10 @@
       </ImageInstall>
     </component>
     <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-      <SetupUILanguage>
-        <UILanguage>en-US</UILanguage>
-      </SetupUILanguage>
-      <InputLocale>en-US</InputLocale>
-      <SystemLocale>en-US</SystemLocale>
-      <UILanguage>en-US</UILanguage>
-      <UILanguageFallback>en-US</UILanguageFallback>
-      <UserLocale>en-US</UserLocale>
+      <InputLocale><%= node.metadata['win_language'] || 'en-US' %></InputLocale>
+      <SystemLocale><%= node.metadata['win_language'] || 'en-US' %></SystemLocale>
+      <UILanguage><%= node.metadata['win_language'] || 'en-US' %></UILanguage>
+      <UserLocale><%= node.metadata['win_language'] || 'en-US' %></UserLocale>
     </component>
   </settings>
   <settings pass="oobeSystem">

--- a/tasks/windows/2008r2.task/unattended.xml.erb
+++ b/tasks/windows/2008r2.task/unattended.xml.erb
@@ -64,10 +64,10 @@
       </ImageInstall>
     </component>
     <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-      <InputLocale>en-US</InputLocale>
-      <SystemLocale>en-US</SystemLocale>
-      <UILanguage>en-US</UILanguage>
-      <UserLocale>en-US</UserLocale>
+      <InputLocale><%= node.metadata['win_language'] || 'en-US' %></InputLocale>
+      <SystemLocale><%= node.metadata['win_language'] || 'en-US' %></SystemLocale>
+      <UILanguage><%= node.metadata['win_language'] || 'en-US' %></UILanguage>
+      <UserLocale><%= node.metadata['win_language'] || 'en-US' %></UserLocale>
     </component>
   </settings>
   <settings pass="oobeSystem">

--- a/tasks/windows/2012r2.task/unattended.xml.erb
+++ b/tasks/windows/2012r2.task/unattended.xml.erb
@@ -63,10 +63,10 @@
       </ImageInstall>
     </component>
     <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-      <InputLocale>en-US</InputLocale>
-      <SystemLocale>en-US</SystemLocale>
-      <UILanguage>en-US</UILanguage>
-      <UserLocale>en-US</UserLocale>
+      <InputLocale><%= node.metadata['win_language'] || 'en-US' %></InputLocale>
+      <SystemLocale><%= node.metadata['win_language'] || 'en-US' %></SystemLocale>
+      <UILanguage><%= node.metadata['win_language'] || 'en-US' %></UILanguage>
+      <UserLocale><%= node.metadata['win_language'] || 'en-US' %></UserLocale>
     </component>
   </settings>
   <settings pass="oobeSystem">


### PR DESCRIPTION
In order for our stock Windows task to allow ISO files in languages other
than `en-US`, users previously needed to override the entire unattended.xml.erb
file.

In the interest of making the stock tasks more generic, this should
implement a "metadata-with-default" pattern. If the node has the `win_language`
metadata, that will be used as the UILanguage (which causes the error), the
InputLocale, the SystemLocale, and the UserLocale.

When a user wishes to install an ISO in a language other than `en-US`, the
recommended approach is to add the `win_language` metadata to the node via the
`node_metadata` property on the given Windows policy.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-938