### PR TITLE
Add SLES task

### DIFF
--- a/lib/razor/command/update_hook_configuration.rb
+++ b/lib/razor/command/update_hook_configuration.rb
@@ -8,20 +8,20 @@ configuration.
   EOT
 
   example api: <<-EOT
-Set a single key from a node:
+Set a single key from a hook's configuration:
 
-    {"node": "node1", "key": "my_key", "value": "twelve"}
+    {"hook": "hook1", "key": "my_key", "value": "twelve"}
   EOT
 
   example cli: <<-EOT
-Set a single key from a node:
+Set a single key from a hook's configuration:
 
-    razor update-hook-configuration --node node1 \\
+    razor update-hook-configuration --hook hook1 \\
         --key my_key --value twelve
 
 With positional arguments, this can be shortened:
 
-    razor update-hook-configuration node1 my_key twelve
+    razor update-hook-configuration hook my_key twelve
   EOT
 
   authz '%{hook}'

--- a/tasks/sles.task/README.md
+++ b/tasks/sles.task/README.md
@@ -1,0 +1,15 @@
+# Task notes for SLES
+
+## Node Metadata
+
+- 'timezone' (optional) - This is the string corresponding to the timezone for
+  the node.
+  - Default: America/Los_Angeles
+- 'root_password' (optional) - This is an override for the root_password that
+  exists on the node when it binds to a policy. If this is provided, it will be
+  used for the node's root password.
+- 'root_password_encrypted' (optional) - Whether the `root_password` metadata
+  value is encrypted.
+- 'hostname' (optional) - This is an override for the hostname that exists
+  on the node when it binds to a policy. If this is provided, it will be used
+  for the node's hostname.

--- a/tasks/sles.task/autoinst.xml.erb
+++ b/tasks/sles.task/autoinst.xml.erb
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile
+    xmlns="http://www.suse.com/1.0/yast2ns"
+    xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+      <mode>
+        <confirm config:type="boolean">false</confirm>
+        <second_stage config:type="boolean">true</second_stage>
+      </mode>
+  </general>
+  <users config:type="list">
+    <user>
+      <username>root</username>
+      <user_password><%= node.metadata['root_password'] || node.root_password %></user_password>
+      <encrypted config:type="boolean"><%= node.metadata['root_password_encrypted'] || 'false' %></encrypted>
+      <forename/>
+      <surname/>
+    </user>
+  </users>
+  <networking>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <dhcp_resolv config:type="boolean">true</dhcp_resolv>
+      <domain><%= (node.metadata['hostname'] || node.hostname).split('.').drop(1).join('.') %></domain>
+      <hostname><%= node.metadata['hostname'] || node.hostname %></hostname>
+    </dns>
+  </networking>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone><%= node.metadata['timezone'] || 'America/Los_Angeles' %></timezone>
+  </timezone>
+  <partitioning config:type="list">
+    <drive>
+      <device>/dev/sda</device>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <software>
+    <packages config:type="list">
+      <package>yast2-bootloader</package>
+    </packages>
+  </software>
+  <scripts>
+    <chroot-scripts config:type="list">
+      <script>
+        <filename>razor-post.sh</filename>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+#!/bin/sh
+curl <%= stage_done_url("autoyast") %>
+]]>
+        </source>
+      </script>
+    </chroot-scripts>
+    <init-scripts config:type="list">
+      <script>
+        <filename>razor-post.sh</filename>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+#!/bin/sh
+<%= render_template("set_hostname") %>
+<%= render_template("store_ip") %>
+<%= render_template("os_complete") %>
+curl -s <%= stage_done_url("finished") %>
+]]>
+        </source>
+      </script>
+    </init-scripts>
+  </scripts>
+</profile>

--- a/tasks/sles.task/boot_install.erb
+++ b/tasks/sles.task/boot_install.erb
@@ -1,0 +1,12 @@
+#!ipxe
+echo Razor <%= task.label %> task boot_call
+echo Installation node: <%= node_url  %>
+echo Installation repo: <%= repo_url %>
+
+sleep 3
+kernel <%= repo_url("boot/x86_64/loader/linux") %> <%= render_template("kernel_args").strip %> || goto error
+initrd <%= repo_url("boot/x86_64/loader/initrd") %> || goto error
+boot
+
+:error
+prompt --key s --timeout 60 ERROR, hit 's' for the iPXE shell; reboot in 60 seconds && shell || reboot

--- a/tasks/sles.task/kernel_args.erb
+++ b/tasks/sles.task/kernel_args.erb
@@ -1,0 +1,1 @@
+initrd=initrd install=<%= repo_url %> autoyast=<%= file_url('autoinst.xml')%>

--- a/tasks/sles.task/metadata.yaml
+++ b/tasks/sles.task/metadata.yaml
@@ -1,0 +1,8 @@
+---
+
+os_version: 12
+label: SUSE Linux Enterprise Server
+description: SLES Generic installer
+boot_sequence:
+  1: boot_install
+  default: boot_local

--- a/tasks/sles.task/os_complete.erb
+++ b/tasks/sles.task/os_complete.erb
@@ -3,13 +3,11 @@ cat <<EOF > /etc/motd
 Installed by Razor using <%= task.label %> - <%= task.description %>
 Repo: <%= repo_url %>
 Node: <%= node_url %>
-Install log: /var/log/razor.log
+Install log: /var/adm/autoinstall
 EOF
-
-sed -i '/razor_postinstall/d' /etc/rc.d/rc.local
 
 curl -s <%= broker_install_url %> | /bin/bash
 
 if [ $? -ne 0 ]; then
-    echo "Broker run failed; see /var/log/razor.log for more details" >> /etc/motd
+  echo "Broker run failed; see /var/adm/autoinstall/log/razor-post.sh.log for more details" >> /etc/motd
 fi

--- a/tasks/sles/11.task/README.md
+++ b/tasks/sles/11.task/README.md
@@ -1,0 +1,15 @@
+# Task notes for SLES 11
+
+## Node Metadata
+
+- 'timezone' (optional) - This is the string corresponding to the timezone for
+  the node.
+  - Default: America/Los_Angeles
+- 'root_password' (optional) - This is an override for the root_password that
+  exists on the node when it binds to a policy. If this is provided, it will be
+  used for the node's root password.
+- 'root_password_encrypted' (optional) - Whether the `root_password` metadata
+  value is encrypted.
+- 'hostname' (optional) - This is an override for the hostname that exists
+  on the node when it binds to a policy. If this is provided, it will be used
+  for the node's hostname.

--- a/tasks/sles/11.task/metadata.yaml
+++ b/tasks/sles/11.task/metadata.yaml
@@ -1,0 +1,5 @@
+---
+
+os_version: 11
+description: SLES 11 installer
+base: sles

--- a/tasks/sles/12.task/README.md
+++ b/tasks/sles/12.task/README.md
@@ -1,0 +1,15 @@
+# Task notes for SLES 12
+
+## Node Metadata
+
+- 'timezone' (optional) - This is the string corresponding to the timezone for
+  the node.
+  - Default: America/Los_Angeles
+- 'root_password' (optional) - This is an override for the root_password that
+  exists on the node when it binds to a policy. If this is provided, it will be
+  used for the node's root password.
+- 'root_password_encrypted' (optional) - Whether the `root_password` metadata
+  value is encrypted.
+- 'hostname' (optional) - This is an override for the hostname that exists
+  on the node when it binds to a policy. If this is provided, it will be used
+  for the node's hostname.

--- a/tasks/sles/12.task/metadata.yaml
+++ b/tasks/sles/12.task/metadata.yaml
@@ -1,0 +1,5 @@
+---
+
+os_version: 12
+description: SLES 12 installer
+base: sles


### PR DESCRIPTION
This adds a task to install SUSE Linux Enterprise Server version 12. It
conforms to the existing standard for default node metadata values, including
'hostname', 'timezone', and 'root_password'.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-966