### PR TITLE
(maint) Add Docker support to run torquebox in container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ log/*
 /.project
 /.ruby-version
 /ext/packaging/
+/repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM jruby:9.1.5.0-alpine
+
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
+WORKDIR /usr/src/app
+
+COPY Gemfile Gemfile.lock ./
+# upgrade bundler and install gems
+RUN gem install bundler && bundle install
+
+COPY app.rb .
+COPY config.yaml.docker .
+COPY config.ru .
+COPY shiro.ini .
+COPY torquebox.rb .
+COPY Rakefile .
+COPY bin ./bin
+RUN chmod +x bin/*
+COPY brokers ./brokers
+COPY db ./db
+COPY hooks ./hooks
+# this seems to be needed
+COPY jars ./jars
+COPY lib ./lib
+COPY locales ./locales
+COPY spec ./spec
+COPY tasks ./tasks
+
+RUN mv config.yaml.docker config.yaml \
+    && mkdir -p /var/lib/razor/repo-store
+
+EXPOSE 8080
+
+# Install openssl so we can download from HTTPS (e.g. microkernel), plus
+# libarchive (must be "-dev" so we can find the .so files).
+RUN apk update && apk --update add openssl && apk --update add libarchive-dev
+
+# For debugging.
+RUN apk add vim
+
+ENTRYPOINT ["/usr/src/app/bin/run-local"]

--- a/bin/run-local
+++ b/bin/run-local
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# A script for running the Razor server, i.e. as a development environment.
+# This will: download the microkernel, migrate the database, deploy
+# the app to torquebox, then start torquebox.
+
+set -e
+set -x
+
+printf "ensuring microkernel is in place"
+if [ ! -e /var/lib/razor/repo-store/microkernel ]
+then
+    cd /var/lib/razor/repo-store
+    wget -c -O microkernel.tar https://pup.pt/razor-microkernel-latest
+    tar -xvf microkernel.tar
+fi
+# Migrate the database.
+$(dirname $0)/razor-admin migrate-database
+
+# Deploy and start torquebox
+(cd $(dirname $0)/..; torquebox deploy)
+torquebox run -b 0.0.0.0

--- a/config.yaml.docker
+++ b/config.yaml.docker
@@ -1,0 +1,141 @@
+---
+# This is the configuration file for the Razor server. For each
+# environment, the file contains a hash of configuration values. The
+# special environment 'all' is used to set configuration values for all
+# environments
+#
+# The *database_url* setting must be a connection URL for
+# (Sequel)[http://sequel.rubyforge.org/rdoc/files/doc/opening_databases_rdoc.html]
+
+all:
+  database_url: 'jdbc:postgresql://postgres:5432/razor?user=razor'
+  # This section configures authentication for the Razor server.
+  # Authentication applies to access to the `/api` URL path only.
+  auth:
+    # You can enable or disable authentication support.  When disabled, all
+    # authentication is ignored and access to `/api` is unrestricted.
+    # When enabled a valid username and password must be present in all
+    # requests to `/api`.
+    enabled: false
+    # The path to the authentication configuration file.  We use Apache Shiro
+    # to manage authentication, since it provides a solid and effective
+    # abstraction over common third party sources of authentication and role
+    # management information.
+    #
+    # You can learn more about the content of this file in their documentation:
+    # http://shiro.apache.org/configuration.html
+    #
+    # If this is an absolute path it will be used as-is, but if you give a
+    # relative path it is relative to the root directory of the
+    # Razor installation.
+    config: shiro.ini
+    # Allow request to '/api' from localhost even if authentication is enabled.
+    allow_localhost: false
+
+  microkernel:
+    debug_level: debug
+    kernel_args:
+    # If this value is present, and points to a zip file, it will be
+    # downloaded and unpacked by the MK client prior to checkin.  This allows
+    # for custom facts and other code to be shipped to the client without
+    # having to rebuild the ISO image.
+    #
+    # If it is not set, no update will be sent, and the ISO will use only the
+    # default facts, etc, available in the default build.
+    #
+    # extension-zip: /etc/puppetlabs/razor-server/mk-extension.zip
+
+  # Should communications with /api be secured? This property determines
+  # whether to require HTTPS/SSL when making calls in the /api namespace.
+  secure_api: false
+
+  # Should newly discovered nodes be marked installed?
+  protect_new_nodes: false
+
+  # Should hook input be recorded in the event log for debugging?
+  store_hook_input: false
+  # Should hook output be recorded in the event log for debugging?
+  store_hook_output: false
+
+  # How to match nodes to possibly existing nodes in the database. The node
+  # sends us the MAC addresses of its network interfaces, serial number,
+  # asset tag, and UUID. We consider two nodes to be the same if they agree
+  # on any of the values named in the array +match_nodes_on+. Array entries
+  # can be any of 'mac', 'serial', 'asset', or 'uuid', in any order.
+  #
+  # Note that if you have nodes that have dummy values for one of these,
+  # e.g. that all have an asset tag of 'No asset tag' and +match_nodes_on+
+  # contains 'asset', all these nodes will be assumed to be the
+  # same. Better yet: make sure that +match_nodes_on+ does not contain
+  # 'asset' in that situation
+  #
+  # By default, we only match on MAC's, which is generally safe, but will
+  # cause trouble if the NIC's in a node are ever completely
+  # replaced. Consider adding one of the other possible values, e.g. 'uuid'
+  # to the array
+  match_nodes_on:
+    - mac
+  checkin_interval: 15
+  # Colon-separated list of paths; each entry must be a directory in which
+  # we should look for tasks
+  task_path: tasks
+  repo_store_root: /var/lib/razor/repo-store
+  # The *broker_path* is a colon separated list of directories containing
+  # broker types
+  broker_path: brokers
+  # The *hook_path* is a colon separated list of directories containing
+  # hook types
+  hook_path: hooks
+  # The *hook_execution_path* is a colon separated list of paths that
+  # Razor will search, in order, when running hooks, prior to using the
+  # default execution path.
+  hook_execution_path:
+
+  facts:
+    # Facts that we should always ignore. These are stripped out before we
+    # do anything else with facts coming in from a node. Each entry in this
+    # array can either be a string (literal name of a fact) or a regexp
+    # enclosed in /../ where any fact that matches the regexp will be
+    # dropped
+    blacklist:
+      - domain
+      - filesystems
+      - fqdn
+      - hostname
+      - id
+      - /kernel.*/
+      - memoryfree
+      - memorysize
+      - memorytotal
+      - /operatingsystem.*/
+      - osfamily
+      - path
+      - ps
+      - rubysitedir
+      - rubyversion
+      - selinux
+      - sshdsakey
+      - /sshfp_[dr]sa/
+      - sshrsakey
+      - /swap.*/
+      - timezone
+      - /uptime.*/
+    # Facts that should be used to match nodes on; these are useful if the
+    # primary hardware information like MAC addresses has changed (e.g.,
+    # because of a motherboard replacement), but you want to make sure that
+    # an existing node is still identified as the 'old' node. These facts
+    # must be unique across all nodes that Razor manages - otherwise, it
+    # will erroneously identify two physically different nodes as the same.
+    #
+    # The entries in the array follow the same format as those for
+    # facts.blacklist
+    #match_on:
+    #  - unique_fact
+    #  - /other_facts_.*/
+
+  # These should correspond to config properties that should be hidden from the
+  # /api/collections/config endpoint. By default, this endpoint will reveal all
+  # config in this file.
+  api_config_blacklist:
+    - database_url
+    - facts.blacklist

--- a/docker/bin/docker-start.sh
+++ b/docker/bin/docker-start.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -e
+
+docker run -p 5432:5432 --network razor-db -it --name postgres -e POSTGRES_USER=razor -d postgres
+
+# Build and run the image, using the tag `latest` and exposing ports 8150 and 8151.
+docker build -t razor-server "$(realpath $(dirname $0))/../.."
+# Run the instance. We need a few things:
+# Port 8080 forwarded for API and SVC traffic.
+# The `repo/` directory mounted, so the microkernel can live outside the container.
+# Connecting to an internal network, `razor-db`, which is where our postgres instance lives.
+docker run -p 8080:8080 -d --network razor-db -v "$(realpath $(dirname $0))/../../repo":/var/lib/razor/repo-store -it --name razor-server razor-server
+
+# To ensure the service is running, let's check the API.
+printf "Waiting for API to be ready"
+tries=0
+until $(curl --output /dev/null --silent --head --fail http://localhost:8080/api); do
+    printf "."
+    sleep 2
+    tries=$((tries+1))
+    if [ "$tries" -gt "40" ]; then
+        echo; echo "Error: took too long to complete"; echo
+        exit 1
+    fi
+done
+echo "done!"

--- a/docker/bin/docker-stop.sh
+++ b/docker/bin/docker-stop.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+docker stop razor-server
+docker stop postgres
+docker rm razor-server
+docker rm postgres


### PR DESCRIPTION
This adds two scripts:
- docker/bin/docker-start.sh: This script builds and starts two
  containers: one for postgres and one jruby container for razor-server.
  The repo_store_root will be mounted to the `repo/` directory, and the
  microkernel will be downloaded if it doesn't already exist.
- docker/bin/docker-stop.sh: This script stops and removes these
  containers.

This is useful for development in testing out API changes. Some future
use cases which require more work include:

- Testing tasks/provisioning workflows by PXE booting against this
  server. This requires an additional dnsmasq box to field DHCP.
- Run the container as a standalone server. Doing this properly
  requires swapping out the `postgres` container and using a
  persistent data store. There may be issues with queues not persisting
  as well.