### PR TITLE
Allow access to structured facts and metadata

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "unix-crypt", "~> 1.1.1"
 
 
 group :doc do
-  gem 'yard', '~> 0.9.11'
+  gem 'yard', '>= 0.9.20'
   # kramdown 1.15.0 requires ruby >= 2.0
   gem 'kramdown', '~> 1.14.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     archive (0.0.6)
       ffi (~> 1.9.3)
     blankslate (2.1.2.4)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.5)
     diff-lcs (1.3)
-    docile (1.3.1)
+    docile (1.3.2)
     edn (1.0.0)
       parslet (~> 1.4.0)
     fabrication (2.7.2)
@@ -27,7 +27,7 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jdbc-postgres (9.4.1206)
-    json (2.1.0-java)
+    json (2.2.0-java)
     json-schema (2.8.1)
       addressable (>= 2.4)
     kramdown (1.14.0)
@@ -35,13 +35,13 @@ GEM
     mustermann (1.0.3)
     parslet (1.4.0)
       blankslate (~> 2.0)
-    public_suffix (3.0.3)
-    rack (2.0.6)
-    rack-protection (2.0.4)
+    public_suffix (3.1.1)
+    rack (2.0.7)
+    rack-protection (2.0.5)
       rack
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
-    rake (12.3.1)
+    rake (12.3.2)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -50,20 +50,20 @@ GEM
     rspec-expectations (2.13.0)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.13.1)
-    sequel (5.14.0)
-    simplecov (0.16.1)
+    sequel (5.22.0)
+    simplecov (0.17.0)
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sinatra (2.0.4)
+    sinatra (2.0.5)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.4)
+      rack-protection (= 2.0.5)
       tilt (~> 2.0)
     text (1.3.1)
     thor (0.20.3)
-    tilt (2.0.8)
+    tilt (2.0.9)
     timecop (0.9.1)
     torquebox (3.2.0)
       thor (>= 0.14.6)
@@ -102,7 +102,7 @@ GEM
       torquebox-core (= 3.2.0)
     torquebox-web (3.2.0-java)
     unix-crypt (1.1.1)
-    yard (0.9.16)
+    yard (0.9.20)
 
 PLATFORMS
   java
@@ -129,10 +129,10 @@ DEPENDENCIES
   torquebox (~> 3.2.0)
   torquebox-server (~> 3.2.0)
   unix-crypt (~> 1.1.1)
-  yard (~> 0.9.11)
+  yard (>= 0.9.20)
 
 RUBY VERSION
    ruby 2.3.1p0 (jruby 9.1.5.0)
 
 BUNDLED WITH
-   1.16.1
+   2.0.1


### PR DESCRIPTION
Modern versions of facter produce structured facts, or facts in a format
like hashes and arrays. If we are to utilize these facts in any way,
Razor's tagging system needs to be updated to allow access into those
facts. Since facts and metadata are similarly structured, the same
accessing method is added for both.

The `"fact"` and `"metadata"` matchers now use a dot-syntax for
scoping into hashes and arrays. Hashes will find the value from the
corresponding key, while arrays will look up the index. For example:

`["fact", "a.b"]` with a fact of `{"a" => {"b" => 1} }` will return
`1`.
`["fact", "a.1"]` with a fact of `{"a" => [1, 2] }` will return `2`.
`["fact", "a.length"]` with a fact of `{"a" => [1, 2, 3] }` will return
`3`.

If the scope does not exist, the `"fact"` and `"metadata"` matchers
will still use the third argument, the default, as prior to this change.

Fixes https://tickets.puppetlabs.com/browse/RAZOR-1110