### PR TITLE
(RAZOR-854) Add Ubuntu Xenial task

### DIFF
--- a/tasks/ubuntu.task/metadata.yaml
+++ b/tasks/ubuntu.task/metadata.yaml
@@ -1,7 +1,7 @@
 ---
 
-os_version: trusty
-label: Ubuntu Trusty 14.04
+os_version: xenial
+label: Ubuntu Xenial 16.04
 description: Ubuntu Generic Installer
 boot_sequence:
   1: boot_install

--- a/tasks/ubuntu/xenial.task/README.md
+++ b/tasks/ubuntu/xenial.task/README.md
@@ -1,0 +1,13 @@
+# Task notes for Ubuntu Xenial
+
+## Node Metadata
+
+- 'timezone' (optional) - This is the string corresponding to the timezone for
+  the node.
+  - Default: US/Pacific
+- 'root_password' (optional) - This is an override for the root_password that
+  exists on the node when it binds to a policy. If this is provided, it will be
+  used for the node's root password.
+- 'hostname' (optional) - This is an override for the hostname that exists
+  on the node when it binds to a policy. If this is provided, it will be used
+  for the node's hostname.

--- a/tasks/ubuntu/xenial.task/metadata.yaml
+++ b/tasks/ubuntu/xenial.task/metadata.yaml
@@ -1,0 +1,6 @@
+---
+
+os_version: xenial
+label: Ubuntu Xenial 14.04
+description: Ubuntu Xenial Installer
+base: ubuntu


### PR DESCRIPTION
This adds a task for Ubuntu Xenial. Since that is the latest version of Ubuntu
that we support, that also means the generic `ubundu` task should point to this.
An `ubuntu/xenial` task now exists, which will work for Xenial even when new
versions are added.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-854