### PR TITLE
(maint) Update Gemfile.lock's bundler version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,4 +135,4 @@ RUBY VERSION
    ruby 2.3.1p0 (jruby 9.1.5.0)
 
 BUNDLED WITH
-   2.0.1
+   1.16.1


### PR DESCRIPTION
CI builds with a version before bundler 2, so this should stay at such
a version.