### PR TITLE
Add UEFI Support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,8 +15,25 @@
 + BUGFIX: Task method `repo_file` was not functional for remote repo
   sources. Stock task usages of this function have been replaced with
   the two methods above.
++ NEW: Added ESXi 6 task, `vmware_esxi/6`.
++ NEW: Added Ubuntu Xenial task, `ubuntu/xenial`.
++ NEW: Added UEFI support for Windows 2012r2 and 2016 on x64 machines.
 + NEW: On the Windows side, ADK 10 is now supported. The output from
   `build-razor-winpe.ps1` will now be named `boot.wim`.
+
+### Other
+
++ NEW: The final step of internationalization, reading the locale from
+  incoming API messages, is complete. Razor will now parse the
+  ACCEPT_LANGUAGE header in requests.
++ NEW: Added `has_macaddress_like` tag matcher, which will use a regex
+  to match macaddresses.
++ NEW: A new `fact_boot_type` value in `hw_info` will reveal which
+  style of booting is used, whether that be `efi` or `pcbios`.
++ IMPROVEMENT: When nodes PXE boot, their `hw_info` will be preserved,
+  even if it is not used for matching to a node in the Razor database.
++ IMPROVEMENT: Updated the README to reference the latest version of the
+  microkernel.
 
 ## 1.6.1 - 2017-03-09
 

--- a/app.rb
+++ b/app.rb
@@ -264,6 +264,7 @@ and requires full control over the database (eg: add and remove tables):
         vars[net_id] = "${#{net_id}/mac:hexhyp}"
       end
       ["dhcp_mac", "serial", "asset", "uuid"].each { |k| vars[k] = "${#{k}}" }
+      vars['fact_boot_type'] = "${platform}"
       q = vars.map { |k,v| "#{k}=#{v}" }.join("&")
       # Sinatra's URL generation is not robust, meaning changes need to happen
       # as string substitutions.

--- a/lib/razor/data/node.rb
+++ b/lib/razor/data/node.rb
@@ -441,6 +441,14 @@ module Razor::Data
         # call register to merge the existing and the new node
         unless dhcp_mac.nil? || node.dhcp_mac == dhcp_mac
           node.dhcp_mac = dhcp_mac
+        end
+        hw_info_facts = Node.hw_hashing(hw_info).select do
+          |name| name.start_with?('fact_')
+        end
+        unless hw_info_facts.empty?
+          node.hw_hash = node.hw_hash.merge(hw_info_facts)
+        end
+        if node.modified?
           node.save
         end
         node
@@ -495,7 +503,7 @@ module Razor::Data
           kill_nodes = nodes[1..-1]
         end
 
-        keep_node.hw_info = hw_info
+        keep_node.hw_hash = keep_node.hw_hash.merge(Node.hw_hashing(hw_info))
 
         kill_nodes.each do |kill_node|
           kill_node.events_dataset.update(:node_id => keep_node.id)

--- a/tasks/windows/2012r2.task/unattended.xml.erb
+++ b/tasks/windows/2012r2.task/unattended.xml.erb
@@ -4,6 +4,25 @@
     <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <DiskConfiguration>
         <Disk wcm:action="add">
+<% if node.hw_hash['fact_boot_type'] == "efi" -%>
+          <CreatePartitions>
+            <CreatePartition wcm:action="add">
+              <Order>1</Order>
+              <Size>200</Size>
+              <Type>EFI</Type>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>2</Order>
+              <Size>128</Size>
+              <Type>MSR</Type>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Extend>true</Extend>
+              <Order>3</Order>
+              <Type>Primary</Type>
+            </CreatePartition>
+          </CreatePartitions>
+<% else -%>
           <CreatePartitions>
             <CreatePartition wcm:action="add">
               <Order>1</Order>
@@ -31,6 +50,7 @@
               <Label>System</Label>
             </ModifyPartition>
           </ModifyPartitions>
+<% end -%>
           <DiskID>0</DiskID>
           <WillWipeDisk>true</WillWipeDisk>
         </Disk>
@@ -55,8 +75,11 @@
           </InstallFrom>
           <InstallTo>
             <DiskID>0</DiskID>
+<% if node.hw_hash['fact_boot_type'] == "efi" %>
+            <PartitionID>3</PartitionID>
+<% else %>
             <PartitionID>2</PartitionID>
-          </InstallTo>
+<% end %></InstallTo>
           <InstallToAvailablePartition>false</InstallToAvailablePartition>
           <WillShowUI>OnError</WillShowUI>
         </OSImage>

--- a/tasks/windows/2016.task/unattended.xml.erb
+++ b/tasks/windows/2016.task/unattended.xml.erb
@@ -4,7 +4,26 @@
     <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <DiskConfiguration>
         <Disk wcm:action="add">
-          <CreatePartitions>
+<% if node.hw_hash['fact_boot_type'] == "efi" %>
+           <CreatePartitions>
+            <CreatePartition wcm:action="add">
+              <Order>1</Order>
+              <Size>200</Size>
+              <Type>EFI</Type>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>2</Order>
+              <Size>128</Size>
+              <Type>MSR</Type>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Extend>true</Extend>
+              <Order>3</Order>
+              <Type>Primary</Type>
+            </CreatePartition>
+          </CreatePartitions>
+<% else %>
+           <CreatePartitions>
             <CreatePartition wcm:action="add">
               <Order>1</Order>
               <Size>350</Size>
@@ -31,6 +50,7 @@
               <Label>System</Label>
             </ModifyPartition>
           </ModifyPartitions>
+<% end %>
           <DiskID>0</DiskID>
           <WillWipeDisk>true</WillWipeDisk>
         </Disk>
@@ -55,7 +75,11 @@
           </InstallFrom>
           <InstallTo>
             <DiskID>0</DiskID>
+<% if node.hw_hash['fact_boot_type'] == "efi" %>
+            <PartitionID>3</PartitionID>
+<% else %>
             <PartitionID>2</PartitionID>
+<% end %>
           </InstallTo>
           <InstallToAvailablePartition>false</InstallToAvailablePartition>
           <WillShowUI>OnError</WillShowUI>


### PR DESCRIPTION
This PR does a few things: 

- Allows `hw_info` not used to match to remain with the node. In the past, these would be removed.
- Adds a `fact_boot_type` value to `hw_info` that can be used in tasks.
- Changes the partitioning info in the Windows unattended.xml files to handle UEFI if the `fact_boot_type` value is set to `efi`.

This fixes https://tickets.puppetlabs.com/browse/RAZOR-1025.