### PR TITLE
(maint) Update documentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,8 +14,6 @@
 ### Other
 
 + IMPROVEMENT: Updated Sinatra to version 2.0.1.
-+ IMPROVEMENT: System config files for packaging various
-  distributions are now consolidated.
 
 ## 1.8.1 - 2018-04-24
 

--- a/ext/README.md
+++ b/ext/README.md
@@ -22,6 +22,9 @@ init systems.
 This file contains environment variables that are used by the razor-server
 service on both SysV and systemd.
 
+### razor-server.env
+This file contains environment variables used only by systemd.
+
 ### razor-server-tmpfiles.conf
 This file uses "the systemd tmpfiles.d mechanism to ensure that the
 /run/razor-server directory is created on boot with the proper ownership as /run


### PR DESCRIPTION
This commit adds razor-server.env to the packaging README (under ext/) and removes config consolidation from NEWS.md, since we reverted the consolidation commits.