### PR TITLE
Skip certain tests if the user is running as root

### DIFF
--- a/spec/broker_type_spec.rb
+++ b/spec/broker_type_spec.rb
@@ -137,6 +137,9 @@ describe Razor::BrokerType do
       end
 
       it "should raise if the install template is present but unreadable" do
+        pending("Skipping this test because process is running with " +
+                "root user privileges and root can read everything") if Process.uid == 0
+
         broker = {'test' => {'install.erb' => "# no real content here\n"}}
         with_brokers_in(paths.first => broker) do
           (Pathname(paths.first) + 'test.broker' + 'install.erb').chmod(0000)

--- a/spec/data/repo_spec.rb
+++ b/spec/data/repo_spec.rb
@@ -278,6 +278,9 @@ describe Razor::Data::Repo do
       let :command do Fabricate(:command) end
 
       it "should raise (to trigger a retry) if the repo is not readable" do
+        pending("Skipping this test because process is running with " +
+                "root user privileges and root can read everything") if Process.uid == 0
+
         File.chmod(00000, path) # yes, *no* permissions, thanks
         expect {
           repo.make_the_repo_accessible(command)


### PR DESCRIPTION
Previously, a test in spec/broker_type_spec.rb and another test in
spec/data/repo_spec.rb set the permissions of a file to "0000" with
the intent that the codebase would throw an exception if that file
was not readable. When running as root, however, everything is
readable so these tests failed. This commit skips these tests when
running as root, because they don't make sense for that specific
case.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-1050