### PR TITLE
(PE-24400) Don't use variables in sysconfig

### DIFF
--- a/ext/razor-server.sysconfig
+++ b/ext/razor-server.sysconfig
@@ -1,3 +1,6 @@
+# This file is used as a systemd environment file, so we can't rely on variable
+# expansion. Instead, we must set each env var to its full string.
+#
 # The location of the razor config files
 RAZOR_CONFIG=/etc/puppetlabs/razor-server/config.yaml
 RAZOR_CONFIG_DEFAULTS=/opt/puppetlabs/server/apps/razor-server/config-defaults.yaml
@@ -7,16 +10,16 @@ RAZOR_HTTP_PORT=8150
 RAZOR_HTTPS_PORT=8151
 # Torquebox args
 TORQUEBOX_HOME=/opt/puppetlabs/server/apps/razor-server/share/torquebox
-JBOSS_HOME=${TORQUEBOX_HOME}/jboss
-JRUBY_HOME=${TORQUEBOX_HOME}/jruby
+JBOSS_HOME=/opt/puppetlabs/server/apps/razor-server/share/torquebox/jboss
+JRUBY_HOME=/opt/puppetlabs/server/apps/razor-server/share/torquebox/jruby
 JBOSS_LIB=/opt/puppetlabs/server/apps/razor-server/var/razor
 JBOSS_PIDFILE=/var/run/puppetlabs/razor-server/torquebox.pid
 JBOSS_LOG_DIR=/var/log/puppetlabs/razor-server
-JBOSS_CONSOLE_LOG=${JBOSS_LOG_DIR}/console.log
+JBOSS_CONSOLE_LOG=/var/log/puppetlabs/razor-server/console.log
 JBOSS_USER=razor
 JBOSS_CONFIG=standalone.xml
-JBOSS_SCRIPT=${JBOSS_HOME}/bin/standalone.sh
+JBOSS_SCRIPT=/opt/puppetlabs/server/apps/razor-server/share/torquebox/jboss/bin/standalone.sh
 JBOSS_MODULES_SYSTEM_PKGS=org.jboss.byteman
 LAUNCH_JBOSS_IN_BACKGROUND=true
 LANG=en_US.UTF-8
-JAVA_OPTS='-Xms128m -Xmx1024m -XX:MaxPermSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=${JBOSS_MODULES_SYSTEM_PKGS} -Djava.awt.headless=true'
+JAVA_OPTS='-Xms128m -Xmx1024m -XX:MaxPermSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true'


### PR DESCRIPTION
This commit expands previously used environment variables into their intended
strings in the sysconfig. Since we use the sysconfig as an environment file for
the razor-server service and systemd only allows simple variable declaration,
we must declare the full strings in each case.