### PR TITLE
Add quotes around kickstart root password variable

### DIFF
--- a/tasks/centos.task/kickstart.erb
+++ b/tasks/centos.task/kickstart.erb
@@ -7,7 +7,7 @@ url --url=<%= repo_url %>
 cmdline
 lang en_US.UTF-8
 keyboard us
-rootpw <%= node.metadata['root_password'] || node.root_password %>
+rootpw '<%= node.metadata["root_password"] || node.root_password %>'
 network --hostname <%= node.metadata['hostname'] || node.hostname %>
 firewall --enabled --ssh
 authconfig --enableshadow --passalgo=sha512 --enablefingerprint

--- a/tasks/redhat.task/kickstart.erb
+++ b/tasks/redhat.task/kickstart.erb
@@ -7,7 +7,7 @@ url --url=<%= repo_url %>
 cmdline
 lang en_US.UTF-8
 keyboard us
-rootpw <%= node.metadata['root_password'] || node.root_password %>
+rootpw '<%= node.metadata["root_password"] || node.root_password %>'
 network --hostname <%= node.metadata['hostname'] || node.hostname %>
 firewall --enabled --ssh
 authconfig --enableshadow --passalgo=sha512 --enablefingerprint


### PR DESCRIPTION
It turns out that these quotes are necessary to allow passwords with spaces, otherwise Razor install will fail with an argument error.