### PR TITLE
Use single source Windows agent installer for puppet-pe broker

### DIFF
--- a/brokers/puppet-pe.broker/configuration.yaml
+++ b/brokers/puppet-pe.broker/configuration.yaml
@@ -1,9 +1,9 @@
 ---
 server:
-  description: "The puppet master to load configurations and installation packages from."
+  description: "The puppet master to load configurations and installation packages from; defaults to `puppet`"
 version:
   description: "Override the PE version to install; defaults to `current`."
 windows_agent_download_url:
-  description: "The download URL for a Windows PE agent installer; defaults to a URL derived from the `version` config."
+  description: "[Deprecated] The download URL for a Windows PE agent installer."
 ntpdate_server:
   description: "The server to use for synchronizing the agent's time"

--- a/brokers/puppet-pe.broker/install.ps1.erb
+++ b/brokers/puppet-pe.broker/install.ps1.erb
@@ -8,12 +8,13 @@ if ((Get-WmiObject -Class Win32_OperatingSystem | Select-Object -ExpandProperty 
 } else {
     $arch = 'x86'
 }
-$version = "<%= (broker[:version] || 'latest') %>"
 $master = "<%= (broker[:server] || 'puppet') %>"
-$installer = "<%= (broker[:windows_agent_download_url] || 'https://pm.puppetlabs.com/cgi-bin/download.cgi?ver=${version}&dist=win&arch=${arch}') %>"
+$version = "<%= (broker[:version] || 'current') %>"
+$installer = "https://${master}:8140/packages/${version}/install.ps1"
 
-write-host "downloading MSI file to install PE agent from $installer"
-$installer_dest = "${ENV:TEMP}\puppet.msi"
+write-host "downloading PS1 file to install PE agent from $installer"
+$installer_dest = "${ENV:TEMP}\puppet-install.ps1"
+[Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
 (New-Object System.Net.WebClient).DownloadFile($installer, $installer_dest)
 if($error.Count) {
     write-host "failed to download puppet agent installer: $error"
@@ -22,12 +23,9 @@ if($error.Count) {
     Exit 1
 }
 
-write-host "starting PE installer"
-$log_dest = "${ENV:TEMP}\puppet.log"
-$installer_args = @('/qn', "PUPPET_MASTER_SERVER=$master", "/l*v `"$log_dest`"")
-
-write-host "running $installer_dest $installer_args"
-Start-Process -File $installer_dest -Arg $installer_args -Passthru | Wait-Process
+write-host "starting PE installer at $installer_dest"
+$installer_args = @('-File', ${installer_dest})
+Start-Process -File "powershell.exe" -Args $installer_args -Passthru | Wait-Process
 if($error.Count) {
     write-host "failed to run puppet agent installer: $error"
     $error_url = "<%= log_url('failed to run puppet agent installer', :error) %>"

--- a/lib/razor/command/update_broker_configuration.rb
+++ b/lib/razor/command/update_broker_configuration.rb
@@ -46,14 +46,17 @@ EOT
   def run(request, data)
     broker = Razor::Data::Broker[:name => data['broker']]
     config = broker.configuration
+    attr_schema = broker.broker_type.configuration_schema[data['key']]
     result = if data['value']
+               request.error 422, :error => _(
+                   "configuration key #{data['key']} is not in the schema " +
+                   "and must be cleared") unless attr_schema
                config[data['key']] = data['value']
                _("value for key %{name} updated") %
                    {name: data['key']}
              elsif data['clear'] and config.has_key?(data['key'])
                config.delete(data['key'])
-               attr_schema = broker.broker_type.configuration_schema[data['key']]
-               if attr_schema['default']
+               if attr_schema && attr_schema.has_key?('default')
                  # The actual setting happens as part of the validation.
                  _("value for key %{name} reset to default") %
                      {name: data['key']}

--- a/lib/razor/command/update_hook_configuration.rb
+++ b/lib/razor/command/update_hook_configuration.rb
@@ -46,14 +46,17 @@ EOT
   def run(request, data)
     hook = Razor::Data::Hook[:name => data['hook']]
     config = hook.configuration
+    attr_schema = hook.hook_type.configuration_schema[data['key']]
     result = if data['value']
+               request.error 422, :error => _(
+                   "configuration key #{data['key']} is not in the schema " +
+                   "and must be cleared") unless attr_schema
                config[data['key']] = data['value']
                _("value for key %{name} updated") %
                    {name: data['key']}
              elsif data['clear'] and config.has_key?(data['key'])
                config.delete(data['key'])
-               attr_schema = hook.hook_type.configuration_schema[data['key']]
-               if attr_schema and attr_schema['default']
+               if attr_schema and attr_schema.has_key?('default')
                  # The actual setting happens as part of the validation.
                  _("value for key %{name} reset to default") %
                      {name: data['key']}

--- a/spec/brokers/puppet-pe_spec.rb
+++ b/spec/brokers/puppet-pe_spec.rb
@@ -81,9 +81,9 @@ describe Razor::BrokerType.find(name: 'puppet-pe') do
 
     it "should work without any configuration" do
       script.should be_an_instance_of String
-      script.should include('$version = "latest"')
+      script.should include('$version = "current"')
       script.should include('$master = "puppet"')
-      script.should include('$installer = "https://pm.puppetlabs.com/cgi-bin/download.cgi?ver=${version}&dist=win&arch=${arch}"')
+      script.should include('$installer = "https://${master}:8140/packages/${version}/install.ps1"')
     end
 
     it "should set the server if given" do
@@ -98,12 +98,6 @@ describe Razor::BrokerType.find(name: 'puppet-pe') do
       script.should include("$version = \"#{version}\"")
     end
 
-    it "should set the windows_agent_download_url if given" do
-      download_url = Faker::Internet.url
-      broker.configuration = {'windows_agent_download_url' => download_url}
-      script.should include("$installer = \"#{download_url}\"")
-    end
-
     it "should set multiple configuration values if given" do
       server = "puppet.#{Faker::Internet.domain_name}"
       version = 3.times.map do Faker::Number.digit end.join('.')
@@ -111,12 +105,10 @@ describe Razor::BrokerType.find(name: 'puppet-pe') do
       broker.configuration = {
           'server'                     => server,
           'version'                    => version,
-          'windows_agent_download_url' => download_url
       }
 
       script.should include("$version = \"#{version}\"")
       script.should include("$master = \"#{server}\"")
-      script.should include("$installer = \"#{download_url}\"")
     end
   end
 end


### PR DESCRIPTION
The PE puppet agent installer for Windows is now installed via a Powershell
script downloaded via the puppet master, similar to how the Linux installer
works. To make the Windows broker standardized, this downloads and runs the
install.ps1 file from the puppet master.

The existing `windows_agent_download_url` and `version` metadata are no
longer used. To facilitate backwards compatibility, these will remain in the
configuration, but have been marked as deprecated in their description.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-974