### PR TITLE
(PE-24135) Load environment variables from sysconfig

### DIFF
--- a/ext/razor-server.init
+++ b/ext/razor-server.init
@@ -60,6 +60,17 @@ JBOSS_LIB="/opt/puppetlabs/server/apps/razor-server/var/razor"
 LAUNCH_JBOSS_IN_BACKGROUND=true
 export LAUNCH_JBOSS_IN_BACKGROUND
 
+# Load overrides and defaults. Fail if it isn't there.
+[ -e "/etc/sysconfig/${NAME}" ] || exit 1
+# Enable variable auto-exporting when we source the
+# sysconfig file so that the exec below doesn't drop
+# the variables set here. We can't export the vars
+# inside the sysconfig file due to the way systemd
+# parses the file.
+set -a
+[ -e "/etc/sysconfig/${NAME}" ] && . "/etc/sysconfig/${NAME}"
+set +a
+
 start() {
     echo -n "Launching ${NAME}: "
 


### PR DESCRIPTION
This commit adds a check for and loads the razor-server sysconfig in the init
script in order to load all environment variables. Without this, the service
can't find the config-defaults file.