### PR TITLE
(maint) Make hostname hook spec tests more tolerant

### DIFF
--- a/spec/hooks/hostname_spec.rb
+++ b/spec/hooks/hostname_spec.rb
@@ -72,7 +72,7 @@ describe 'hostname hook' do
     Razor::Data::Hook.trigger('node-bound-to-policy', node: node, policy: policy)
     queue.count_messages.should == 1
     run_message(queue.receive)
-    Razor::Data::Event.first.entry['error'].should == 'Hook configuration `counter` must be an integer (was: abc)'
+    Razor::Data::Event.first.entry['error'].should =~ /Hook configuration `counter` must be an integer \(was: abc\)/
   end
   it "should fail with invalid `padding` property" do
     arguments = {:name => 'hostname-test', :hook_type => Razor::HookType.find(name: 'hostname'),
@@ -83,7 +83,7 @@ describe 'hostname hook' do
     Razor::Data::Hook.trigger('node-bound-to-policy', node: node, policy: policy)
     queue.count_messages.should == 1
     run_message(queue.receive)
-    Razor::Data::Event.first.entry['error'].should == 'Hook configuration `padding` must be an integer (was: def)'
+    Razor::Data::Event.first.entry['error'].should =~ /Hook configuration `padding` must be an integer \(was: def\)/
   end
   it "should succeed with a string `padding` property" do
     arguments = {:name => 'hostname-test', :hook_type => Razor::HookType.find(name: 'hostname'),


### PR DESCRIPTION
When run in Travis, a few spec tests were failing because an unrelated STDERR
message was being included in the test:

"Picked up _JAVA_OPTIONS: -Xmx2048m -Xms512m"

This commit works around this warning that is being output in STDERR by making
the test's validating condition less strict.