### PR TITLE
Fix handling of `hw_info`

### DIFF
--- a/lib/razor/data/node.rb
+++ b/lib/razor/data/node.rb
@@ -101,7 +101,7 @@ module Razor::Data
     # Turn the hw_info back into a hash. Possible keys are the ones in
     # +HW_INFO_KEYS+; all values are strings, except for +mac+, which is an
     # array of strings if any MAC addresses are present
-    def hw_hash
+    def self.hw_hashing(hw_info)
       hw_info.inject({}) do |h, p|
         pair = p.split("=", 2)
         if pair[0] == 'mac'
@@ -112,6 +112,10 @@ module Razor::Data
         end
         h
       end
+    end
+
+    def hw_hash
+      Node.hw_hashing(self.hw_info)
     end
 
     def task

--- a/spec/app/provisioning_spec.rb
+++ b/spec/app/provisioning_spec.rb
@@ -23,6 +23,12 @@ describe "provisioning API" do
     assert_booting("Microkernel")
   end
 
+  it "should store all hw_info" do
+    get "/svc/boot?net0=00:11:22:33:44:55&serial=12345&asset=54321"
+    Razor::Data::Node.all.first.hw_info.should ==
+        ['asset=54321', 'mac=00-11-22-33-44-55', 'serial=12345']
+  end
+
   it "should log an error if more than one node matches the hw_info" do
     n1 = Fabricate(:node, :hw_info => ["serial=s1", "asset=a1"])
     n2 = Fabricate(:node, :hw_info => ["serial=s2", "asset=a1"])


### PR DESCRIPTION
Two features related to `hw_info`, bundled into one PR to avoid a rebase race condition.

* Allow `mac` in `set-node-hw-info`

One confusing aspect about how Razor identifies nodes is that the mac
addresses are passed in as `net0`, `net1`, etc., but are represented in Razor
as `mac`, an array of all of these. To mitigate that confusion, the
`set-node-hw-info` command will now accept the `mac` attribute directly.

Additionally, when only `net0` was supplied, it was not being properly
converted into `mac` before the validation checks. This meant an error was
thrown saying that `mac` is a required attribute.

Now, the user can supply `netX`, `mac`, or both methods.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-939

* Store all `hw_info` when nodes are initially registered
Whenever a node is initially added to the system, the only `hw_info` values
that are recorded are the values that are used to match the node. This can be
a problem if the value used to match nodes changes, because there will be no
previous value to compare to in order to find the same node in the system.

To solve this, we will store all hardware info values that are passed by iPXE.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-958