### PR TITLE
Fix `kernel_args` template to handle UEFI for RHEL

### DIFF
--- a/tasks/redhat.task/kernel_args.erb
+++ b/tasks/redhat.task/kernel_args.erb
@@ -1,1 +1,1 @@
-ks=<%= file_url("kickstart") %> network ksdevice=bootif BOOTIF=01-${netX/mac}
+ks=<%= file_url("kickstart") %> initrd=initrd.img network ksdevice=bootif BOOTIF=01-${netX/mac}


### PR DESCRIPTION
In order for UEFI to work on tasks that derive from the stock RHEL task,
we need to add a `initrd=initrd.img` to the kernel arguments.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-1095