### PR TITLE
(maint) Add gem version bindings since many gems are dropping 1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,13 +19,16 @@ source 'https://rubygems.org'
 ruby '1.9.3', :engine => 'jruby', :engine_version => '1.7.19'
 
 gem 'torquebox', '~> 3.1.2'
-gem 'sinatra', '>= 1.4.4'
+# sinatra 2.0 pulls in dependencies that don't work on ruby 1.9
+gem 'sinatra', '~> 1.4.4'
 # sequel 4.10 has issues with the serialization plugin; rspec tests fail.
 gem 'sequel', '= 4.9'
 gem 'jdbc-postgres'
 gem 'archive'
 gem 'hashie', '~> 2.0.5'
 gem 'gettext-setup'
+# rake 12.3 requires ruby >= 2.0.0
+gem 'rake', '~> 12.2.1'
 
 ## support for various tasks and utility
 # This allows us to encrypt plain-text-in-the-DB passwords when they travel,
@@ -35,12 +38,14 @@ gem "unix-crypt", "~> 1.1.1"
 
 group :doc do
   gem 'yard'
-  gem 'kramdown'
+  # kramdown 1.15.0 requires ruby >= 2.0
+  gem 'kramdown', '~> 1.14.0'
 end
 
 # This group will be excluded by default in `torquebox archive`
 group :test do
-  gem 'rack-test'
+  # rack-test 0.8.0 requires ruby >= 2.2.2
+  gem 'rack-test', '~> 0.7.0'
   gem 'rspec', '~> 2.13.0'
   gem 'rspec-core', '~> 2.13.1'
   gem 'rspec-expectations', '~> 2.13.0'
@@ -50,7 +55,7 @@ group :test do
   gem 'faker', '~> 1.2.0'
   # json-schema versions beyond this version require
   # ruby version > 2.0 when jruby is upgraded to 9K+
-  # this pin can be removed 
+  # this pin can be removed
   gem 'json-schema', '2.6.2'
   gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,16 +27,16 @@ GEM
     json (2.0.2-java)
     json-schema (2.6.2)
       addressable (~> 2.3.8)
-    kramdown (1.12.0)
+    kramdown (1.14.0)
     locale (2.1.2)
     parslet (1.4.0)
       blankslate (~> 2.0)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
-    rack-test (0.6.3)
-      rack (>= 1.0)
-    rake (11.3.0)
+    rack-test (0.7.0)
+      rack (>= 1.0, < 3)
+    rake (12.2.1)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -109,15 +109,16 @@ DEPENDENCIES
   hashie (~> 2.0.5)
   jdbc-postgres
   json-schema (= 2.6.2)
-  kramdown
-  rack-test
+  kramdown (~> 1.14.0)
+  rack-test (~> 0.7.0)
+  rake (~> 12.2.1)
   rspec (~> 2.13.0)
   rspec-core (~> 2.13.1)
   rspec-expectations (~> 2.13.0)
   rspec-mocks (~> 2.13.1)
   sequel (= 4.9)
   simplecov
-  sinatra (>= 1.4.4)
+  sinatra (~> 1.4.4)
   timecop
   torquebox (~> 3.1.2)
   torquebox-server (~> 3.1.2)
@@ -128,4 +129,4 @@ RUBY VERSION
    ruby 1.9.3p551 (jruby 1.7.19)
 
 BUNDLED WITH
-   1.13.6
+   1.13.7


### PR DESCRIPTION
This still uses a 1.9.3 jruby. Since many gems are moving to requiring
more recent versions of ruby, or dependencies requiring more recent
versions of ruby, we need to make sure we're binding to a version that
works with our dependencies.