### PR TITLE
Boot Local Task Sanboot by Tag

### DIFF
--- a/tasks/common/boot_local.erb
+++ b/tasks/common/boot_local.erb
@@ -16,7 +16,7 @@ sleep 3
 <%
   facts = node.facts || {}
   if !facts.has_key?('is_virtual') or ((facts["is_virtual"] != "false") and (facts["is_virtual"] != false)) or
-      node.metadata['sanboot'] %>
+      node.metadata['sanboot'] or node.tags.collect{|t| t.name }.include?('sanboot') %>
 echo forcing local booting with sanboot 0x80
 sanboot --no-describe --drive 0x80
 <% end %>


### PR DESCRIPTION
Boot Local Task Sanboot by Tag

This adds the option to detect machines that should use the sanboot iPXE
command through the use of a 'sanboot' tag.

Tags allow a policy based approach to selecting the hardware platforms
that require this boot method.  For example, creating a sanboot tag that applies
to all HP m300 moonshot cartridges which require the sanboot
method through the use of the 'productname' fact.
