### PR TITLE
Fix unattended.xml script for Windows 2012r2 task

### DIFF
--- a/tasks/windows/2012r2.task/unattended.xml.erb
+++ b/tasks/windows/2012r2.task/unattended.xml.erb
@@ -4,7 +4,7 @@
     <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <DiskConfiguration>
         <Disk wcm:action="add">
-<% if node.hw_hash['fact_boot_type'] == "efi" -%>
+<% if node.hw_hash['fact_boot_type'] == "efi" %>
           <CreatePartitions>
             <CreatePartition wcm:action="add">
               <Order>1</Order>
@@ -22,7 +22,7 @@
               <Type>Primary</Type>
             </CreatePartition>
           </CreatePartitions>
-<% else -%>
+<% else %>
           <CreatePartitions>
             <CreatePartition wcm:action="add">
               <Order>1</Order>
@@ -50,7 +50,7 @@
               <Label>System</Label>
             </ModifyPartition>
           </ModifyPartitions>
-<% end -%>
+<% end %>
           <DiskID>0</DiskID>
           <WillWipeDisk>true</WillWipeDisk>
         </Disk>


### PR DESCRIPTION
There is an invalid script-ending tag in the `windows/2012r2` stock
task.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-1046