### PR TITLE
Fix command execution when `auth.allow_localhost` is used

### DIFF
--- a/lib/razor/command.rb
+++ b/lib/razor/command.rb
@@ -30,7 +30,8 @@ class Razor::Command
         raise Razor::ValidationFailure, _('expected %{expected} but got %{actual}') %
             {expected: ruby_type_to_json(Hash), actual: ruby_type_to_json(data)}
 
-    self.class.validate!(data, nil) do |data|
+    opts = {local_bypass: app.local_request?}
+    self.class.validate!(data, nil, opts) do |data|
       self.class.conform!(data)
     end
 

--- a/spec/app/local_no_auth.rb
+++ b/spec/app/local_no_auth.rb
@@ -9,44 +9,39 @@ describe "local requests without authentication" do
 
   let(:app) { Razor::App }
 
-  context "/api without auth" do
+  before :each do
+    header 'content-type', 'application/json'
+  end
 
+  context "/api without auth" do
     it "no auth for local requests if auth.allow_localhost is set" do
-      
       Razor.config['auth.allow_localhost'] = true
       get '/api/collections/repos', {}, {'REMOTE_ADDR' => '127.0.0.1'}
-
       last_response.status.should == 200
 
+      post '/api/commands/create-broker', {'name' => 'abc', 'broker-type' => 'puppet'}.to_json
+      last_response.status.should == 202
     end
    
     it "auth for non local requests if auth.allow_localhost is set" do
-      
       Razor.config['auth.allow_localhost'] = true
       get '/api/collections/repos', {}, {'REMOTE_ADDR' => '172.17.10.10'}
 
       last_response.status.should == 401
-
     end
  
     it "auth for local requests if auth.allow_localhost is not set" do
-      
       Razor.config['auth.allow_localhost'] = false
       get '/api/collections/repos', {}, {'REMOTE_ADDR' => '127.0.0.1'}
 
       last_response.status.should == 401
-
     end
 
     it "auth for non local requests if auth.allow_localhost is not set" do
-      
       Razor.config['auth.allow_localhost'] = false
       get '/api/collections/repos', {}, {'REMOTE_ADDR' => '172.17.10.10'}
 
       last_response.status.should == 401
-
     end
-
   end
-
 end


### PR DESCRIPTION
Previously whenever a command execution was attempted, the
`auth.allow_localhost` functionality would cause a failure, meaning
non-authenticated localhost commands to return a 500 error. This commit results
in the intended behavior for commands as well as collections.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-994