### PR TITLE
Add Windows Server 2016 task

### DIFF
--- a/tasks/windows.task/unattended.xml.erb
+++ b/tasks/windows.task/unattended.xml.erb
@@ -30,6 +30,9 @@
       <UserData>
         <AcceptEula>true</AcceptEula>
         <ProductKey>
+          <!-- Evaluation key from
+               http://technet.microsoft.com/en-us/library/jj612867.aspx
+               Fill in your own for real deployments -->
           <Key><%= node.metadata['productkey'] || 'V7C3N-3W6CM-PDKR2-KW8DQ-RJMRD' %></Key>
         </ProductKey>
       </UserData>

--- a/tasks/windows/2012r2.task/README.md
+++ b/tasks/windows/2012r2.task/README.md
@@ -1,5 +1,11 @@
 # Task notes for Windows 2012 R2
 
+## Install Prerequisites
+
+- Machine must be running Windows Server 2012R2.
+- Windows Assessment and Deployment Kit (Windows ADK) version 8.0 or 8.1 is
+  installed.
+
 ## Pre-install Steps
 
 Follow same instructions for all other Windows tasks:

--- a/tasks/windows/2016.task/README.md
+++ b/tasks/windows/2016.task/README.md
@@ -1,0 +1,33 @@
+# Task notes for Windows 2016 Server
+
+## Install Prerequisites
+
+- Machine must be running Windows Server 2016.
+- Windows Assessment and Deployment Kit (Windows ADK) version 8.0 or 8.1 is
+  installed.
+
+## Pre-install Steps
+
+Follow same instructions for all other Windows tasks:
+
+- Download `build-winpe` folder from Razor server.
+- Build winpe.wim image using the `build-razor-winpe.ps1` script.
+- Copy winpe.wim to the server.
+- Make sure winpe.wim is readable by the Razor service.
+- Install/configure Samba share.
+
+## Node Metadata
+
+- 'productkey' (optional) - This is the product key which will be substituted
+  into the unattended.xml file inside the UserData => ProductKey tag.
+  - Default: The product key provided as an evaluation key for this Windows
+    version.
+- 'timezone' (optional) - This is the string corresponding to the timezone for
+  the node.
+  - Default: Pacific Standard Time
+- 'root_password' (optional) - This is an override for the root_password that
+  exists on the node when it binds to a policy. If this is provided, it will be
+  used for the node's root password.
+- 'hostname' (optional) - This is an override for the computer name that
+  exists on the node when it binds to a policy. If this is provided, it will be
+  used for the node's computer name. (NOTE: This should not include the domain.)

--- a/tasks/windows/2016.task/metadata.yaml
+++ b/tasks/windows/2016.task/metadata.yaml
@@ -1,0 +1,8 @@
+---
+os_version: 2016
+label: Microsoft Windows 2016
+description: Microsoft Windows 2016 Server
+base: windows
+boot_sequence:
+  1: boot_wim
+  default: boot_local

--- a/tasks/windows/2016.task/unattended.xml.erb
+++ b/tasks/windows/2016.task/unattended.xml.erb
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <DiskConfiguration>
+        <Disk wcm:action="add">
+          <CreatePartitions>
+            <CreatePartition wcm:action="add">
+              <Order>1</Order>
+              <Size>350</Size>
+              <Type>Primary</Type>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Extend>true</Extend>
+              <Order>2</Order>
+              <Type>Primary</Type>
+            </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add">
+              <Active>true</Active>
+              <Format>NTFS</Format>
+              <Label>Boot</Label>
+              <Order>1</Order>
+              <PartitionID>1</PartitionID>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>2</Order>
+              <PartitionID>2</PartitionID>
+              <Format>NTFS</Format>
+              <Label>System</Label>
+            </ModifyPartition>
+          </ModifyPartitions>
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+        </Disk>
+      </DiskConfiguration>
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+        <ProductKey>
+          <!-- Evaluation key from
+               http://technet.microsoft.com/en-us/library/jj612867.aspx
+               Fill in your own for real deployments -->
+          <WillShowUI>OnError</WillShowUI>
+          <Key><%= node.metadata['productkey'] || 'WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY' %></Key>
+        </ProductKey>
+      </UserData>
+      <ImageInstall>
+        <OSImage>
+          <InstallFrom>
+            <MetaData wcm:action="add">
+              <Key>/IMAGE/NAME</Key>
+              <Value>Windows Server 2016 SERVERSTANDARD</Value>
+            </MetaData>
+          </InstallFrom>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>2</PartitionID>
+          </InstallTo>
+          <InstallToAvailablePartition>false</InstallToAvailablePartition>
+          <WillShowUI>OnError</WillShowUI>
+        </OSImage>
+      </ImageInstall>
+    </component>
+    <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <InputLocale><%= node.metadata['win_language'] || 'en-US' %></InputLocale>
+      <SystemLocale><%= node.metadata['win_language'] || 'en-US' %></SystemLocale>
+      <UILanguage><%= node.metadata['win_language'] || 'en-US' %></UILanguage>
+      <UserLocale><%= node.metadata['win_language'] || 'en-US' %></UserLocale>
+    </component>
+  </settings>
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <UserAccounts>
+        <AdministratorPassword>
+          <Value><%= node.metadata['root_password'] || node.root_password %></Value>
+          <PlainText>true</PlainText>
+        </AdministratorPassword>
+      </UserAccounts>
+      <RegisteredOrganization>---</RegisteredOrganization>
+      <RegisteredOwner>---</RegisteredOwner>
+    </component>
+  </settings>
+  <settings pass="specialize">
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <OEMInformation>
+        <HelpCustomized>false</HelpCustomized>
+      </OEMInformation>
+      <ComputerName><%= (node.metadata['hostname'] || node.hostname).split('.').first %></ComputerName>
+      <TimeZone><%= node.metadata['timezone'] || 'Pacific Standard Time' %></TimeZone>
+    </component>
+    <component name="Microsoft-Windows-OutOfBoxExperience" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <DoNotOpenInitialConfigurationTasksAtLogon>true</DoNotOpenInitialConfigurationTasksAtLogon>
+    </component>
+    <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <DoNotOpenServerManagerAtLogon>true</DoNotOpenServerManagerAtLogon>
+    </component>
+    <component name="Microsoft-Windows-Security-Licensing-SLC-UX" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <SkipAutoActivation>true</SkipAutoActivation>
+    </component>
+  </settings>
+</unattend>

--- a/tasks/windows/8pro.task/README.md
+++ b/tasks/windows/8pro.task/README.md
@@ -1,5 +1,11 @@
 # Task notes for Windows 8 Professional
 
+## Install Prerequisites
+
+- Machine must be running Windows 8 Professional.
+- Windows Assessment and Deployment Kit (Windows ADK) version 8.0 or 8.1 is
+  installed.
+
 ## Pre-install Steps
 
 Follow same instructions for all other Windows tasks:


### PR DESCRIPTION
Razor should ship with an installer for Windows Server 2016. This adds a task
for that.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-975