### PR TITLE
(RAZOR-1022) Fix `repo_file` task function for repos with remote source

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,21 @@
 # Razor Server Release Notes
 
+## Next - Next
+
+### API changes
+
++ NEW: Added `repo_file_contents` method for use in templates that
+  returns the contents of a file in the repo.
++ NEW: Added `repo_file?` method for use in task templates that returns
+  a path to a file in a repo, if it exists. This will replace the
+  current `repo_file` method.
+
+### Task changes
+
++ BUGFIX: Task method `repo_file` was not functional for remote repo
+  sources. Stock task usages of this function have been replaced with
+  the two methods above.
+
 ## 1.6.1 - 2017-03-09
 
 ### Task changes

--- a/tasks/debian.task/boot_install.erb
+++ b/tasks/debian.task/boot_install.erb
@@ -11,13 +11,13 @@ set cmdline <%= render_template("kernel_args").strip %>
     # one architecture present in the files we discover?  If so, we
     # want to use that.  This also allows us to handle architecture
     # nicely for installation.
-    if repo_file('install.amd') or repo_file('install.386')
+    if repo_file?('install.amd') or repo_file?('install.386')
 %>
 # check for 64-bit CPU support and boot the AMD64 installer.
 cpuid --ext 29 || goto i386
 
 # AMD64 support in CPU, boot the AMD64 installer.
-<% if repo_file('install.amd') %>
+<% if repo_file?('install.amd') %>
 echo detected AMD64 CPU support, booting AMD64 installer
 kernel <%= repo_url('install.amd/vmlinuz') %> ${cmdline}        || goto error
 initrd <%= repo_url('install.amd/initrd.gz') %>                 || goto error
@@ -27,7 +27,7 @@ echo No AMD64 installer present, expected install.amd directory
 <% end %>
 
 :i386
-<% if repo_file('install.386') %>
+<% if repo_file?('install.386') %>
 kernel <%= repo_url('install.386/vmlinuz') %> ${cmdline}        || goto error
 initrd <%= repo_url('install.386/initrd.gz') %>                 || goto error
 boot

--- a/tasks/vmware_esxi.task/boot.cfg.erb
+++ b/tasks/vmware_esxi.task/boot.cfg.erb
@@ -16,7 +16,7 @@
     # Given the changes are purely mechanical and well understood, this will
     # do for the majority of cases without the risk / cost that a slight
     # variant in the CD breaks everything, I think. --daniel 2013-10-14
-    (File.read(repo_file('/boot.cfg')) rescue '').split("\n").map do |line|
+    (repo_file_contents('/boot.cfg')).split("\n").map do |line|
       case line
         when /^kernel=/
           'kernel=' + repo_url(line.sub('kernel=', ''))


### PR DESCRIPTION
The `repo_file` function, accessible by tasks, currently only looks for local
files in the repo directory. This works fine when the repo is created with the
`iso_url` argument, but not when it's using a remote source via the `url`
argument.

The fix is for this function is to download from a remote source when `url` is
set, otherwise use the current behavior of using a local source's contents.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-1022