### PR TITLE
Fix 64-bit puppet agent installation on non-English Windows

### DIFF
--- a/brokers/puppet-pe.broker/install.ps1.erb
+++ b/brokers/puppet-pe.broker/install.ps1.erb
@@ -3,7 +3,7 @@ write-host "Razor Windows broker script starting"
 $ErrorActionPreference = "Continue"
 $error.clear()
 
-if ((Get-WmiObject -Class Win32_OperatingSystem | Select-Object -ExpandProperty OSArchitecture) -eq '64-bit') {
+if ((Get-WmiObject -Class Win32_OperatingSystem | Select-Object -ExpandProperty OSArchitecture) -match '64') {
     $arch = 'x64'
 } else {
     $arch = 'x86'


### PR DESCRIPTION
When using a non-English version of the Windows installer, the architecture
of the machine was not being properly read. The install.ps1.erb script was
looking for "64-bit", but the "bit" part of that gets translated.

To solve this issue, the script should match on the string "64" instead.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-941