### PR TITLE
Link to newest prebuilt microkernel (008)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ image that Razor boots on new nodes to do discovery. It periodically
 submits [facts](https://github.com/puppetlabs/facter) about the node and
 waits for instructions from the server about what to do next, if anything.
 
-A [prebuilt archive](https://s3-us-west-2.amazonaws.com/razor-releases/microkernel-007.tar)
+A [prebuilt archive](https://s3-us-west-2.amazonaws.com/razor-releases/microkernel-008.tar)
 is available.
 
 ## Razor Client


### PR DESCRIPTION
Updating the link to the prebuilt archive, 008 was released on 2-2-2017 and contains important fixes for booting on modern hardware.