### PR TITLE
(maint) update jruby to 1.7.26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ services:
   - postgresql
 before_install:
   - gem install bundler -v 1.10
+  - unset _JAVA_OPTIONS
 before_script:
   - mkdir -p /tmp/repo
   - cp config.yaml.travis config.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
 notifications:
   email: false
 rvm:
-  - jruby-1.7.19
+  - jruby-1.7.26
 addons:
   postgresql: "9.3"
   apt:

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ source 'https://rubygems.org'
 # Note that the lack of whitespace matters in those two lines:
 #ruby=jruby-1.7.8
 #ruby-gemset=razor-server
-ruby '1.9.3', :engine => 'jruby', :engine_version => '1.7.19'
+ruby '1.9.3', :engine => 'jruby', :engine_version => '1.7.26'
 
 gem 'torquebox', '~> 3.1.2'
 gem 'sinatra', '>= 1.4.4'
@@ -50,7 +50,7 @@ group :test do
   gem 'faker', '~> 1.2.0'
   # json-schema versions beyond this version require
   # ruby version > 2.0 when jruby is upgraded to 9K+
-  # this pin can be removed 
+  # this pin can be removed
   gem 'json-schema', '2.6.2'
   gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ DEPENDENCIES
   yard
 
 RUBY VERSION
-   ruby 1.9.3p551 (jruby 1.7.19)
+   ruby 1.9.3p551 (jruby 1.7.26)
 
 BUNDLED WITH
-   1.13.6
+   1.15.4


### PR DESCRIPTION
jruby-1.7.19 is no longer on the travis ci list of rubies. This
commit bumps to jruby-1.7.26.