### PR TITLE
(maint) pin json-schema version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ group :test do
   gem 'simplecov'
   gem 'fabrication', '~> 2.7.2'
   gem 'faker', '~> 1.2.0'
-  gem 'json-schema', '~> 2.0'
+  gem 'json-schema', '2.6.2'
   gem 'timecop'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,9 @@ group :test do
   gem 'simplecov'
   gem 'fabrication', '~> 2.7.2'
   gem 'faker', '~> 1.2.0'
+  # json-schema versions beyond this version require
+  # ruby version > 2.0 when jruby is upgraded to 9K+
+  # this pin can be removed 
   gem 'json-schema', '2.6.2'
   gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,8 +21,8 @@ GEM
     i18n (0.7.0)
     jdbc-postgres (9.4.1200)
     json (1.8.3-java)
-    json-schema (2.5.1)
-      addressable (~> 2.3.7)
+    json-schema (2.6.2)
+      addressable (~> 2.3.8)
     kramdown (1.7.0)
     locale (2.1.1)
     parslet (1.4.0)
@@ -105,7 +105,7 @@ DEPENDENCIES
   gettext (~> 3.1.1)
   hashie (~> 2.0.5)
   jdbc-postgres
-  json-schema (~> 2.0)
+  json-schema (= 2.6.2)
   kramdown
   rack-test
   rspec (~> 2.13.0)


### PR DESCRIPTION
This commit pins json-schema to v2.6.2 as later versions pull
in (through addressable) v2.0.4 of public_suffix which is
incompatible with ruby < v2.