### PR TITLE
handle both forms of auth

### DIFF
--- a/tasks/windows.task/second-stage.ps1.erb
+++ b/tasks/windows.task/second-stage.ps1.erb
@@ -22,7 +22,11 @@ write-host "mapping SMB share ${drive_path} for installer access"
 # and that means we can't actually run stuff off it.
 $pass = "password" | ConvertTo-SecureString -AsPlainText -Force
 $cred = New-Object System.Management.Automation.PSCredential('user', $pass)
-new-psdrive -name 'i' -psprovider filesystem -root "$($drive_path)" -persist -credential $cred
+try { new-psdrive -name 'i' -psprovider filesystem -root "$($drive_path)" -persist -credential $cred -ErrorAction Stop }
+catch {
+        Write-Host "Connecting with a dummy credential failed, retrying without credentials..."
+        new-psdrive -name 'i' -psprovider filesystem -root "$($drive_path)" -persist
+}
 If (!(Test-Path i:))
 {
         Invoke-WebRequest -Uri "<%= log_url("samba share not accessible ${drive_path}", :error) %>" -UseBasicParsing


### PR DESCRIPTION
In some versions, the PSDrive must be mapped with a (dummy) credential, in other versions, no credential must be specified.
This PR ensures the system can handle both through a try{} catch{} block.