### PR TITLE
Node Metadata updates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,9 @@
   exists. For the latter command, you may supply the new argument
   `force` to achieve the old functionality of simply skipping the
   replacing key.
++ NEW: Added `update-policy-node-metadata` command to facilitate
+  changing the metadata that gets added to a node when it binds to a
+  policy.
 + IMPROVEMENT: Added `update-policy-repo` command to facilitate changing
   the repo associated with a policy without needing to manually update
   the repo's contents or delete the policy.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@
 
 ### API changes
 
++ BUGFIX: The `update-node-metadata` and `modify-node-metadata` commands
+  now throw the intended errors if `no_replace` is supplied and the key
+  exists. For the latter command, you may supply the new argument
+  `force` to achieve the old functionality of simply skipping the
+  replacing key.
 + IMPROVEMENT: Added `update-policy-repo` command to facilitate changing
   the repo associated with a policy without needing to manually update
   the repo's contents or delete the policy.

--- a/lib/razor/command/update_node_metadata.rb
+++ b/lib/razor/command/update_node_metadata.rb
@@ -45,9 +45,13 @@ With positional arguments, this can be shortened:
     operation = { 'update' => { data['key'] => data['value'] } }
     operation['no_replace'] = data['no_replace']
 
-    node.modify_metadata(operation)
+    begin
+      node.modify_metadata(operation)
+    rescue Razor::Data::NoReplaceMetadataError
+      request.error 409, :error => _('no_replace supplied and key is present')
+    end
   end
-  
+
   def self.conform!(data)
     data.tap do |_|
       data['all'] = true if data['all'] == 'true'

--- a/lib/razor/command/update_policy_node_metadata.rb
+++ b/lib/razor/command/update_policy_node_metadata.rb
@@ -1,0 +1,59 @@
+# -*- encoding: utf-8 -*-
+
+class Razor::Command::UpdatePolicyNodeMetadata < Razor::Command
+  summary "Update one key in a policy's node_metadata"
+  description <<-EOT
+This command can also be used to update a single key in a policy's
+`node_metadata`.
+  EOT
+
+  example api: <<-EOT
+Set a single key for a policy's node_metadata:
+
+    {"policy": "policy1", "key": "my_key", "value": "twelve"}
+  EOT
+
+  example cli: <<-EOT
+Set a single key for a policy's `node_metadata`:
+
+    razor update-policy-node-metadata --policy policy1\\
+        --key my_key --value twelve
+
+With positional arguments, this can be shortened:
+
+    razor update-policy-node-metadata policy1 my_key twelve
+  EOT
+
+  authz '%{policy}'
+
+  attr 'policy', type: String, required: true, references: [Razor::Data::Policy, :name],
+                 position: 0, help: _('The policy for which to update the associated node metadata.')
+
+  attr 'key', required: true, type: String, size: 1..Float::INFINITY,
+              position: 1, help: _('The key to change in the metadata.')
+
+  attr 'value', required: true,
+                position: 2, help: _('The value for the metadata.')
+
+  attr 'no_replace', type: :bool,
+                     help: _('If true, it is an error to try to change an existing key')
+
+  # Update/add specific metadata key (works with GET)
+  def run(request, data)
+    policy = Razor::Data::Policy[:name => data['policy']]
+    if data['no_replace'] && (policy.node_metadata || {}).has_key?(data['key'])
+      request.error 409, { :error => _('no_replace supplied and key is present') }
+    else
+      policy.node_metadata = (policy.node_metadata || {}).merge({data['key'] => data['value']})
+      policy.save
+      policy
+    end
+  end
+
+  def self.conform!(data)
+    data.tap do |_|
+      data['no_replace'] = true if data['no_replace'] == 'true'
+      data['no_replace'] = false if data['no_replace'] == 'false'
+    end
+  end
+end

--- a/spec/app/modify_node_metadata_spec.rb
+++ b/spec/app/modify_node_metadata_spec.rb
@@ -106,23 +106,24 @@ describe Razor::Command::ModifyNodeMetadata do
       node_metadata['k1'].should == 'v2'
     end
 
-    it "should NOT update the value of an existing tag if no_replace is set" do
+    it "should throw an error if no_replace is set" do
       id = node.id
       data = { 'node' => "node#{id}", 'update' => { 'k1' => 'v1'} }
       modify_metadata(data)
       data = { 'node' => "node#{id}", 'update' => { 'k1' => 'v2', 'k2' => 'v2'}, 'no_replace' => true }
       modify_metadata(data)
-      last_response.status.should == 202
+      last_response.status.should == 409
+      last_response.json['error'].should == 'no_replace supplied and key is present'
       node_metadata = Node[:id => id].metadata
-      node_metadata['k1'].should == 'v1'  #should not have updated.
-      node_metadata['k2'].should == 'v2'  #still should have added this.
+      node_metadata['k1'].should == 'v1'
+      node_metadata['k2'].should be_nil
     end
 
-    it "should work for no_replace" do
+    it "should bypass problems if no_replace and force are both set" do
       id = node.id
       data = { 'node' => "node#{id}", 'update' => { 'k1' => 'v1'} }
       modify_metadata(data)
-      data = { 'node' => "node#{id}", 'update' => { 'k1' => 'v2', 'k2' => 'v2'}, 'no_replace' => true }
+      data = { 'node' => "node#{id}", 'update' => { 'k1' => 'v2', 'k2' => 'v2'}, 'no_replace' => true, 'force' => true }
       modify_metadata(data)
       last_response.status.should == 202
       node_metadata = Node[:id => id].metadata

--- a/spec/app/update_node_metadata_spec.rb
+++ b/spec/app/update_node_metadata_spec.rb
@@ -31,17 +31,30 @@ describe Razor::Command::UpdateNodeMetadata do
   it_behaves_like "a command"
 
   it "should require no_replace to equal true" do
-    data = { 'node' => "node#{node.id}", 'key' => 'k1', 'value' => 'v1', 'no_replace' => 'not true' }
+    data = { 'node' => node.name, 'key' => 'k1', 'value' => 'v1', 'no_replace' => 'not true' }
     update_metadata(data)
     last_response.status.should == 422
     last_response.json["error"].should =~ /no_replace should be a boolean, but was actually a string/
   end
 
-  it "should conform no_replace" do
-    data = { 'node' => "node#{node.id}", 'key' => 'k1', 'value' => 'v1', 'no_replace' => 'not true' }
+  it "should not update the value if no_replace is true and the value exists" do
+    node.metadata = {'k1' => 'old-value'}
+    node.save
+    data = { 'node' => node.name, 'key' => 'k1', 'value' => 'v1', 'no_replace' => true }
     update_metadata(data)
-    last_response.status.should == 422
-    last_response.json["error"].should =~ /no_replace should be a boolean, but was actually a string/
+    last_response.status.should == 409
+    node.reload.metadata.should == {'k1' => 'old-value'}
+    last_response.json['error'].should == 'no_replace supplied and key is present'
+  end
+
+  it "should conform no_replace" do
+    node.metadata = {'k1' => 'old-value'}
+    node.save
+    data = { 'node' => node.name, 'key' => 'k1', 'value' => 'v1', 'no_replace' => 'true' }
+    update_metadata(data)
+    last_response.status.should == 409
+    node.reload.metadata.should == {'k1' => 'old-value'}
+    last_response.json['error'].should == 'no_replace supplied and key is present'
   end
 
   #Defer to the modify-node-metadata tests for the verification of the

--- a/spec/app/update_policy_node_metadata_spec.rb
+++ b/spec/app/update_policy_node_metadata_spec.rb
@@ -1,0 +1,73 @@
+# -*- encoding: utf-8 -*-
+require_relative '../spec_helper'
+require_relative '../../app'
+
+describe Razor::Command::UpdatePolicyNodeMetadata do
+  include Razor::Test::Commands
+
+  let(:app) { Razor::App }
+
+  let(:policy) { Fabricate(:policy) }
+
+  let(:command_hash) do
+    {
+        'policy' => policy.name,
+        'value' => 'v1',
+        'key' => 'k1',
+        'no_replace' => 'true'
+    }
+  end
+
+  before :each do
+    header 'content-type', 'application/json'
+    authorize 'fred', 'dead'
+  end
+
+  def update_metadata(data)
+    command 'update-policy-node-metadata', data
+  end
+
+  it_behaves_like "a command"
+
+  it "should require no_replace to equal true" do
+    data = { 'policy' => policy.name, 'key' => 'k1', 'value' => 'v1', 'no_replace' => 'not true' }
+    update_metadata(data)
+    last_response.status.should == 422
+    last_response.json["error"].should =~ /no_replace should be a boolean, but was actually a string/
+  end
+
+  it "should conform no_replace" do
+    policy.node_metadata = {'k1' => 'old-value'}
+    policy.save
+    data = { 'policy' => policy.name, 'key' => 'k1', 'value' => 'v1', 'no_replace' => 'true' }
+    update_metadata(data)
+    last_response.status.should == 409
+  end
+
+  it "should set a policy's node_metadata" do
+    policy = Fabricate(:policy)
+    data = { 'policy' => policy.name, 'key' => 'k1', 'value' => 'v1' }
+    update_metadata(data)
+    last_response.status.should == 202
+    policy.reload
+    policy.node_metadata.should == {'k1' => 'v1'}
+  end
+
+  it "should not update the value if no_replace is true and the value exists" do
+    policy.node_metadata = {'k1' => 'old-value'}
+    policy.save
+    data = { 'policy' => policy.name, 'key' => 'k1', 'value' => 'v1', 'no_replace' => true }
+    update_metadata(data)
+    last_response.status.should == 409
+    policy.reload.node_metadata.should == {'k1' => 'old-value'}
+    last_response.json['error'].should == 'no_replace supplied and key is present'
+  end
+
+  it "should update a policy's node_metadata" do
+    update_data = { 'policy' => "#{policy.name}", 'key' => 'k1', 'value' => 'v2' }
+    update_metadata(update_data)
+    last_response.status.should == 202
+    policy.reload
+    policy.node_metadata.should == {'k1' => 'v2'}
+  end
+end


### PR DESCRIPTION
This PR fixes two related issues: RAZOR-672 and RAZOR-940.

#1:
Users may need to modify the node metadata that gets assigned when a node binds
to a policy. There is currently no command to perform this, so the user must
work around the issue by either deleting the policy or creating a specialized
hook to achieve this.

This commit creates a new command, `update-policy-node-metadata`, to handle
this case.

#2:
When the user runs either `modify-node-metadata` or `update-node-metadata`
using the `no_replace` flag, the result is that the operation fails silently
for any key(s) that already exist. This is not the behavior documented for
these commands, which state that the command will fail if this happens.

In the case of `modify-node-metadata`, a new flag `force` will be added so that
batch operations can still succeed. This will allow feature parity with the
existing behavior by supplying a value of `true`.