### PR TITLE
Revert "Move service user declaration to environment variable"

### DIFF
--- a/ext/razor-server.env
+++ b/ext/razor-server.env
@@ -8,4 +8,3 @@ JBOSS_MODULES_SYSTEM_PKGS=org.jboss.byteman
 LAUNCH_JBOSS_IN_BACKGROUND=true
 LANG=en_US.UTF-8
 JAVA_OPTS="-Xms128m -Xmx1024m -XX:MaxPermSize=256m -Djava.net.preferIPv4Stack=true"
-RAZOR_USER=razor

--- a/ext/razor-server.service
+++ b/ext/razor-server.service
@@ -15,7 +15,7 @@ After=network.target
 [Service]
 EnvironmentFile=/opt/puppetlabs/server/apps/razor-server/share/razor-server/razor-server.env
 EnvironmentFile=/etc/sysconfig/razor-server
-User=${RAZOR_USER}
+User=razor
 ExecStart=/opt/puppetlabs/server/apps/razor-server/share/torquebox/jboss/bin/standalone.sh -Djboss.server.log.dir=${JBOSS_LOG_DIR} -Dhttp.port=${RAZOR_HTTP_PORT} -Dhttps.port=${RAZOR_HTTPS_PORT} -b 0.0.0.0
 Type=simple
 PIDFile=/var/run/puppetlabs/razor-server/torquebox.pid


### PR DESCRIPTION
This reverts commit 590f528a24ac1e397ae61f5b36f3e941a477b013.

When passed as an environment variable, the service user ends up quoted in the
service file, which causes the error `Failed at step USER spawning
/opt/puppetlabs/server/apps/razor-server/share/torquebox/jboss/bin/standalone.sh:
No such process`. See https://superuser.com/questions/1156676/what-causes-systemd-failed-at-step-user-spawning-usr-sbin-opendkim-no-such-p