### PR TITLE
Modifications to support Windows ADK 10

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@
 + BUGFIX: Task method `repo_file` was not functional for remote repo
   sources. Stock task usages of this function have been replaced with
   the two methods above.
++ NEW: On the Windows side, ADK 10 is now supported. The output from
+  `build-razor-winpe.ps1` will now be named `boot.wim`.
 
 ## 1.6.1 - 2017-03-09
 

--- a/app.rb
+++ b/app.rb
@@ -587,6 +587,16 @@ and requires full control over the database (eg: add and remove tables):
     # hit trouble.  So, to make this more user friendly we look for a
     # case-insensitive match on the file.
     fpath = Razor::Data::Repo.find_file_ignoring_case(root, path)
+    if fpath.nil? && path == 'razor-winpe.wim'
+      # These are odd cases; Windows 2012r2 and 2016 require the winpe file to
+      # be called `boot.wim`. Our old tasks used `razor-winpe.wim` instead.
+      # For backwards compatibility, we should also look for razor-winpe.wim in
+      # this case. This checks both, in case the user copied our task.
+      fpath = Razor::Data::Repo.find_file_ignoring_case(root, 'boot.wim')
+    elsif fpath.nil? and path == 'boot.wim'
+      fpath = Razor::Data::Repo.find_file_ignoring_case(root, 'razor-winpe.wim')
+    end
+
     if fpath and fpath.start_with?(root) and File.file?(fpath)
       content_type nil
       send_file fpath, :disposition => nil

--- a/build-winpe/build-razor-winpe.ps1
+++ b/build-winpe/build-razor-winpe.ps1
@@ -119,9 +119,9 @@ if (-not (test-path -path $mount)) {
 
 
 write-host "* Copy the clean ADK WinPE image into our output area."
-copy-item $wim (join-path $output "razor-winpe.wim") -ErrorAction Stop
+copy-item $wim (join-path $output "boot.wim") -ErrorAction Stop
 # update our wim location...
-$wim = (join-path $output "razor-winpe.wim")
+$wim = (join-path $output "boot.wim")
 
 
 $env:Path = ($env:Path + ";$adk\..\..\Deployment Tools\amd64\DISM")

--- a/tasks/windows.task/boot_wim.erb
+++ b/tasks/windows.task/boot_wim.erb
@@ -12,7 +12,7 @@ initrd ${base}/boot/fonts/segmono_boot.ttf  segmono_boot.ttf
 initrd ${base}/boot/fonts/segoe_slboot.ttf  segoe_slboot.ttf
 initrd ${base}/boot/fonts/wgl4_boot.ttf     wgl4_boot.ttf
 initrd ${base}/boot/boot.sdi                boot.sdi
-initrd ${base}/razor-winpe.wim              boot.wim
+initrd ${base}/boot.wim                     boot.wim
 
 echo ======================================================================
 imgstat

--- a/tasks/windows.task/second-stage.ps1.erb
+++ b/tasks/windows.task/second-stage.ps1.erb
@@ -20,7 +20,9 @@ $unattended = "${env:SYSTEMDRIVE}\unattended.xml"
 write-host "mapping SMB share ${drive_path} for installer access"
 # As far as I can tell, if we don't persist, we don't connect the SMB share,
 # and that means we can't actually run stuff off it.
-new-psdrive -name 'i' -psprovider filesystem -root "$($drive_path)" -persist
+$pass = "password" | ConvertTo-SecureString -AsPlainText -Force
+$cred = New-Object System.Management.Automation.PSCredential('user', $pass)
+new-psdrive -name 'i' -psprovider filesystem -root "$($drive_path)" -persist -credential $cred
 If (!(Test-Path i:))
 {
         Invoke-WebRequest -Uri "<%= log_url("samba share not accessible ${drive_path}", :error) %>" -UseBasicParsing

--- a/tasks/windows/2008r2.task/boot_wim.erb
+++ b/tasks/windows/2008r2.task/boot_wim.erb
@@ -10,7 +10,7 @@ initrd ${base}/bootmgr                      bootmgr
 initrd ${base}/boot/bcd                     BCD
 initrd ${base}/boot/fonts/wgl4_boot.ttf     wgl4_boot.ttf
 initrd ${base}/boot/boot.sdi                boot.sdi
-initrd ${base}/razor-winpe.wim              boot.wim
+initrd ${base}/boot.wim                     boot.wim
 
 echo ======================================================================
 imgstat


### PR DESCRIPTION
ADK 10 requires that the WinPE image have a specific name of `boot.wim`.
This alters the output from the build-razor-winpe.ps1 to match that
convention instead of the previous `razor-winpe.wim`. Renaming here
should save the user a step when the WIM is copied to the Razor server.

Additionally, this adds fake credentials to the SMB connection in the
Windows task. This is required for ADK 10 to mount an anonymous
fileshare.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-1024