### PR TITLE
(maint) update yard to >= 0.9.11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'torquebox', '~> 3.1.2'
 gem 'sinatra', '~> 1.4.4'
 # sequel 4.10 has issues with the serialization plugin; rspec tests fail.
 gem 'sequel', '= 4.9'
-gem 'jdbc-postgres'
+gem 'jdbc-postgres', '= 9.4.1206'
 gem 'archive'
 gem 'hashie', '~> 2.0.5'
 gem 'gettext-setup'
@@ -37,7 +37,7 @@ gem "unix-crypt", "~> 1.1.1"
 
 
 group :doc do
-  gem 'yard'
+  gem 'yard', '~> 0.9.11'
   # kramdown 1.15.0 requires ruby >= 2.0
   gem 'kramdown', '~> 1.14.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,8 @@ GEM
     archive (0.0.6)
       ffi (~> 1.9.3)
     blankslate (2.1.2.4)
-    diff-lcs (1.2.5)
+    concurrent-ruby (1.0.5-java)
+    diff-lcs (1.3)
     docile (1.1.5)
     edn (1.0.0)
       parslet (~> 1.4.0)
@@ -13,25 +14,26 @@ GEM
     faker (1.2.0)
       i18n (~> 0.5)
     fast_gettext (1.1.0)
-    ffi (1.9.14-java)
-    gettext (3.1.9)
+    ffi (1.9.18-java)
+    gettext (3.2.6)
       locale (>= 2.0.5)
       text (>= 1.3.0)
-    gettext-setup (0.17)
+    gettext-setup (0.29)
       fast_gettext (~> 1.1.0)
       gettext (>= 3.0.2)
       locale
     hashie (2.0.5)
-    i18n (0.7.0)
+    i18n (0.9.1)
+      concurrent-ruby (~> 1.0)
     jdbc-postgres (9.4.1206)
-    json (2.0.2-java)
+    json (2.1.0-java)
     json-schema (2.6.2)
       addressable (~> 2.3.8)
     kramdown (1.14.0)
     locale (2.1.2)
     parslet (1.4.0)
       blankslate (~> 2.0)
-    rack (1.6.4)
+    rack (1.6.8)
     rack-protection (1.5.3)
       rack
     rack-test (0.7.0)
@@ -46,19 +48,19 @@ GEM
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.13.1)
     sequel (4.9.0)
-    simplecov (0.12.0)
+    simplecov (0.15.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
-    sinatra (1.4.7)
+    simplecov-html (0.10.2)
+    sinatra (1.4.8)
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     text (1.3.1)
-    thor (0.19.1)
-    tilt (2.0.5)
-    timecop (0.8.1)
+    thor (0.20.0)
+    tilt (2.0.8)
+    timecop (0.9.1)
     torquebox (3.1.2)
       thor (>= 0.14.6)
       torquebox-cache (= 3.1.2)
@@ -96,7 +98,7 @@ GEM
       torquebox-core (= 3.1.2)
     torquebox-web (3.1.2-java)
     unix-crypt (1.1.1)
-    yard (0.9.5)
+    yard (0.9.12)
 
 PLATFORMS
   java
@@ -107,7 +109,7 @@ DEPENDENCIES
   faker (~> 1.2.0)
   gettext-setup
   hashie (~> 2.0.5)
-  jdbc-postgres
+  jdbc-postgres (= 9.4.1206)
   json-schema (= 2.6.2)
   kramdown (~> 1.14.0)
   rack-test (~> 0.7.0)
@@ -123,10 +125,10 @@ DEPENDENCIES
   torquebox (~> 3.1.2)
   torquebox-server (~> 3.1.2)
   unix-crypt (~> 1.1.1)
-  yard
+  yard (~> 0.9.11)
 
 RUBY VERSION
    ruby 1.9.3p551 (jruby 1.7.19)
 
 BUNDLED WITH
-   1.13.7
+   1.15.4


### PR DESCRIPTION
Yard < 0.9.11 had a security vulnerability [1], this
commit updates yard and a few other gems.

[1]: https://nvd.nist.gov/vuln/detail/CVE-2017-17042