### PR TITLE
(RAZOR-1065) Add jboss default JAVA_OPTS to our JAVA_OPTS

### DIFF
--- a/ext/razor-server.env
+++ b/ext/razor-server.env
@@ -7,5 +7,5 @@ JBOSS_CONFIG=standalone.xml
 JBOSS_MODULES_SYSTEM_PKGS=org.jboss.byteman
 LAUNCH_JBOSS_IN_BACKGROUND=true
 LANG=en_US.UTF-8
-JAVA_OPTS="-Xms128m -Xmx1024m -XX:MaxPermSize=256m -Djava.net.preferIPv4Stack=true"
+JAVA_OPTS="-server -XX:+UseCompressedOops -Xms128m -Xmx1024m -XX:MaxPermSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true"
 RAZOR_USER=razor


### PR DESCRIPTION
This commit adds the `-server`, `-Djboss.modules.system.pkgs=org.jboss.byteman`,
`-Djava.awt.headless=true`, and `-XX:+UseCompressedOops` options to our
JAVA_OPTS variable that gets passed to the jboss standalone.sh script.